### PR TITLE
RUB-655: derive stock devnet target on every live Go and Rust path

### DIFF
--- a/clients/go/node/chainstate_recovery.go
+++ b/clients/go/node/chainstate_recovery.go
@@ -201,13 +201,17 @@ func replayCanonicalBlocks(state *ChainState, store *BlockStore, cfg SyncConfig,
 			// height instead of having to reconstruct the loop state.
 			return false, fmt.Errorf("missing canonical block hash during chainstate replay at height %d (tip_height=%d)", height, tipHeight)
 		}
+		expectedTarget, err := replayExpectedTarget(store, cfg, height, tipHeight)
+		if err != nil {
+			return false, err
+		}
 		blockBytes, prevTimestamps, err := replayBlockInputs(store, blockHash, height)
 		if err != nil {
 			return false, err
 		}
 		if _, err := state.ConnectBlockWithSuiteContext(
 			blockBytes,
-			cfg.ExpectedTarget,
+			expectedTarget,
 			prevTimestamps,
 			cfg.ChainID,
 			cfg.RotationProvider,
@@ -218,6 +222,41 @@ func replayCanonicalBlocks(state *ChainState, store *BlockStore, cfg SyncConfig,
 		changed = true
 	}
 	return changed, nil
+}
+
+// replayExpectedTarget resolves the expected target per replayed block: the
+// selected parent is the canonical index entry at height-1. Only the
+// free-function form of the primitive is callable here — this runs before the
+// sync engine exists.
+//
+// Failure contract (RUB-655 done_when): the error returns unchanged through
+// replayCanonicalBlocks and ReconcileChainStateWithBlockStore to
+// cmd/rubin-node/main.go, which exits 2 BEFORE chainState.Save, before
+// newSyncEngineFn, and before the mempool, peer manager and every service
+// start. This helper writes nothing, so the only durable write already made is
+// the pre-existing incomplete-suffix truncation from
+// truncateIncompleteCanonicalSuffix; it stays intact and nothing is added to
+// it. The in-memory reset reconcileReplayStart may have done is not durable —
+// chainState.Save is never reached.
+func replayExpectedTarget(store *BlockStore, cfg SyncConfig, height uint64, tipHeight uint64) (*[32]byte, error) {
+	if height == 0 {
+		return cfg.ExpectedTarget, nil
+	}
+	if !StockDevnetTargetSchedule(cfg.Network, cfg.ChainID) {
+		return cfg.ExpectedTarget, nil
+	}
+	parentHash, ok, err := store.CanonicalHash(height - 1)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("missing canonical parent hash for target context during chainstate replay at height %d (tip_height=%d)", height, tipHeight)
+	}
+	target, err := deriveExpectedTargetFn(store, parentHash, height)
+	if err != nil {
+		return nil, err
+	}
+	return &target, nil
 }
 
 func replayBlockInputs(store *BlockStore, blockHash [32]byte, height uint64) ([]byte, []uint64, error) {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -335,7 +335,8 @@ func canonicalCoinbaseWeight(height uint64, alreadyGenerated uint64, mineAddress
 		addrLen := uint64(len(mineAddress))
 		parts = append(parts, 8+2+compactSizeLenForMiner(addrLen)+addrLen)
 	}
-	parts = append(parts,
+	parts = append(
+		parts,
 		compactSizeLenForMiner(outputCount),
 		8+2+compactSizeLenForMiner(32)+32,
 		4,
@@ -791,18 +792,40 @@ func (m *Miner) buildCoinbaseAndMerkleRoot(nextHeight uint64, alreadyGenerated u
 }
 
 func (m *Miner) mineHeader(ctx context.Context, nextHeight uint64, prevHash [32]byte, merkleRoot [32]byte) ([]uint64, uint64, []byte, uint64, error) {
+	target, err := m.templateTarget(prevHash, nextHeight)
+	if err != nil {
+		return nil, 0, nil, 0, err
+	}
 	prevTimestamps, err := m.prevTimestamps(nextHeight)
 	if err != nil {
 		return nil, 0, nil, 0, err
 	}
 	now := m.cfg.TimestampSource()
 	timestamp := chooseValidTimestamp(nextHeight, prevTimestamps, now)
-	blockWithoutNonce := makeHeaderPrefix(prevHash, merkleRoot, timestamp, m.cfg.Target)
-	headerBytes, nonce, err := mineHeaderNonce(ctx, blockWithoutNonce, m.cfg.Target)
+	blockWithoutNonce := makeHeaderPrefix(prevHash, merkleRoot, timestamp, target)
+	headerBytes, nonce, err := mineHeaderNonce(ctx, blockWithoutNonce, target)
 	if err != nil {
 		return nil, 0, nil, 0, err
 	}
 	return prevTimestamps, timestamp, headerBytes, nonce, nil
+}
+
+// templateTarget returns the target the post-genesis template commits to, for
+// BOTH header construction and the nonce search — the miner must never mine
+// against a target the apply path will then reject.
+//
+// prevHash is the canonical tip snapshotted by buildContext under the chainstate
+// read lock, i.e. this template's authoritative selected parent. On a stock
+// devnet chain the derived target replaces MinerConfig.Target, so that field
+// carries no static authority there; everywhere else the configured target is
+// returned unchanged, including nextHeight == 0 (the empty-chain path, already
+// redirected to the published genesis by BootstrapCanonicalGenesisIfEmpty).
+func (m *Miner) templateTarget(prevHash [32]byte, nextHeight uint64) ([32]byte, error) {
+	if nextHeight == 0 || m.sync == nil || m.blockStore == nil ||
+		!StockDevnetTargetSchedule(m.sync.cfg.Network, m.sync.cfg.ChainID) {
+		return m.cfg.Target, nil
+	}
+	return deriveExpectedTargetFn(m.blockStore, prevHash, nextHeight)
 }
 
 func assembleBlockBytes(headerBytes []byte, coinbase []byte, parsed []minedCandidate) []byte {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -310,7 +310,22 @@ func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]b
 		p.bumpBan(100, err.Error())
 		return err
 	}
-	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+	// The stock Phase-0 devnet predicate gates ONLY this optional static
+	// equality. When it holds, a header whose target follows the derived
+	// schedule must not be rejected here against one configured constant; the
+	// reconstructed block goes on to SyncEngine.ApplyBlockWithReorg, which
+	// derives the target from the selected parent and candidate height. Parse,
+	// PoW range, PoW work and the peer disposition are untouched — nothing new
+	// is accepted, the authority simply moves to the apply path. When the
+	// predicate is false this comparison and its peer outcome are byte-identical
+	// to pre-RUB-655.
+	//
+	// Ask the ENGINE, never this service's own SyncConfig copy.
+	// validateServiceConfig does not require the two to agree, so reading the
+	// copy would let this layer reject a header the engine it defers to would
+	// have accepted. Nil-safe on the method.
+	stockDevnet := p.service.cfg.SyncEngine.StockDevnetTargetSchedule()
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && !stockDevnet && parsed.Target != *expected {
 		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
 		p.bumpBan(100, err.Error())
 		return err

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -679,7 +679,7 @@ func TestCompactBlockTransactionsByIndexRejectsRangeBeforeScanningTx(t *testing.
 }
 
 func TestCompactBlockTransactionsByIndexStopsAfterHighestRequested(t *testing.T) {
-	txs := [][]byte{minimalBlockTxnTestTxBytes(501), []byte{0xff}}
+	txs := [][]byte{minimalBlockTxnTestTxBytes(501), {0xff}}
 	block := compactTestBlockBytesWithRawTxTail(t, txs, nil)
 
 	got, err := compactBlockTransactionsByIndex(block, []uint64{0})
@@ -771,6 +771,10 @@ func TestHandleCmpctBlockValidationAndFallbackEdges(t *testing.T) {
 
 	wrongExpected := compactFilledTarget(0xee)
 	p = newCompactScriptedPeer(t)
+	// RUB-655: the static equality is now skipped under the stock devnet
+	// predicate, so this row pins the unchanged non-stock behavior. The
+	// predicate follows the ENGINE, so the engine is what must move off devnet.
+	retargetPeerEngine(t, p, "regtest", node.DevnetGenesisChainID())
 	p.service.cfg.SyncConfig.ExpectedTarget = &wrongExpected
 	err = p.handleCmpctBlock(full)
 	if err == nil || !strings.Contains(err.Error(), "target mismatch") || p.snapshotState().BanScore == 0 {
@@ -1548,4 +1552,157 @@ func compactFilledTarget(fill byte) [32]byte {
 		out[i] = fill
 	}
 	return out
+}
+
+// TestTargetScheduleRuntimeCompactStaticTargetGate pins both sides of the
+// RUB-655 compact-relay gate: under the exact stock Phase-0 devnet predicate
+// the optional static expected-target equality is skipped so the reconstructed
+// block reaches the authoritative SyncEngine apply, and under any other
+// configuration the pre-existing static comparison and peer disposition are
+// unchanged. Parse, PoW range and PoW work are enforced either way.
+func TestTargetScheduleRuntimeCompactStaticTargetGate(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	// The published genesis carries POW_LIMIT, so this configured value is
+	// deliberately not the header's target.
+	wrongExpected := compactFilledTarget(0xee)
+	powInvalid := [32]byte{}
+	powInvalid[31] = 0x01
+
+	for _, tc := range []struct {
+		name      string
+		breakTerm func(*testing.T, *peer) // nil keeps the stock devnet configuration
+		target    *[32]byte               // nil keeps the published genesis header target
+		wantStock bool
+		wantErr   string // "" means the block must reach the apply path
+	}{
+		{name: "stock_devnet_defers_to_apply_path", wantStock: true},
+		{name: "stock_devnet_still_enforces_pow", target: &powInvalid, wantStock: true, wantErr: "pow invalid"},
+		// The predicate moves with the ENGINE's identity, not this service's
+		// SyncConfig copy, and NewSyncEngine normalizes what it is given.
+		{name: "engine_padded_mixed_case_network_is_devnet", breakTerm: func(t *testing.T, p *peer) {
+			retargetPeerEngine(t, p, " DevNet\t", node.DevnetGenesisChainID())
+		}, wantStock: true},
+		{name: "engine_non_devnet_network", breakTerm: func(t *testing.T, p *peer) {
+			retargetPeerEngine(t, p, "regtest", node.DevnetGenesisChainID())
+		}, wantErr: "target mismatch"},
+		{name: "engine_foreign_chain_id", breakTerm: func(t *testing.T, p *peer) {
+			retargetPeerEngine(t, p, "devnet", [32]byte{0x01})
+		}, wantErr: "target mismatch"},
+		// validateServiceConfig never requires ServiceConfig.SyncConfig to
+		// agree with the engine, so the gate must follow the engine it hands
+		// the block to. Reading the copy here would reject a header the engine
+		// would have accepted — a same-process accept/reject divergence.
+		{name: "service_config_disagrees_gate_follows_engine", breakTerm: func(_ *testing.T, p *peer) {
+			p.service.cfg.SyncConfig.Network = "regtest"
+			p.service.cfg.SyncConfig.ChainID = [32]byte{0x01}
+		}, wantStock: true},
+		// The configured genesis hash is deliberately NOT a predicate term:
+		// the chain id already commits to the published genesis bytes, and a
+		// hash term had no single realizable form across layers. Changing it
+		// must not flip rule selection.
+		{name: "foreign_genesis_hash_is_not_a_term", breakTerm: func(_ *testing.T, p *peer) { p.service.cfg.GenesisHash = [32]byte{0x01} }, wantStock: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newCompactScriptedPeer(t)
+			p.service.cfg.SyncConfig.ExpectedTarget = &wrongExpected
+			if tc.breakTerm != nil {
+				tc.breakTerm(t, p)
+			}
+			if got := peerStockDevnetTargetSchedule(p); got != tc.wantStock {
+				t.Fatalf("predicate=%v, want %v", got, tc.wantStock)
+			}
+			relayed := header
+			if tc.target != nil {
+				relayed = compactHeaderWithTarget(header, *tc.target)
+			}
+			err := p.handleCmpctBlock(mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{
+				Header:    relayed,
+				Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}},
+			}))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) || p.snapshotState().BanScore == 0 {
+					t.Fatalf("err=%v state=%+v, want %q with a ban", err, p.snapshotState(), tc.wantErr)
+				}
+				return
+			}
+			requireNoCompactErr(t, err, tc.name)
+			have, haveErr := p.service.hasBlock(blockHash)
+			if p.snapshotState().BanScore != 0 || haveErr != nil || !have {
+				t.Fatalf("ban=%d have=%v err=%v, want the block accepted by the apply path", p.snapshotState().BanScore, have, haveErr)
+			}
+		})
+	}
+}
+
+// peerStockDevnetTargetSchedule reads the predicate exactly as
+// validateCompactBlockHeader does: from the ENGINE the service defers to.
+func peerStockDevnetTargetSchedule(p *peer) bool {
+	return p.service.cfg.SyncEngine.StockDevnetTargetSchedule()
+}
+
+// retargetPeerEngine rebuilds the service's sync engine with a different
+// startup identity. The gate reads the ENGINE's normalized config, so this —
+// not ServiceConfig.SyncConfig — is what moves the predicate.
+func retargetPeerEngine(t *testing.T, p *peer, network string, chainID [32]byte) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	cfg := node.DefaultSyncConfig(nil, chainID, node.ChainStatePath(dir))
+	cfg.Network = network
+	engine, err := node.NewSyncEngine(node.NewChainState(), store, cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	// Keep the service's store with its engine, as production wires them.
+	p.service.cfg.SyncEngine = engine
+	p.service.cfg.BlockStore = store
+}
+
+func compactHeaderWithPrev(header [consensus.BLOCK_HEADER_BYTES]byte, prev [32]byte) [consensus.BLOCK_HEADER_BYTES]byte {
+	const prevOffset = 4
+	copy(header[prevOffset:prevOffset+32], prev[:])
+	return header
+}
+
+// TestTargetScheduleRuntimeCompactOrphanRetainedNotBanned pins the disposition
+// of a relayed block whose parent is not in the store: target-schedule context
+// cannot be derived for an unresolved parent, so the block must be RETAINED as
+// an orphan — never turned into a connection-level error and never ban-scored.
+// Go reaches this through compactApplyErrorFallback -> retainRelayedOrphanIfValid;
+// the row exists so the two clients are provably aligned on it.
+func TestTargetScheduleRuntimeCompactOrphanRetainedNotBanned(t *testing.T) {
+	header, _, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	// A non-zero, unknown parent. The published genesis carries POW_LIMIT so
+	// the header still satisfies PoW and the orphan guard admits it.
+	orphanHeader := compactHeaderWithPrev(header, [32]byte{0xab})
+	orphanHash, err := consensus.BlockHash(orphanHeader[:])
+	if err != nil {
+		t.Fatalf("BlockHash: %v", err)
+	}
+
+	p := newCompactScriptedPeer(t)
+	if !peerStockDevnetTargetSchedule(p) {
+		t.Fatal("scripted peer is not the stock devnet configuration")
+	}
+	// Prefilled-only: no short ids, so the apply path does not fall back to a
+	// full-block request and the orphan disposition is what gets exercised.
+	err = p.handleCmpctBlock(mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{
+		Header:    orphanHeader,
+		Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}},
+	}))
+	if err != nil {
+		t.Fatalf("unresolved-parent compact block returned a connection-level error: %v", err)
+	}
+	if score := p.snapshotState().BanScore; score != 0 {
+		t.Fatalf("BanScore=%d, want 0 for an orphan", score)
+	}
+	if p.service.orphans.Len() != 1 {
+		t.Fatalf("orphan pool len=%d, want the block retained", p.service.orphans.Len())
+	}
+	if have, herr := p.service.hasBlock(orphanHash); herr != nil || have {
+		t.Fatalf("hasBlock=%v err=%v, want the orphan NOT applied", have, herr)
+	}
 }

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -332,7 +332,108 @@ func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*Ch
 	if err != nil {
 		return nil, err
 	}
-	return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps)
+	return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil)
+}
+
+// StockDevnetTargetSchedule reports whether the exact stock Phase-0 devnet
+// predicate holds: a candidate's expected target MUST then come from the
+// derived schedule, not from the static SyncConfig.ExpectedTarget.
+//
+// This is the SINGLE formula for that rule in the Go tree, and every layer —
+// including node/p2p — MUST call it rather than replicate it, so no layer can
+// select a different rule than the one the apply path enforces. It normalizes
+// the network itself (blank and any case/whitespace variant of "devnet" count
+// as devnet) because callers may hold the operator's RAW SyncConfig:
+// NewSyncEngine normalizes only its own copy.
+//
+// Stateless by contract: it takes startup identity only, reads no chain state,
+// performs no derivation, and cannot fail. It confers no derivation capability
+// — the schedule helper, its ancestry walk and the retarget entry stay
+// unexported.
+//
+// Exactly TWO immutable startup terms, and deliberately no chain-state term.
+// A genesis-hash term would add no guarantee: the chain id IS the SHA3-256
+// commitment over the published genesis bytes (deriveGenesisChainID, re-derived
+// and panic-checked at init in chainstate.go), so chain-id equality already
+// implies the published genesis identity. What such a term did add was rule
+// selection that depends on chain state — an empty or recovering store flipped
+// it — a canonical-index read per untrusted peer message, and no single
+// realizable form across layers. The genesis hash is still verified at startup
+// by ValidateDevnetGenesisIdentity; that is where it belongs.
+//
+// Being a pure function of startup identity, this cannot fail, so it returns no
+// error and reads nothing.
+func StockDevnetTargetSchedule(network string, chainID [32]byte) bool {
+	return normalizedNetworkName(network) == "devnet" && chainID == devnetGenesisChainID
+}
+
+// StockDevnetTargetSchedule reports the predicate for THIS engine, from the
+// engine's OWN normalized configuration. Every layer that defers a target
+// decision to an engine MUST ask that engine rather than consult a separate
+// SyncConfig copy: a layer holding its own copy could otherwise select a
+// different rule than the engine it hands the block to, which is a
+// same-process accept/reject divergence. Mirrors Rust's
+// SyncEngine::stock_devnet_target_schedule.
+//
+// Nil-receiver safe, like the other exported SyncEngine methods: a nil engine
+// reports false, which keeps the caller on its pre-existing static behavior
+// instead of panicking on a validity path.
+func (s *SyncEngine) StockDevnetTargetSchedule() bool {
+	if s == nil {
+		return false
+	}
+	return StockDevnetTargetSchedule(s.cfg.Network, s.cfg.ChainID)
+}
+
+// canonicalApplyTarget carries an expected target already resolved by a caller
+// that owns the (selected parent, candidate height) pair. Nil means "resolve at
+// the choke point"; non-nil is used verbatim, so a boundary candidate is never
+// walked twice. Its expected field is nil exactly when no derivation ran — a
+// height-0 candidate (including the production genesis bootstrap, where the
+// predicate DOES hold) or a non-stock identity — and the configured static
+// target is itself nil. A derivation failure is always an error and can never
+// reach a validation call as a nil expected target.
+type canonicalApplyTarget struct {
+	expected *[32]byte
+}
+
+// targetContextForCandidate resolves the expected target for one candidate. The
+// CALLER owns both inputs: parentHash MUST be the authoritative selected parent
+// and candidateHeight the caller's own height. Height 0 is the
+// published-genesis path and keeps the configured static target.
+func targetContextForCandidate(store *BlockStore, cfg SyncConfig, parentHash [32]byte, candidateHeight uint64) (*canonicalApplyTarget, error) {
+	if candidateHeight == 0 || !StockDevnetTargetSchedule(cfg.Network, cfg.ChainID) {
+		return &canonicalApplyTarget{expected: cfg.ExpectedTarget}, nil
+	}
+	// Fail closed, with or without a configured static target. Once the
+	// predicate holds the derived target is the ONLY binding rule, so falling
+	// back to the static field when derivation is impossible would silently
+	// restore the very hole this issue closes. Mirrors the Rust
+	// UNBOUND_DEVNET_TARGET_ERR refusal byte-for-byte in wording and category
+	// (a plain error, not a consensus TxError), so neither client can accept
+	// what the other refuses.
+	if store == nil {
+		return nil, errors.New("target schedule context: stock devnet predicate holds but there is no block store")
+	}
+	target, err := deriveExpectedTargetFn(store, parentHash, candidateHeight)
+	if err != nil {
+		return nil, err
+	}
+	return &canonicalApplyTarget{expected: &target}, nil
+}
+
+// deriveExpectedTargetFn indirects the merged derivation primitive so tests can
+// count how many times the CALLERS invoke it. Production always holds
+// expectedTargetForCandidate; the read count inside the primitive is the
+// primitive's own property and is pinned by its own tests. Mirrors the existing
+// readFileByPathFn / writeFileAtomicFn seams in blockstore.go.
+var deriveExpectedTargetFn = expectedTargetForCandidate
+
+func (s *SyncEngine) targetContextForCandidate(parentHash [32]byte, candidateHeight uint64) (*canonicalApplyTarget, error) {
+	if s == nil {
+		return nil, errors.New("sync engine is not initialized")
+	}
+	return targetContextForCandidate(s.blockStore, s.cfg, parentHash, candidateHeight)
 }
 
 func (s *SyncEngine) SetMempool(mempool *Mempool) {
@@ -509,30 +610,33 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 	prevTimestamps []uint64,
+	target *canonicalApplyTarget,
 ) (*ChainStateConnectSummary, error) {
-	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps)
+	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps, target)
 	s.noteBlockApplyOutcome(outcome)
 	return summary, err
 }
 
 type canonicalBlockApplyContext struct {
-	blockHeight   uint64
-	blockHash     [32]byte
-	rollbackState syncRollbackState
-	prevState     *ChainState
+	blockHeight    uint64
+	blockHash      [32]byte
+	expectedTarget *[32]byte
+	rollbackState  syncRollbackState
+	prevState      *ChainState
 }
 
 func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 	prevTimestamps []uint64,
+	target *canonicalApplyTarget,
 ) (*ChainStateConnectSummary, blockApplyMetricOutcome, error) {
-	ctx, outcome, err := s.prepareCanonicalBlockApply(pb)
+	ctx, outcome, err := s.prepareCanonicalBlockApply(pb, target)
 	if err != nil {
 		return nil, outcome, err
 	}
-	summary, err := s.connectCanonicalBlock(pb, blockBytes, prevTimestamps)
-	s.runPVShadowIfActive(blockBytes, prevTimestamps, ctx.prevState, ctx.blockHeight, err, summary)
+	summary, err := s.connectCanonicalBlock(blockBytes, prevTimestamps, ctx.expectedTarget)
+	s.runPVShadowIfActive(blockBytes, prevTimestamps, ctx, err, summary)
 	if err != nil {
 		return nil, blockApplyMetricRejected, err
 	}
@@ -542,11 +646,15 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	return summary, blockApplyMetricAccepted, nil
 }
 
-func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock) (canonicalBlockApplyContext, blockApplyMetricOutcome, error) {
+func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, target *canonicalApplyTarget) (canonicalBlockApplyContext, blockApplyMetricOutcome, error) {
 	if err := s.validateCanonicalBlockApplyReady(pb); err != nil {
 		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
 	}
-	blockHeight, _, err := nextBlockContext(s.chainState)
+	blockHeight, canonicalTip, err := nextBlockContext(s.chainState)
+	if err != nil {
+		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
+	}
+	expectedTarget, err := s.resolveCanonicalApplyTarget(target, canonicalTip, blockHeight)
 	if err != nil {
 		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
 	}
@@ -562,11 +670,40 @@ func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock) (cano
 		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
 	}
 	return canonicalBlockApplyContext{
-		blockHeight:   blockHeight,
-		blockHash:     blockHash,
-		rollbackState: rollbackState,
-		prevState:     cloneChainState(rollbackState.chainState),
+		blockHeight:    blockHeight,
+		blockHash:      blockHash,
+		expectedTarget: expectedTarget,
+		rollbackState:  rollbackState,
+		prevState:      cloneChainState(rollbackState.chainState),
 	}, blockApplyMetricNone, nil
+}
+
+// resolveCanonicalApplyTarget is the choke point for every apply that runs
+// through applyCanonicalParsedBlockTracked, so no such path can reach
+// ConnectBlock with an unbound target. Two paths deliberately do NOT pass
+// through it and resolve their own context instead: the reorg preview in
+// preparePreferredBranch, and startup replay in replayCanonicalBlocks.
+//
+// A caller that already resolved the context — because it had to acquire the
+// target BEFORE its own MTP window, or because it owns a branch-relative height
+// the chainstate does not yet reflect — supplies it, keeping a boundary
+// candidate to one WINDOW_SIZE walk instead of two. Otherwise the selected
+// parent is the canonical tip from nextBlockContext; at height 0 nothing is
+// derived and the published-genesis path is unchanged. All of it is read-only
+// and runs before captureRollbackState, therefore before any mutation.
+func (s *SyncEngine) resolveCanonicalApplyTarget(target *canonicalApplyTarget, canonicalTip *[32]byte, blockHeight uint64) (*[32]byte, error) {
+	if target != nil {
+		return target.expected, nil
+	}
+	var parentHash [32]byte
+	if canonicalTip != nil {
+		parentHash = *canonicalTip
+	}
+	resolved, err := s.targetContextForCandidate(parentHash, blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.expected, nil
 }
 
 func (s *SyncEngine) validateCanonicalBlockApplyReady(pb *consensus.ParsedBlock) error {
@@ -580,13 +717,13 @@ func (s *SyncEngine) validateCanonicalBlockApplyReady(pb *consensus.ParsedBlock)
 }
 
 func (s *SyncEngine) connectCanonicalBlock(
-	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 	prevTimestamps []uint64,
+	expectedTarget *[32]byte,
 ) (*ChainStateConnectSummary, error) {
 	return s.chainState.ConnectBlockWithSuiteContext(
 		blockBytes,
-		s.cfg.ExpectedTarget,
+		expectedTarget,
 		prevTimestamps,
 		s.cfg.ChainID,
 		s.cfg.RotationProvider,

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -26,13 +26,19 @@ func (s *SyncEngine) validateGenesisIdentity(blockHeight uint64, blockHash [32]b
 }
 
 // runPVShadowOnError runs parallel validation when sequential connect failed.
-func (s *SyncEngine) runPVShadowOnError(blockBytes []byte, prevTimestamps []uint64, prevState *ChainState, blockHeight uint64, seqErr error) {
+//
+// The shadow run MUST observe the same expected target as the sequential
+// connect that produced seqErr — ctx.expectedTarget, never the static
+// SyncConfig.ExpectedTarget, or PV reports a fabricated seq/par divergence at
+// every retarget boundary.
+func (s *SyncEngine) runPVShadowOnError(blockBytes []byte, prevTimestamps []uint64, ctx canonicalBlockApplyContext, seqErr error) {
+	blockHeight := ctx.blockHeight
 	s.pvTelemetry.RecordBlockValidated()
 	validateStart := time.Now()
-	shadowState := cloneChainState(prevState)
+	shadowState := cloneChainState(ctx.prevState)
 	_, parErr := shadowState.ConnectBlockParallelSigsWithSuiteContext(
 		blockBytes,
-		s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID,
+		ctx.expectedTarget, prevTimestamps, s.cfg.ChainID,
 		s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
 	)
 	s.pvTelemetry.RecordValidateLatency(time.Since(validateStart))
@@ -49,13 +55,16 @@ func (s *SyncEngine) runPVShadowOnError(blockBytes []byte, prevTimestamps []uint
 }
 
 // runPVShadowOnSuccess runs parallel validation when sequential connect succeeded.
-func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []uint64, prevState *ChainState, blockHeight uint64, seqSummary *ChainStateConnectSummary) {
+//
+// Same contract as runPVShadowOnError: binds to ctx.expectedTarget.
+func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []uint64, ctx canonicalBlockApplyContext, seqSummary *ChainStateConnectSummary) {
+	blockHeight := ctx.blockHeight
 	s.pvTelemetry.RecordBlockValidated()
 	validateStart := time.Now()
-	shadowState := cloneChainState(prevState)
+	shadowState := cloneChainState(ctx.prevState)
 	parSummary, parErr := shadowState.ConnectBlockParallelSigsWithSuiteContext(
 		blockBytes,
-		s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID,
+		ctx.expectedTarget, prevTimestamps, s.cfg.ChainID,
 		s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
 	)
 	s.pvTelemetry.RecordValidateLatency(time.Since(validateStart))
@@ -77,16 +86,16 @@ func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []ui
 }
 
 // runPVShadowIfActive runs the appropriate PV shadow validation.
-func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uint64, prevState *ChainState, blockHeight uint64, seqErr error, seqSummary *ChainStateConnectSummary) {
+func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uint64, ctx canonicalBlockApplyContext, seqErr error, seqSummary *ChainStateConnectSummary) {
 	pvActive := (s.pvMode == pvModeShadow || s.pvMode == pvModeOn) && s.isInIBDUnchecked()
 	if !pvActive {
 		s.pvTelemetry.RecordBlockSkipped()
 		return
 	}
 	if seqErr != nil {
-		s.runPVShadowOnError(blockBytes, prevTimestamps, prevState, blockHeight, seqErr)
+		s.runPVShadowOnError(blockBytes, prevTimestamps, ctx, seqErr)
 	} else {
-		s.runPVShadowOnSuccess(blockBytes, prevTimestamps, prevState, blockHeight, seqSummary)
+		s.runPVShadowOnSuccess(blockBytes, prevTimestamps, ctx, seqSummary)
 	}
 }
 

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -75,11 +75,21 @@ func (s *SyncEngine) storeSideBlockAndSummary(branch []reorgBranchBlock, commonA
 		return nil, errors.New("empty side branch")
 	}
 	candidate := branch[len(branch)-1]
+	// Target context BEFORE the MTP window, so a target-context failure
+	// short-circuits without reading MTP state. Selected parent = the
+	// candidate's PrevBlockHash, already resolved against stored ancestry by
+	// collectBranchToCanonical; height = the caller-owned candidateHeight.
+	targetCtx, err := s.targetContextForCandidate(candidate.header.PrevBlockHash, candidateHeight)
+	if err != nil {
+		return nil, err
+	}
 	prevTimestamps, err := sideBranchPrevTimestamps(s.blockStore, branch, commonAncestorHeight)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := consensus.ValidateBlockBasicWithContextAtHeightAndRotation(candidate.blockBytes, &candidate.header.PrevBlockHash, s.cfg.ExpectedTarget, candidateHeight, prevTimestamps, s.cfg.ChainID, s.cfg.RotationProvider); err != nil {
+	// Full validation still precedes StoreBlock, so an invalid side-branch
+	// target contributes nothing to stored state or to fork choice.
+	if _, err := consensus.ValidateBlockBasicWithContextAtHeightAndRotation(candidate.blockBytes, &candidate.header.PrevBlockHash, targetCtx.expected, candidateHeight, prevTimestamps, s.cfg.ChainID, s.cfg.RotationProvider); err != nil {
 		return nil, err
 	}
 	if err := s.blockStore.StoreBlock(candidate.hash, candidate.parsed.HeaderBytes, candidate.blockBytes); err != nil {
@@ -117,25 +127,37 @@ func (s *SyncEngine) applyDirectBlockIfPossible(
 		if pb.Header.PrevBlockHash != zero {
 			return nil, true, ErrParentNotFound
 		}
-		summary, err := s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps)
+		summary, err := s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil)
 		return summary, true, err
 	case pb.Header.PrevBlockHash == view.tipHash:
-		nextHeight, _, err := nextBlockContextFromFields(view.hasTip, view.height, view.tipHash)
-		if err != nil {
-			return nil, true, err
-		}
-		if s.blockStore == nil {
-			return nil, true, errors.New("missing blockstore for direct-tip timestamp context")
-		}
-		canonicalPrevTimestamps, err := prevTimestampsFromStore(s.blockStore, nextHeight)
-		if err != nil {
-			return nil, true, err
-		}
-		summary, err := s.applyCanonicalParsedBlock(pb, blockBytes, canonicalPrevTimestamps)
+		summary, err := s.applyDirectTipBlock(pb, blockBytes, view)
 		return summary, true, err
 	default:
 		return nil, false, nil
 	}
+}
+
+// applyDirectTipBlock applies a candidate whose parent is the canonical tip.
+// Acquisition order is target-then-MTP: the target context must precede the
+// RUB-647 canonical MTP window so a target-context failure short-circuits
+// before any MTP state is read. The height-0 genesis branch never reaches here.
+func (s *SyncEngine) applyDirectTipBlock(pb *consensus.ParsedBlock, blockBytes []byte, view chainStateView) (*ChainStateConnectSummary, error) {
+	nextHeight, _, err := nextBlockContextFromFields(view.hasTip, view.height, view.tipHash)
+	if err != nil {
+		return nil, err
+	}
+	if s.blockStore == nil {
+		return nil, errors.New("missing blockstore for direct-tip timestamp context")
+	}
+	targetCtx, err := s.targetContextForCandidate(view.tipHash, nextHeight)
+	if err != nil {
+		return nil, err
+	}
+	canonicalPrevTimestamps, err := prevTimestampsFromStore(s.blockStore, nextHeight)
+	if err != nil {
+		return nil, err
+	}
+	return s.applyCanonicalParsedBlock(pb, blockBytes, canonicalPrevTimestamps, targetCtx)
 }
 
 func (s *SyncEngine) shouldSwitchToBranch(
@@ -202,17 +224,8 @@ func (s *SyncEngine) applyPreferredBranch(
 	var pendingAccepted uint64
 	var canonicalBlocks []CanonicalAppliedBlock
 	for i, item := range branch {
-		// Derive fresh timestamps from the (updated) canonical index for
-		// each block in the branch.  The stale caller prevTimestamps was
-		// computed for height commonAncestorHeight+1 and is wrong for
-		// blocks 2+ (finding B.9, issue #1166).
-		nextHeight := commonAncestorHeight + 1 + uint64(i)
-		freshTs, tsErr := prevTimestampsFromStore(s.blockStore, nextHeight)
-		if tsErr != nil {
-			return nil, s.rollbackApplyBlock(tsErr, rollbackState)
-		}
 		var outcome blockApplyMetricOutcome
-		summary, outcome, err = s.applyCanonicalParsedBlockTracked(item.parsed, item.blockBytes, freshTs)
+		summary, outcome, err = s.applyBranchBlock(item, commonAncestorHeight+1+uint64(i))
 		if err != nil {
 			return nil, s.rollbackBranchBlockApply(err, rollbackState, outcome)
 		}
@@ -230,6 +243,24 @@ func (s *SyncEngine) applyPreferredBranch(
 		summary.CanonicalAppliedBlocks = canonicalBlocks
 	}
 	return summary, nil
+}
+
+// applyBranchBlock commits one row of the preferred branch at its caller-owned
+// height. Both context windows are re-derived per iteration: the canonical
+// index moved when the previous row committed, and a branch can cross a
+// retarget boundary (the target half of the B.9 / issue #1166 argument). Target
+// context first, so a target-context failure short-circuits before the MTP
+// window is read.
+func (s *SyncEngine) applyBranchBlock(item reorgBranchBlock, nextHeight uint64) (*ChainStateConnectSummary, blockApplyMetricOutcome, error) {
+	targetCtx, err := s.targetContextForCandidate(item.header.PrevBlockHash, nextHeight)
+	if err != nil {
+		return nil, blockApplyMetricNone, err
+	}
+	freshTs, err := prevTimestampsFromStore(s.blockStore, nextHeight)
+	if err != nil {
+		return nil, blockApplyMetricNone, err
+	}
+	return s.applyCanonicalParsedBlockTracked(item.parsed, item.blockBytes, freshTs, targetCtx)
 }
 
 func (s *SyncEngine) rollbackBranchBlockApply(
@@ -266,10 +297,19 @@ func (s *SyncEngine) preparePreferredBranch(
 	if err != nil {
 		return nil, 0, err
 	}
-	for _, item := range branch {
+	for i, item := range branch {
+		// Per-row derivation: a branch can cross a retarget boundary. Unlike
+		// the MTP window this needs no sliding workaround — it reads headers
+		// by hash and never consults the canonical index, and every ancestor
+		// it needs is already stored (collectBranchToCanonical fetched
+		// branch[0..len-2] from the store; the common ancestor is canonical).
+		targetCtx, targetErr := s.targetContextForCandidate(item.header.PrevBlockHash, commonAncestorHeight+1+uint64(i))
+		if targetErr != nil {
+			return nil, 0, targetErr
+		}
 		if _, err := previewState.ConnectBlockWithSuiteContext(
 			item.blockBytes,
-			s.cfg.ExpectedTarget,
+			targetCtx.expected,
 			slidingTs,
 			s.cfg.ChainID,
 			s.cfg.RotationProvider,

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -332,33 +332,36 @@ func TestApplyBlockWithReorgTimestampFailureDoesNotMutateState(t *testing.T) {
 
 func TestApplyBlockWithReorgRejectsMissingDirectTipTimestampHistory(t *testing.T) {
 	tests := []struct {
-		name         string
-		setup        func(*testing.T, *SyncEngine, *BlockStore)
-		wantExact    string
-		wantCode     consensus.ErrorCode
-		wantNotExist bool
+		name      string
+		setup     func(*testing.T, *SyncEngine, *BlockStore)
+		wantExact string
+		wantCode  consensus.ErrorCode
 	}{
-		{"nil_blockstore", func(_ *testing.T, e *SyncEngine, _ *BlockStore) { e.blockStore = nil }, "missing blockstore for direct-tip timestamp context", "", false},
+		{"nil_blockstore", func(_ *testing.T, e *SyncEngine, _ *BlockStore) { e.blockStore = nil }, "missing blockstore for direct-tip timestamp context", ""},
 		{"missing_hash", func(t *testing.T, _ *SyncEngine, s *BlockStore) {
 			if err := s.TruncateCanonical(0); err != nil {
 				t.Fatalf("TruncateCanonical: %v", err)
 			}
-		}, "missing canonical hash at height 0 for timestamp context (next_height=1)", "", false},
+		}, "missing canonical hash at height 0 for timestamp context (next_height=1)", ""},
+		// RUB-655 ordering: target context precedes the MTP window, so a
+		// missing selected-parent header is now the primitive's documented
+		// ErrParentNotFound instead of the MTP read's raw os.ErrNotExist.
+		// Rejected either way, and nothing is stored.
 		{"missing_header", func(t *testing.T, _ *SyncEngine, s *BlockStore) {
 			if err := os.Remove(filepath.Join(s.headersDir, hex.EncodeToString(devnetGenesisBlockHash[:])+".bin")); err != nil {
 				t.Fatalf("Remove(header): %v", err)
 			}
-		}, "", "", true},
+		}, ErrParentNotFound.Error(), ""},
 		{"malformed_header", func(t *testing.T, _ *SyncEngine, s *BlockStore) {
 			if err := os.WriteFile(filepath.Join(s.headersDir, hex.EncodeToString(devnetGenesisBlockHash[:])+".bin"), []byte{0}, 0o600); err != nil {
 				t.Fatalf("WriteFile(header): %v", err)
 			}
-		}, "", consensus.TX_ERR_PARSE, false},
+		}, "", consensus.TX_ERR_PARSE},
 		{"height_overflow", func(_ *testing.T, e *SyncEngine, _ *BlockStore) {
 			e.chainState.mu.Lock()
 			e.chainState.Height = ^uint64(0)
 			e.chainState.mu.Unlock()
-		}, "height overflow", "", false},
+		}, "height overflow", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -375,8 +378,6 @@ func TestApplyBlockWithReorgRejectsMissingDirectTipTimestampHistory(t *testing.T
 			switch {
 			case tc.wantExact != "" && (err == nil || err.Error() != tc.wantExact):
 				t.Fatalf("err=%v, want %q", err, tc.wantExact)
-			case tc.wantNotExist && !errors.Is(err, os.ErrNotExist):
-				t.Fatalf("err=%v, want os.ErrNotExist", err)
 			case tc.wantCode != "":
 				requireConsensusTxErrCode(t, err, tc.wantCode)
 			}
@@ -735,7 +736,7 @@ func TestCollectBranchToCanonicalPropagatesNonNotExistErrors(t *testing.T) {
 
 func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 	var nilEngine *SyncEngine
-	if _, err := nilEngine.applyCanonicalParsedBlock(nil, nil, nil); err == nil {
+	if _, err := nilEngine.applyCanonicalParsedBlock(nil, nil, nil, nil); err == nil {
 		t.Fatalf("expected nil sync engine error")
 	}
 
@@ -755,7 +756,7 @@ func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 	}
 
 	engine := newEmptyEngine(t, devnetGenesisChainID)
-	if _, err := engine.applyCanonicalParsedBlock(nil, nil, nil); err == nil {
+	if _, err := engine.applyCanonicalParsedBlock(nil, nil, nil, nil); err == nil {
 		t.Fatalf("expected nil parsed block error")
 	}
 

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -99,6 +99,11 @@ func TestValidateParallelValidationMode(t *testing.T) {
 func TestPVShadowMismatch_SequentialTruthPreserved(t *testing.T) {
 	target := consensus.POW_LIMIT
 	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, "")
+	// Storeless engine: a stock devnet identity now fails closed rather than
+	// falling back to the static target (RUB-655), so this PV fixture declares
+	// a non-devnet network. The chain id must stay devnet — it is the sighash
+	// domain these signed transactions were built against.
+	cfg.Network = "regtest"
 	cfg.ParallelValidationMode = "shadow"
 	cfg.PVShadowMaxSamples = 2
 
@@ -226,6 +231,11 @@ func TestPVShadowMismatch_IsBounded(t *testing.T) {
 func TestPVShadow_NoMismatchOnValidBlock(t *testing.T) {
 	target := consensus.POW_LIMIT
 	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, "")
+	// Storeless engine: a stock devnet identity now fails closed rather than
+	// falling back to the static target (RUB-655), so this PV fixture declares
+	// a non-devnet network. The chain id must stay devnet — it is the sighash
+	// domain these signed transactions were built against.
+	cfg.Network = "regtest"
 	cfg.ParallelValidationMode = "shadow"
 	cfg.PVShadowMaxSamples = 3
 

--- a/clients/go/node/target_schedule_runtime_test.go
+++ b/clients/go/node/target_schedule_runtime_test.go
@@ -1,0 +1,910 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// boundarySpacingSeconds halves the synthetic window's block interval so the
+// retarget lands near POW_LIMIT/2, inside the /4 clamp.
+const boundarySpacingSeconds = consensus.TARGET_BLOCK_INTERVAL / 2
+
+func newStockDevnetEngine(t *testing.T, mutate func(*SyncConfig)) (*SyncEngine, *BlockStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	cfg := DefaultSyncConfig(nil, devnetGenesisChainID, ChainStatePath(dir))
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	engine, err := NewSyncEngine(NewChainState(), store, cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if err := engine.BootstrapCanonicalGenesisIfEmpty(); err != nil {
+		t.Fatalf("BootstrapCanonicalGenesisIfEmpty: %v", err)
+	}
+	return engine, store, dir
+}
+
+// setStaticExpectedTargetAfterGenesis installs a static expected target once the
+// published genesis is applied: at height 0 the static value still binds — that
+// path is deliberately untouched — so setting a wrong one earlier would reject
+// the published genesis itself.
+func setStaticExpectedTargetAfterGenesis(engine *SyncEngine, target *[32]byte) {
+	engine.cfg.ExpectedTarget = target
+}
+
+func wrongTarget() [32]byte {
+	out := consensus.POW_LIMIT
+	out[1] = 0x7f
+	return out
+}
+
+func mustRemove(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove(%s): %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func mustBlockHash(t *testing.T, block []byte) [32]byte {
+	t.Helper()
+	return mustHeaderHash(t, blockHeaderBytes(t, block))
+}
+
+func requireNotStored(t *testing.T, store *BlockStore, hash [32]byte) {
+	t.Helper()
+	if _, err := store.GetBlockByHash(hash); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected candidate stored: err=%v", err)
+	}
+}
+
+// mineTargetScheduleBlock builds a single-transaction block whose header really
+// satisfies PoW against `target`, reusing the production header-prefix and
+// nonce-search helpers; buildSingleTxBlock pins nonce 7 and only works at
+// POW_LIMIT-scale targets.
+func mineTargetScheduleBlock(t *testing.T, prevHash [32]byte, target [32]byte, timestamp uint64, tx []byte) []byte {
+	t.Helper()
+	_, txid, _, _, err := consensus.ParseTx(tx)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+	root, err := consensus.MerkleRootTxids([][32]byte{txid})
+	if err != nil {
+		t.Fatalf("MerkleRootTxids: %v", err)
+	}
+	headerBytes, _, err := mineHeaderNonce(context.Background(), makeHeaderPrefix(prevHash, root, timestamp, target), target)
+	if err != nil {
+		t.Fatalf("mineHeaderNonce: %v", err)
+	}
+	block := append([]byte(nil), headerBytes...)
+	block = consensus.AppendCompactSize(block, 1)
+	return append(block, tx...)
+}
+
+func nextCandidateBlock(t *testing.T, engine *SyncEngine, target [32]byte, timestamp uint64) []byte {
+	t.Helper()
+	view := engine.chainState.view()
+	height := view.height + 1
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, consensus.BlockSubsidy(height, view.alreadyGenerated))
+	return mineTargetScheduleBlock(t, view.tipHash, target, timestamp, coinbase)
+}
+
+func requireBlockTxError(t *testing.T, err error, code consensus.ErrorCode, msg string) {
+	t.Helper()
+	var txErr *consensus.TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("err=%T %v, want *consensus.TxError %s/%q", err, err, code, msg)
+	}
+	if txErr.Code != code || txErr.Msg != msg {
+		t.Fatalf("err=%s/%q, want %s/%q", txErr.Code, txErr.Msg, code, msg)
+	}
+}
+
+func applyCanonicalChain(t *testing.T, engine *SyncEngine, blocks uint64) {
+	t.Helper()
+	for i := uint64(1); i <= blocks; i++ {
+		block := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(i))
+		if _, err := engine.ApplyBlockWithReorg(block, nil); err != nil {
+			t.Fatalf("apply canonical block %d: %v", i, err)
+		}
+	}
+}
+
+func canonicalTipSnapshot(t *testing.T, store *BlockStore) (uint64, [32]byte) {
+	t.Helper()
+	height, hash, ok, err := store.Tip()
+	if err != nil || !ok {
+		t.Fatalf("Tip()=(%d,%x,%v,%v)", height, hash, ok, err)
+	}
+	return height, hash
+}
+
+// newTargetScheduleBoundaryChain materializes a stock devnet chain whose tip is
+// at WINDOW_SIZE-1, so the next candidate sits exactly on a retarget boundary.
+//
+// Heights 1..WINDOW_SIZE-2 are synthetic HEADERS plus a matching canonical
+// index — 10,078 real blocks would cost ~30k fsync'd writes and an O(n^2) index
+// rewrite, while the derivation reads only headers by hash and MTP only the last
+// 11. Height 0 (the published genesis) and the TOP height are applied for real
+// so they own block and undo artifacts, which a reorg preview must disconnect.
+// Returns the window timestamps ascending plus the retarget value the boundary
+// candidate must carry, checked here to be distinct from the parent's own target
+// so the boundary rows are discriminating rather than tautological.
+func newTargetScheduleBoundaryChain(t *testing.T) (*SyncEngine, *BlockStore, []uint64, [32]byte) {
+	t.Helper()
+	engine, store, _ := newStockDevnetEngine(t, nil)
+
+	times := make([]uint64, consensus.WINDOW_SIZE)
+	times[0] = reorgTestTimestamp(0)
+	canonical := make([]string, 1, consensus.WINDOW_SIZE)
+	canonical[0] = hex.EncodeToString(devnetGenesisBlockHash[:])
+	prev := devnetGenesisBlockHash
+	for height := 1; height < consensus.WINDOW_SIZE-1; height++ {
+		times[height] = times[0] + uint64(height)*boundarySpacingSeconds
+		raw, hash := scheduleHeader(t, prev, consensus.POW_LIMIT, times[height], uint64(height))
+		mustWriteFile(t, filepath.Join(store.headersDir, hex.EncodeToString(hash[:])+".bin"), raw)
+		canonical = append(canonical, hex.EncodeToString(hash[:]))
+		prev = hash
+	}
+	store.index.Canonical = canonical
+	store.rebuildCanonicalHeightIndex()
+	engine.chainState.mu.Lock()
+	engine.chainState.Height = uint64(consensus.WINDOW_SIZE - 2)
+	engine.chainState.TipHash = prev
+	engine.chainState.mu.Unlock()
+	// The TOP canonical block is applied for real so it owns block and undo
+	// artifacts: a reorg preview disconnects it, and synthetic header-only
+	// heights cannot be disconnected.
+	times[consensus.WINDOW_SIZE-1] = times[0] + uint64(consensus.WINDOW_SIZE-1)*boundarySpacingSeconds
+	top := nextCandidateBlock(t, engine, consensus.POW_LIMIT, times[consensus.WINDOW_SIZE-1])
+	if _, err := engine.ApplyBlockWithReorg(top, nil); err != nil {
+		t.Fatalf("apply the real top canonical block: %v", err)
+	}
+	want, err := consensus.RetargetV1Clamped(consensus.POW_LIMIT, times)
+	if err != nil || want == consensus.POW_LIMIT {
+		t.Fatalf("boundary retarget=%x err=%v, want a value distinct from POW_LIMIT", want, err)
+	}
+	return engine, store, times, want
+}
+
+func TestTargetScheduleRuntimePublishedGenesisUnchanged(t *testing.T) {
+	// The predicate HOLDS here, so the height-0 short-circuit is the only
+	// reason nothing is derived: the primitive rejects height 0 outright with
+	// errTargetHeightInvalid, and this engine has no static target to fall
+	// back on. Bootstrap succeeding is the proof that height 0 never derives.
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	height, hash := canonicalTipSnapshot(t, store)
+	if engine.cfg.ExpectedTarget != nil || height != 0 || hash != devnetGenesisBlockHash {
+		t.Fatalf("static=%v tip=(%d,%x), want no static target and the published genesis at height 0", engine.cfg.ExpectedTarget, height, hash)
+	}
+	if err := engine.BootstrapCanonicalGenesisIfEmpty(); err != nil {
+		t.Fatalf("idempotent bootstrap: %v", err)
+	}
+}
+
+// targetRuntimeCase drives one height-1 candidate through a live apply entry
+// point on its own stock devnet chain. Every rejecting row must also satisfy the
+// shared no-side-effect obligation checked by runTargetRuntimeCase.
+type targetRuntimeCase struct {
+	name          string
+	network       string    // "" keeps the stock devnet network
+	static        *[32]byte // installed AFTER genesis
+	prevHash      *[32]byte // overrides the selected parent
+	target        [32]byte
+	pinNonce      bool // skip the PoW search so the header fails PoW
+	viaApplyBlock bool // canonical ApplyBlock instead of ApplyBlockWithReorg
+	wantCode      consensus.ErrorCode
+	wantMsg       string
+	wantIs        error // sentinel outcome that must NOT gain a consensus class
+	thenAccept    bool  // a correctly targeted block at the SAME height must follow
+}
+
+func runTargetRuntimeCase(t *testing.T, tc targetRuntimeCase) {
+	t.Helper()
+	engine, store, _ := newStockDevnetEngine(t, func(cfg *SyncConfig) {
+		if tc.network != "" {
+			cfg.Network = tc.network
+		}
+	})
+	if tc.static != nil {
+		setStaticExpectedTargetAfterGenesis(engine, tc.static)
+	}
+	view := engine.chainState.view()
+	prev := view.tipHash
+	if tc.prevHash != nil {
+		prev = *tc.prevHash
+	}
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, view.alreadyGenerated))
+	// pinNonce rows MUST skip the search: their targets are unsatisfiable
+	// (zero, or 1) and mineHeaderNonce would spin forever.
+	block := buildSingleTxBlock(t, prev, tc.target, reorgTestTimestamp(1), coinbase)
+	if !tc.pinNonce {
+		block = mineTargetScheduleBlock(t, prev, tc.target, reorgTestTimestamp(1), coinbase)
+	}
+	apply := engine.ApplyBlockWithReorg
+	if tc.viaApplyBlock {
+		apply = engine.ApplyBlock
+	}
+	_, err := apply(block, nil)
+	switch {
+	case tc.wantIs != nil:
+		var txErr *consensus.TxError
+		if !errors.Is(err, tc.wantIs) || errors.As(err, &txErr) {
+			t.Fatalf("err=%v, want bare %v with no consensus class", err, tc.wantIs)
+		}
+	case tc.wantCode != "":
+		requireBlockTxError(t, err, tc.wantCode, tc.wantMsg)
+	default:
+		if err != nil {
+			t.Fatalf("want acceptance, got %v", err)
+		}
+		return
+	}
+	// Shared obligation: a rejected candidate is never stored and never moves
+	// the canonical tip.
+	requireNotStored(t, store, mustBlockHash(t, block))
+	if height, tip := canonicalTipSnapshot(t, store); height != 0 || tip != devnetGenesisBlockHash {
+		t.Fatalf("rejected candidate moved the tip to (%d,%x)", height, tip)
+	}
+	if !tc.thenAccept {
+		return
+	}
+	good := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(1))
+	summary, err := engine.ApplyBlockWithReorg(good, nil)
+	if err != nil || summary.BlockHeight != 1 {
+		t.Fatalf("valid candidate at the same height: summary=%v err=%v", summary, err)
+	}
+}
+
+func TestTargetScheduleRuntimeApplyMatrix(t *testing.T) {
+	wrong, foreign := wrongTarget(), [32]byte{0xab}
+	tiny := [32]byte{}
+	tiny[31] = 0x01
+	for _, tc := range []targetRuntimeCase{
+		// PoW range and PoW work both precede the expected-target equality;
+		// each block also carries an unexpected target, so a target check
+		// running ahead of PoW would change the answer.
+		{name: "pow_work_precedes_target", target: tiny, pinNonce: true, wantCode: consensus.BLOCK_ERR_POW_INVALID, wantMsg: "pow invalid"},
+		{name: "pow_range_precedes_target", target: [32]byte{}, pinNonce: true, wantCode: consensus.BLOCK_ERR_TARGET_INVALID, wantMsg: "target out of range"},
+		// Mis-targeted AND mis-linked: derivation uses the RESOLVED canonical
+		// tip as selected parent, so the target check wins over linkage.
+		{name: "resolved_parent_target_precedes_linkage", target: wrong, prevHash: &foreign, viaApplyBlock: true, wantCode: consensus.BLOCK_ERR_TARGET_INVALID, wantMsg: "target mismatch"},
+		// Control: no schedule context exists for an unknown parent, so the
+		// candidate keeps its orphan outcome instead of gaining a target class.
+		{name: "unresolved_parent_stays_orphan", target: consensus.POW_LIMIT, prevHash: &foreign, wantIs: ErrParentNotFound},
+		// The candidate carries the STATIC target: under the predicate the
+		// derived value (the genesis POW_LIMIT) binds and rejects it,
+		// otherwise the static value binds and it is accepted as before.
+		{name: "predicate_true_derives", target: wrong, static: &wrong, wantCode: consensus.BLOCK_ERR_TARGET_INVALID, wantMsg: "target mismatch"},
+		{name: "predicate_false_keeps_static", target: wrong, static: &wrong, network: "regtest"},
+		// Reject-then-valid at the SAME height on one chain.
+		{name: "reject_then_valid_same_height", target: wrong, wantCode: consensus.BLOCK_ERR_TARGET_INVALID, wantMsg: "target mismatch", thenAccept: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) { runTargetRuntimeCase(t, tc) })
+	}
+
+	t.Run("predicate_is_pure_startup_identity", func(t *testing.T) {
+		// The predicate is exactly two immutable startup terms and reads no
+		// chain state, so destroying canonical[0] must NOT flip rule
+		// selection — that dependency is what made an empty or recovering
+		// store change the rules mid-flight.
+		engine, store, _ := newStockDevnetEngine(t, nil)
+		if err := store.TruncateCanonical(0); err != nil {
+			t.Fatalf("TruncateCanonical: %v", err)
+		}
+		if !StockDevnetTargetSchedule(engine.cfg.Network, engine.cfg.ChainID) {
+			t.Fatal("predicate flipped when canonical[0] was destroyed")
+		}
+		// The single shared accessor normalizes the network itself, because
+		// node/p2p hands it the operator's RAW SyncConfig value.
+		for _, tc := range []struct {
+			network string
+			chainID [32]byte
+			want    bool
+		}{
+			{"", devnetGenesisChainID, true},
+			{"devnet", devnetGenesisChainID, true},
+			{"DEVNET", devnetGenesisChainID, true},
+			{" DevNet\t", devnetGenesisChainID, true},
+			{"regtest", devnetGenesisChainID, false},
+			{"mainnet", devnetGenesisChainID, false},
+			{"devnet", [32]byte{0x01}, false},
+			{"devnet", [32]byte{}, false},
+		} {
+			if got := StockDevnetTargetSchedule(tc.network, tc.chainID); got != tc.want {
+				t.Fatalf("StockDevnetTargetSchedule(%q, %x...)=%v, want %v", tc.network, tc.chainID[:2], got, tc.want)
+			}
+		}
+	})
+
+	t.Run("storeless_devnet_fails_closed", func(t *testing.T) {
+		// Once the predicate holds the derived target is the ONLY binding
+		// rule, so a storeless caller is refused WITH OR WITHOUT a configured
+		// static target: falling back to that field would silently restore the
+		// hole this issue closes. Same wording and same category (a plain
+		// error, not a consensus class) as Rust's UNBOUND_DEVNET_TARGET_ERR.
+		const want = "target schedule context: stock devnet predicate holds but there is no block store"
+		static := consensus.POW_LIMIT
+		for _, configured := range []*[32]byte{nil, &static} {
+			cfg := DefaultSyncConfig(configured, devnetGenesisChainID, "")
+			ctx, err := targetContextForCandidate(nil, cfg, foreign, 1)
+			if err == nil || err.Error() != want || ctx != nil {
+				t.Fatalf("storeless devnet (static=%v): ctx=%v err=%v, want the fail-closed refusal", configured, ctx, err)
+			}
+			var txErr *consensus.TxError
+			if errors.As(err, &txErr) {
+				t.Fatalf("refusal carries consensus class %s; Rust returns a plain message", txErr.Code)
+			}
+		}
+		// A non-stock identity keeps its pre-existing static behavior.
+		nonStock := DefaultSyncConfig(&static, devnetGenesisChainID, "")
+		nonStock.Network = "regtest"
+		if ctx, err := targetContextForCandidate(nil, nonStock, foreign, 1); err != nil || ctx.expected != &static {
+			t.Fatalf("non-stock storeless engine: ctx=%v err=%v, want the configured target", ctx, err)
+		}
+	})
+}
+
+func TestTargetScheduleRuntimeParallelValidationSeesDerivedTarget(t *testing.T) {
+	// The static target is deliberately wrong: a shadow run still reading
+	// SyncConfig.ExpectedTarget would reject the block the sequential run
+	// accepts, recording a fabricated divergence.
+	wrong := wrongTarget()
+	engine, _, _ := newStockDevnetEngine(t, func(cfg *SyncConfig) { cfg.ParallelValidationMode = "shadow" })
+	setStaticExpectedTargetAfterGenesis(engine, &wrong)
+	// Assert rather than skip: the Rust mirror asserts here, and a skip would
+	// turn this row into a silent no-op the day the fixture stops satisfying
+	// the IBD predicate.
+	if !engine.isInIBDUnchecked() {
+		t.Fatal("fixture chain is not in IBD, so PV shadow would not run")
+	}
+	block := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(1))
+	if _, err := engine.ApplyBlockWithReorg(block, nil); err != nil {
+		t.Fatalf("ApplyBlockWithReorg: %v", err)
+	}
+	mismatches, samples := engine.PVShadowStats()
+	if mismatches != 0 || len(samples) != 0 {
+		t.Fatalf("pv shadow mismatches=%d samples=%v, want none", mismatches, samples)
+	}
+	if engine.pvTelemetry.Snapshot().BlocksValidated == 0 {
+		t.Fatal("pv shadow did not run, so it proves nothing about the target it used")
+	}
+}
+
+func TestTargetScheduleRuntimeTargetContextPrecedesMTP(t *testing.T) {
+	// Height 1: the selected-parent header and the whole MTP window are the
+	// same missing genesis header, so the error class identifies which context
+	// was acquired first. Target context wins.
+	genesisHeaderName := hex.EncodeToString(devnetGenesisBlockHash[:]) + ".bin"
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	block := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(1))
+	mustRemove(t, filepath.Join(store.headersDir, genesisHeaderName))
+	_, err := engine.ApplyBlockWithReorg(block, nil)
+	if !errors.Is(err, ErrParentNotFound) || errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err=%v, want the target-context class (ErrParentNotFound), not the MTP read error", err)
+	}
+
+	// Height 2 with the genesis header missing: the non-boundary derivation
+	// reads only the height-1 header and succeeds, so the failure now comes
+	// from the MTP window — the ordering is real, not an artifact of both
+	// contexts sharing one file.
+	engine, store, _ = newStockDevnetEngine(t, nil)
+	applyCanonicalChain(t, engine, 1)
+	next := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(2))
+	mustRemove(t, filepath.Join(store.headersDir, genesisHeaderName))
+	_, err = engine.ApplyBlockWithReorg(next, nil)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err=%v, want the MTP read error after a successful target context", err)
+	}
+}
+
+func TestTargetScheduleRuntimeReorgPreviewRejectsBeforeDisconnect(t *testing.T) {
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	applyCanonicalChain(t, engine, 2)
+	before := durableStoreFingerprint(t, store)
+	_, beforeTip := canonicalTipSnapshot(t, store)
+	beforeCounts := engine.BlockApplyCounts()
+
+	// A competing height-1 branch at a quarter of POW_LIMIT carries MORE chain
+	// work than the two canonical blocks, so fork choice selects it and the
+	// reorg preview must reject it — before any disconnect, any store write,
+	// and any contribution to chain work.
+	heavier := consensus.POW_LIMIT
+	heavier[0] = 0x3f
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0))
+	side := mineTargetScheduleBlock(t, devnetGenesisBlockHash, heavier, reorgTestTimestamp(9), coinbase)
+	sideHash := mustBlockHash(t, side)
+	_, err := engine.ApplyBlockWithReorg(side, nil)
+	requireBlockTxError(t, err, consensus.BLOCK_ERR_TARGET_INVALID, "target mismatch")
+	requireNotStored(t, store, sideHash)
+	if durableStoreFingerprint(t, store) != before {
+		t.Fatalf("durable store state changed by a rejected side branch")
+	}
+	if _, tip := canonicalTipSnapshot(t, store); tip != beforeTip {
+		t.Fatalf("canonical tip moved to %x", tip)
+	}
+	if _, err := store.ChainWork(sideHash); err == nil {
+		t.Fatal("rejected side block contributed chain work")
+	}
+	// The PREVIEW is the site that rejected it: had the preview skipped
+	// derivation, the commit loop would still reject, but only after the
+	// disconnect and after recording a block-apply rejection.
+	if got := engine.BlockApplyCounts(); got != beforeCounts {
+		t.Fatalf("preview reject recorded a block-apply outcome: %+v -> %+v", beforeCounts, got)
+	}
+}
+
+func TestTargetScheduleRuntimeRecoveryDerivesPerBlock(t *testing.T) {
+	engine, store, dir := newStockDevnetEngine(t, nil)
+	genesisSnapshot := cloneChainState(engine.chainState)
+	applyCanonicalChain(t, engine, 2)
+	cfg := engine.cfg
+	replayed := NewChainState()
+	changed, err := ReconcileChainStateWithBlockStore(replayed, store, cfg)
+	if err != nil || !changed || replayed.Height != 2 {
+		t.Fatalf("baseline reconcile: changed=%v height=%d err=%v", changed, replayed.Height, err)
+	}
+
+	// The derived VALUE must bind, not merely be computed: resume replay from
+	// the height-0 snapshot under a deliberately WRONG static expected target.
+	// Replay can only succeed if ConnectBlock received the derived value, and
+	// height 0 (which still uses the static target) is never re-entered.
+	wrongCfg := cfg
+	wrongStatic := wrongTarget()
+	wrongCfg.ExpectedTarget = &wrongStatic
+	resumed := cloneChainState(genesisSnapshot)
+	if changed, rerr := ReconcileChainStateWithBlockStore(resumed, store, wrongCfg); rerr != nil || !changed || resumed.Height != 2 {
+		t.Fatalf("resume under a wrong static target: changed=%v height=%d err=%v", changed, resumed.Height, rerr)
+	}
+
+	// Corrupt the height-1 HEADER artifact only: replay of height 1 still
+	// derives from the intact genesis header and its block artifact still
+	// re-hashes, so the failure lands on height 2's own parent lookup — the
+	// per-block evidence.
+	height1Hash, ok, err := store.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1)=(%x,%v,%v)", height1Hash, ok, err)
+	}
+	mustWriteFile(t, filepath.Join(store.headersDir, hex.EncodeToString(height1Hash[:])+".bin"), []byte{0x00})
+	before := durableStoreFingerprint(t, store)
+	chainStatePath := ChainStatePath(dir)
+	if err := os.Remove(chainStatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("clear chainstate snapshot: %v", err)
+	}
+
+	// No additional durable write after a target-context failure: the
+	// canonical index, the artifacts, and the absent chainstate snapshot must
+	// all be exactly as they were.
+	// The selected parent is the canonical index entry at height-1, never the
+	// replayed block's own hash. With ONLY the height-1 header corrupted, a
+	// self-parenting derivation would already fail at height 1; the canonical
+	// parent lets height 1 replay from the intact genesis header so that only
+	// height 2 fails. How far the replay got is the witness.
+	partial := NewChainState()
+	if _, err := ReconcileChainStateWithBlockStore(partial, store, cfg); !errors.Is(err, errTargetHistoryCorrupt) {
+		t.Fatalf("reconcile err=%v, want errTargetHistoryCorrupt", err)
+	}
+	if partial.Height != 1 {
+		t.Fatalf("replay reached height %d before failing, want 1", partial.Height)
+	}
+
+	// A non-devnet replay derives nothing and keeps cfg.ExpectedTarget, so the
+	// corrupt header surfaces from the MTP window, never from the schedule.
+	nonStock := cfg
+	nonStock.Network = "regtest"
+	if _, err := ReconcileChainStateWithBlockStore(NewChainState(), store, nonStock); err == nil || errors.Is(err, errTargetHistoryCorrupt) {
+		t.Fatalf("non-devnet replay err=%v, want a failure that is not the schedule class", err)
+	}
+	if durableStoreFingerprint(t, store) != before {
+		t.Fatalf("durable store state changed after a target-context failure")
+	}
+	if _, err := os.Stat(chainStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("chainstate snapshot written after target-context failure: %v", err)
+	}
+}
+
+// durableStoreFingerprint captures every durable thing a failing path must not
+// change: the canonical index plus the block/header/undo artifact listings.
+func durableStoreFingerprint(t *testing.T, store *BlockStore) string {
+	t.Helper()
+	parts, err := store.CanonicalIndexSnapshot()
+	if err != nil {
+		t.Fatalf("CanonicalIndexSnapshot: %v", err)
+	}
+	for _, dir := range []string{store.blocksDir, store.headersDir, store.undoDir} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir(%s): %v", dir, err)
+		}
+		for _, entry := range entries {
+			parts = append(parts, entry.Name())
+		}
+	}
+	return strings.Join(parts, "|")
+}
+
+func TestTargetScheduleRuntimeBoundaryReadBoundsAndBinding(t *testing.T) {
+	engine, store, times, want := newTargetScheduleBoundaryChain(t)
+	parent := engine.chainState.view().tipHash
+
+	reads := 0
+	counting := func(hash [32]byte) ([]byte, error) {
+		reads++
+		return store.GetHeaderByHash(hash)
+	}
+
+	nonBoundary, err := expectedTargetForCandidateWithReader(counting, parent, consensus.WINDOW_SIZE-1)
+	if err != nil || reads != 1 || nonBoundary != consensus.POW_LIMIT {
+		t.Fatalf("non-boundary: target=%x err=%v reads=%d, want %x nil 1", nonBoundary, err, reads, consensus.POW_LIMIT)
+	}
+
+	reads = 0
+	boundary, err := expectedTargetForCandidateWithReader(counting, parent, consensus.WINDOW_SIZE)
+	if err != nil || reads != consensus.WINDOW_SIZE || boundary != want {
+		t.Fatalf("boundary: target=%x err=%v reads=%d, want %x nil %d", boundary, err, reads, want, consensus.WINDOW_SIZE)
+	}
+
+	// The production resolver every call site uses must agree with both.
+	for _, tc := range []struct {
+		height uint64
+		want   [32]byte
+	}{{consensus.WINDOW_SIZE - 1, consensus.POW_LIMIT}, {consensus.WINDOW_SIZE, want}} {
+		ctx, err := engine.targetContextForCandidate(parent, tc.height)
+		if err != nil || ctx.expected == nil || *ctx.expected != tc.want {
+			t.Fatalf("resolver at height %d: ctx=%v err=%v, want %x", tc.height, ctx, err, tc.want)
+		}
+	}
+
+	// ...and the derived value is what actually binds a boundary candidate:
+	// reject-then-valid at the same boundary height, where the parent's own
+	// target is no longer the expected one.
+	timestamp := times[len(times)-1] + boundarySpacingSeconds
+	stale := nextCandidateBlock(t, engine, consensus.POW_LIMIT, timestamp)
+	_, err = engine.ApplyBlockWithReorg(stale, nil)
+	requireBlockTxError(t, err, consensus.BLOCK_ERR_TARGET_INVALID, "target mismatch")
+	requireNotStored(t, store, mustBlockHash(t, stale))
+
+	good := nextCandidateBlock(t, engine, want, timestamp)
+	summary, err := engine.ApplyBlockWithReorg(good, nil)
+	if err != nil || summary.BlockHeight != consensus.WINDOW_SIZE {
+		t.Fatalf("boundary candidate at the derived target: summary=%v err=%v", summary, err)
+	}
+	if height, _ := canonicalTipSnapshot(t, store); height != consensus.WINDOW_SIZE {
+		t.Fatalf("canonical tip height=%d, want %d", height, consensus.WINDOW_SIZE)
+	}
+}
+
+func mustMiner(t *testing.T, engine *SyncEngine, store *BlockStore, cfg MinerConfig) *Miner {
+	t.Helper()
+	miner, err := NewMiner(engine.chainState, store, engine, cfg)
+	if err != nil {
+		t.Fatalf("NewMiner: %v", err)
+	}
+	return miner
+}
+
+func TestTargetScheduleRuntimeMinerUsesDerivedTarget(t *testing.T) {
+	// A deliberately wrong static MinerConfig.Target: on a stock devnet chain
+	// the template must ignore it for both header construction and the nonce
+	// search, or SyncEngine.ApplyBlock would reject the miner's own block.
+	// Far HARDER than POW_LIMIT (POW_LIMIT >> 16), so a header found by
+	// searching against the derived target does not satisfy it, while a search
+	// that used it necessarily would. That is what separates the nonce search
+	// from header construction.
+	staticTarget := [32]byte{}
+	for i := 2; i < 32; i++ {
+		staticTarget[i] = 0xff
+	}
+	cfg := DefaultMinerConfig()
+	cfg.Target = staticTarget
+
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	mined, err := mustMiner(t, engine, store, cfg).MineOne(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("MineOne: %v", err)
+	}
+	header, err := store.GetHeaderByHash(mined.Hash)
+	if err != nil {
+		t.Fatalf("GetHeaderByHash: %v", err)
+	}
+	if parsed, perr := consensus.ParseBlockHeaderBytes(header); perr != nil || parsed.Target != consensus.POW_LIMIT {
+		t.Fatalf("mined target=%x err=%v, want the derived %x", parsed.Target, perr, consensus.POW_LIMIT)
+	}
+	// The NONCE SEARCH used the derived target too, not just the header field.
+	if err := consensus.PowCheck(header, staticTarget); err == nil {
+		t.Fatal("mined header also satisfies the static MinerConfig.Target: the nonce search used it")
+	}
+
+	// Boundary height: the template must commit to the retargeted value.
+	boundaryEngine, boundaryStore, _, want := newTargetScheduleBoundaryChain(t)
+	got, err := mustMiner(t, boundaryEngine, boundaryStore, cfg).templateTarget(boundaryEngine.chainState.view().tipHash, consensus.WINDOW_SIZE)
+	if err != nil || got != want {
+		t.Fatalf("boundary template target=%x err=%v, want %x", got, err, want)
+	}
+
+	// Non-stock configuration keeps the static MinerConfig.Target verbatim.
+	regtestEngine, regtestStore, _ := newStockDevnetEngine(t, func(c *SyncConfig) { c.Network = "regtest" })
+	got, err = mustMiner(t, regtestEngine, regtestStore, cfg).templateTarget(regtestEngine.chainState.view().tipHash, 1)
+	if err != nil || got != staticTarget {
+		t.Fatalf("regtest template target=%x err=%v, want the static %x", got, err, staticTarget)
+	}
+}
+
+// mineOrderedBlock mines a valid block, advancing the timestamp until its hash
+// orders as requested against `other`. Fork choice breaks EQUAL-work ties on the
+// lexicographically lower tip hash, so a test that needs a branch row to win or
+// lose such a tie has to pin the ordering instead of relying on luck.
+func mineOrderedBlock(t *testing.T, prev, target [32]byte, baseTs uint64, tx []byte, other [32]byte, wantLower bool) []byte {
+	t.Helper()
+	for offset := uint64(0); offset < 512; offset++ {
+		block := mineTargetScheduleBlock(t, prev, target, baseTs+offset, tx)
+		hash := mustBlockHash(t, block)
+		if (bytes.Compare(hash[:], other[:]) < 0) == wantLower {
+			return block
+		}
+	}
+	t.Fatal("no timestamp in range produced the required hash ordering")
+	return nil
+}
+
+// countDerivations pins how many times the CALLERS invoke the derivation
+// primitive. The read count INSIDE the primitive is its own property and is
+// pinned by its own tests; what matters here is that no caller derives twice for
+// one block, and that the preview and commit loops stay linear in branch length.
+// The seam is a package global, so these rows must not run in parallel.
+func countDerivations(t *testing.T, body func()) int {
+	t.Helper()
+	previous := deriveExpectedTargetFn
+	defer func() { deriveExpectedTargetFn = previous }()
+	count := 0
+	deriveExpectedTargetFn = func(store *BlockStore, parentHash [32]byte, candidateHeight uint64) ([32]byte, error) {
+		count++
+		return previous(store, parentHash, candidateHeight)
+	}
+	body()
+	return count
+}
+
+// twoRowWinningBranch stores branch row A as a losing side block, then returns
+// row B so that applying B makes [A, B] outweigh the two canonical blocks and
+// take the switching reorg path.
+func twoRowWinningBranch(t *testing.T, engine *SyncEngine, store *BlockStore) []byte {
+	t.Helper()
+	_, canonicalTip := canonicalTipSnapshot(t, store)
+	rowA := mineTargetScheduleBlock(t, devnetGenesisBlockHash, consensus.POW_LIMIT, reorgTestTimestamp(9),
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+	if _, err := engine.ApplyBlockWithReorg(rowA, nil); err != nil {
+		t.Fatalf("store losing branch row A: %v", err)
+	}
+	hashA := mustBlockHash(t, rowA)
+	parsedA, err := consensus.ParseBlockBytes(rowA)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(rowA): %v", err)
+	}
+	subsidy := consensus.BlockSubsidy(2, consensus.BlockSubsidy(1, 0))
+	return mineOrderedBlock(t, hashA, consensus.POW_LIMIT, parsedA.Header.Timestamp+1,
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy), canonicalTip, true)
+}
+
+func TestTargetScheduleRuntimeReorgCommitLoopBindsDerivedTarget(t *testing.T) {
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	applyCanonicalChain(t, engine, 2)
+	// A deliberately wrong static target: the reorg completes only if the
+	// commit loop binds the DERIVED value for every row it applies. Reverting
+	// the commit loop alone turns this success into a target rejection.
+	wrong := wrongTarget()
+	setStaticExpectedTargetAfterGenesis(engine, &wrong)
+	rowB := twoRowWinningBranch(t, engine, store)
+	summary, err := engine.ApplyBlockWithReorg(rowB, nil)
+	if err != nil || summary.BlockHeight != 2 {
+		t.Fatalf("switching reorg under a wrong static target: summary=%v err=%v", summary, err)
+	}
+	if height, tip := canonicalTipSnapshot(t, store); height != 2 || tip != mustBlockHash(t, rowB) {
+		t.Fatalf("canonical tip=(%d,%x), want the branch tip at height 2", height, tip)
+	}
+}
+
+func TestTargetScheduleRuntimeSideBranchStoreRejectsBeforeStoreBlock(t *testing.T) {
+	// A branch that does NOT win fork choice takes storeSideBlockAndSummary,
+	// a different derivation site from the reorg preview. A wrong declared
+	// target must be rejected there before StoreBlock, contributing nothing to
+	// storage or to chain work.
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	applyCanonicalChain(t, engine, 2)
+	before := durableStoreFingerprint(t, store)
+	_, beforeTip := canonicalTipSnapshot(t, store)
+	side := mineTargetScheduleBlock(t, devnetGenesisBlockHash, wrongTarget(), reorgTestTimestamp(9),
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+	sideHash := mustBlockHash(t, side)
+	_, err := engine.ApplyBlockWithReorg(side, nil)
+	requireBlockTxError(t, err, consensus.BLOCK_ERR_TARGET_INVALID, "target mismatch")
+	requireNotStored(t, store, sideHash)
+	if durableStoreFingerprint(t, store) != before {
+		t.Fatal("durable store state changed by a rejected non-switching side branch")
+	}
+	if _, tip := canonicalTipSnapshot(t, store); tip != beforeTip {
+		t.Fatalf("canonical tip moved to %x", tip)
+	}
+	if _, err := store.ChainWork(sideHash); err == nil {
+		t.Fatal("rejected side block contributed chain work")
+	}
+}
+
+func TestTargetScheduleRuntimeParallelValidationOnErrorSeesDerivedTarget(t *testing.T) {
+	// The shadow-on-ERROR call site. The candidate carries the correct derived
+	// target but an invalid coinbase subsidy, so the sequential connect fails
+	// AFTER the target check. A shadow lane still reading the (wrong) static
+	// target would fail at the target check instead and record a fabricated
+	// seq/par divergence.
+	engine, _, _ := newStockDevnetEngine(t, func(cfg *SyncConfig) { cfg.ParallelValidationMode = "shadow" })
+	wrong := wrongTarget()
+	setStaticExpectedTargetAfterGenesis(engine, &wrong)
+	view := engine.chainState.view()
+	bad := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, view.alreadyGenerated)+1)
+	block := mineTargetScheduleBlock(t, view.tipHash, consensus.POW_LIMIT, reorgTestTimestamp(1), bad)
+	_, err := engine.ApplyBlockWithReorg(block, nil)
+	if err == nil {
+		t.Fatal("candidate with an over-paying coinbase was accepted")
+	}
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) && txErr.Code == consensus.BLOCK_ERR_TARGET_INVALID {
+		t.Fatalf("sequential path failed at the target check, not past it: %s/%q", txErr.Code, txErr.Msg)
+	}
+	mismatches, samples := engine.PVShadowStats()
+	if mismatches != 0 || len(samples) != 0 || engine.pvTelemetry.Snapshot().BlocksValidated == 0 {
+		t.Fatalf("pv shadow-on-error mismatches=%d samples=%v validated=%d", mismatches, samples,
+			engine.pvTelemetry.Snapshot().BlocksValidated)
+	}
+}
+
+func TestTargetScheduleRuntimeBranchCrossingRetargetBoundary(t *testing.T) {
+	// The only path where boundary derivation walks BRANCH ancestry instead of
+	// canonical ancestry: a branch row at the boundary height whose parent is
+	// another branch row. Its window ends at the branch row's timestamp, so the
+	// canonical-derived value is the WRONG answer here — binding it would be
+	// fork-class.
+	engine, store, times, canonicalWant := newTargetScheduleBoundaryChain(t)
+	_, canonicalTip := canonicalTipSnapshot(t, store)
+	forkParent, ok, err := store.CanonicalHash(consensus.WINDOW_SIZE - 2)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(fork parent)=(%x,%v,%v)", forkParent, ok, err)
+	}
+
+	// Row A at WINDOW_SIZE-1 must LOSE the equal-work tie so it is stored as a
+	// side block rather than triggering a reorg of its own.
+	heightA := uint64(consensus.WINDOW_SIZE - 1)
+	rowA := mineOrderedBlock(t, forkParent, consensus.POW_LIMIT, times[consensus.WINDOW_SIZE-2]+boundarySpacingSeconds,
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, heightA, consensus.BlockSubsidy(heightA, engine.chainState.view().alreadyGenerated)),
+		canonicalTip, false)
+	if _, err := engine.ApplyBlockWithReorg(rowA, nil); err != nil {
+		t.Fatalf("store losing branch row A at the pre-boundary height: %v", err)
+	}
+	parsedA, err := consensus.ParseBlockBytes(rowA)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(rowA): %v", err)
+	}
+	branchTimes := append(append([]uint64(nil), times[:consensus.WINDOW_SIZE-1]...), parsedA.Header.Timestamp)
+	branchWant, err := consensus.RetargetV1Clamped(consensus.POW_LIMIT, branchTimes)
+	if err != nil || branchWant == canonicalWant {
+		t.Fatalf("branch retarget=%x err=%v, want a value distinct from the canonical %x", branchWant, err, canonicalWant)
+	}
+
+	// Row B sits exactly on the boundary. The canonical-derived value must be
+	// rejected; the branch-derived value must get past the target check.
+	heightB := uint64(consensus.WINDOW_SIZE)
+	coinbaseB := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, heightB, consensus.BlockSubsidy(heightB, engine.chainState.view().alreadyGenerated))
+	tsB := parsedA.Header.Timestamp + boundarySpacingSeconds
+	_, err = engine.ApplyBlockWithReorg(mineTargetScheduleBlock(t, mustBlockHash(t, rowA), canonicalWant, tsB, coinbaseB), nil)
+	requireBlockTxError(t, err, consensus.BLOCK_ERR_TARGET_INVALID, "target mismatch")
+
+	_, err = engine.ApplyBlockWithReorg(mineTargetScheduleBlock(t, mustBlockHash(t, rowA), branchWant, tsB, coinbaseB), nil)
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) && txErr.Code == consensus.BLOCK_ERR_TARGET_INVALID {
+		t.Fatalf("branch-derived boundary target rejected: %s/%q", txErr.Code, txErr.Msg)
+	}
+}
+
+func TestTargetScheduleRuntimeCallerDerivesOncePerBlockAndRow(t *testing.T) {
+	t.Run("direct_tip_apply_derives_once", func(t *testing.T) {
+		engine, _, _ := newStockDevnetEngine(t, nil)
+		block := nextCandidateBlock(t, engine, consensus.POW_LIMIT, reorgTestTimestamp(1))
+		got := countDerivations(t, func() {
+			if _, err := engine.ApplyBlockWithReorg(block, nil); err != nil {
+				t.Fatalf("ApplyBlockWithReorg: %v", err)
+			}
+		})
+		// One acquisition in applyDirectTipBlock, threaded through the choke
+		// point verbatim — a second walk here would double a boundary block's
+		// ancestry cost.
+		if got != 1 {
+			t.Fatalf("derivations=%d, want 1", got)
+		}
+	})
+
+	t.Run("non_switching_side_branch_derives_once", func(t *testing.T) {
+		engine, _, _ := newStockDevnetEngine(t, nil)
+		applyCanonicalChain(t, engine, 2)
+		side := mineTargetScheduleBlock(t, devnetGenesisBlockHash, consensus.POW_LIMIT, reorgTestTimestamp(9),
+			coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+		got := countDerivations(t, func() {
+			if _, err := engine.ApplyBlockWithReorg(side, nil); err != nil {
+				t.Fatalf("store side block: %v", err)
+			}
+		})
+		if got != 1 {
+			t.Fatalf("derivations=%d, want 1", got)
+		}
+	})
+
+	t.Run("switching_reorg_is_linear_in_branch_length", func(t *testing.T) {
+		engine, store, _ := newStockDevnetEngine(t, nil)
+		applyCanonicalChain(t, engine, 2)
+		rowB := twoRowWinningBranch(t, engine, store)
+		got := countDerivations(t, func() {
+			if _, err := engine.ApplyBlockWithReorg(rowB, nil); err != nil {
+				t.Fatalf("switching reorg: %v", err)
+			}
+		})
+		// Two rows x two passes: one preview derivation and one commit
+		// derivation per row. Linear, not quadratic, and never twice per pass.
+		if got != 4 {
+			t.Fatalf("derivations=%d for a 2-row branch, want 4 (one per row per pass)", got)
+		}
+	})
+
+	t.Run("replay_derives_once_per_block", func(t *testing.T) {
+		engine, store, _ := newStockDevnetEngine(t, nil)
+		applyCanonicalChain(t, engine, 2)
+		cfg := engine.cfg
+		got := countDerivations(t, func() {
+			if _, err := ReconcileChainStateWithBlockStore(NewChainState(), store, cfg); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+		})
+		// Heights 1 and 2; height 0 keeps the static target and derives nothing.
+		if got != 2 {
+			t.Fatalf("derivations=%d for a 2-block replay, want 2", got)
+		}
+	})
+}
+
+func TestTargetScheduleRuntimeSideBranchTargetContextPrecedesMTP(t *testing.T) {
+	// storeSideBlockAndSummary acquires target context BEFORE the MTP window.
+	// The genesis header is both the branch's selected parent and the whole MTP
+	// window for height 1, so removing it makes the error class name whichever
+	// context was acquired first: the target class, not the MTP read error.
+	engine, store, _ := newStockDevnetEngine(t, nil)
+	applyCanonicalChain(t, engine, 2)
+	side := mineTargetScheduleBlock(t, devnetGenesisBlockHash, consensus.POW_LIMIT, reorgTestTimestamp(9),
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+	// Warm the chain-work cache first: fork choice runs before the store path
+	// and would otherwise read the same header, masking the ordering.
+	_, tip := canonicalTipSnapshot(t, store)
+	for _, hash := range [][32]byte{tip, devnetGenesisBlockHash} {
+		if _, err := store.ChainWork(hash); err != nil {
+			t.Fatalf("warm ChainWork(%x): %v", hash, err)
+		}
+	}
+	mustRemove(t, filepath.Join(store.headersDir, hex.EncodeToString(devnetGenesisBlockHash[:])+".bin"))
+	_, err := engine.ApplyBlockWithReorg(side, nil)
+	if !errors.Is(err, ErrParentNotFound) || errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err=%v, want the target-context class (ErrParentNotFound), not the MTP read error", err)
+	}
+}

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -53,7 +53,8 @@
 
 use crate::blockstore::BlockStore;
 use crate::chainstate::{ChainState, ChainStateConnectSummary};
-use crate::sync::SyncConfig;
+use crate::sync::{stock_devnet_target_schedule, target_schedule_error_message, SyncConfig};
+use crate::target_schedule::expected_target_for_candidate;
 use rubin_consensus::parse_block_header_bytes;
 
 /// Snapshot cadence: persist `ChainState` to disk on every block until
@@ -327,6 +328,7 @@ pub fn reconcile_chain_state_with_block_store(
                 "missing canonical block hash during chainstate replay at height {height} (tip_height={tip_height})"
             )
         })?;
+        let expected_target = replay_expected_target(store, cfg, height, tip_height)?;
         let block_bytes = store.get_block_by_hash(block_hash)?;
         // Defence-in-depth: re-hash the loaded block's header and
         // confirm it matches the canonical-index entry BEFORE
@@ -359,7 +361,7 @@ pub fn reconcile_chain_state_with_block_store(
         let prev_timestamps = prev_timestamps_from_store(store, height)?;
         state.connect_block_with_suite_context(
             &block_bytes,
-            cfg.expected_target,
+            expected_target,
             prev_timestamps.as_deref(),
             cfg.chain_id,
             rotation,
@@ -368,6 +370,41 @@ pub fn reconcile_chain_state_with_block_store(
         changed = true;
     }
     Ok(changed)
+}
+
+/// Expected target for the canonical block at `height`, resolved PER replayed
+/// block: the selected parent is the canonical index entry at `height - 1`, the
+/// candidate height is the loop variable. Only the free-function form of the
+/// primitive is callable here — reconcile runs before the sync engine exists.
+/// Mirror of Go `chainstate_recovery.go::replayExpectedTarget`.
+///
+/// Failure contract (RUB-655 `done_when`): the error returns unchanged through
+/// `reconcile_chain_state_with_block_store` to `main.rs`, which exits 2 BEFORE
+/// `chain_state.save`, before `SyncEngine::new`, and before the tx pool, p2p
+/// service, RPC server and miner start. This helper writes nothing, so the only
+/// durable write already made is the pre-existing incomplete-suffix truncation
+/// from `truncate_incomplete_canonical_suffix`; it stays intact and nothing is
+/// added. The in-memory `*state` reset is not durable — save is never reached.
+fn replay_expected_target(
+    store: &BlockStore,
+    cfg: &SyncConfig,
+    height: u64,
+    tip_height: u64,
+) -> Result<Option<[u8; 32]>, String> {
+    if height == 0 {
+        return Ok(cfg.expected_target);
+    }
+    if !stock_devnet_target_schedule(&cfg.network, cfg.chain_id) {
+        return Ok(cfg.expected_target);
+    }
+    let parent_hash = store.canonical_hash(height - 1)?.ok_or_else(|| {
+        format!(
+            "missing canonical parent hash for target context during chainstate replay at height {height} (tip_height={tip_height})"
+        )
+    })?;
+    expected_target_for_candidate(store, parent_hash, height)
+        .map(Some)
+        .map_err(target_schedule_error_message)
 }
 
 /// Build the prev-timestamps window used by `connect_block` consensus
@@ -1095,5 +1132,86 @@ mod tests {
             "explicit save outside the apply-block gate must always land"
         );
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ---- RUB-655 target-schedule runtime rows ----
+
+    /// Replay derives the expected target PER BLOCK, and a target-context
+    /// failure adds NO durable write of its own: canonical index,
+    /// block/header/undo artifacts and the absence of a chainstate snapshot are
+    /// all unchanged across the failing reconcile. Corrupting the height-1
+    /// HEADER artifact ONLY is what makes it per-block evidence — replay of
+    /// height 1 derives from the intact genesis header and its own block
+    /// artifact still re-hashes, so the failure lands on height 2's lookup.
+    #[test]
+    fn target_schedule_runtime_recovery_derives_per_block_without_durable_write() {
+        use crate::sync::{next_candidate_block_for_test, stock_devnet_engine_for_test};
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-recover", |_| {});
+        let at_genesis = engine.chain_state_snapshot();
+        for _ in 0..2 {
+            let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+            assert!(engine.apply_block_with_reorg(&block, None).is_ok());
+        }
+        // The deliberately wrong static target makes the row discriminating:
+        // replaying heights 1..=2 only succeeds if the DERIVED value binds.
+        // Replay resumes from the height-0 snapshot, so the published-genesis
+        // path (which keeps the static value by design) is not re-run.
+        let mut cfg = default_sync_config(None, devnet_genesis_chain_id(), None);
+        cfg.expected_target = Some([0x7f; 32]);
+        let mut store = engine.block_store_snapshot().expect("blockstore");
+        drop(engine);
+
+        let mut replayed = at_genesis.clone();
+        let changed = reconcile_chain_state_with_block_store(&mut replayed, &mut store, &cfg);
+        assert_eq!((changed, replayed.height), (Ok(true), 2));
+
+        let root = block_store_path(&dir);
+        // The selected parent is the canonical entry at height-1, NEVER the
+        // block's own: making canonical[2]'s header unreadable must not disturb
+        // the derivation FOR height 2, which reads canonical[1].
+        let tip = hex::encode(store.canonical_hash(2).expect("read").expect("height 2"));
+        let tip_header = root.join("headers").join(format!("{tip}.bin"));
+        let saved = fs::read(&tip_header).expect("read tip header");
+        fs::write(&tip_header, [0x00]).expect("corrupt tip header");
+        let derived = replay_expected_target(&store, &cfg, 2, 2);
+        assert!(
+            derived.is_ok(),
+            "derivation read the block's own header: {derived:?}"
+        );
+        fs::write(&tip_header, &saved).expect("restore tip header");
+        // A non-devnet replay keeps the configured static target verbatim.
+        let mut regtest = cfg.clone();
+        regtest.network = "regtest".to_string();
+        assert_eq!(
+            replay_expected_target(&store, &regtest, 1, 2),
+            Ok(cfg.expected_target)
+        );
+
+        let h1 = hex::encode(store.canonical_hash(1).expect("read").expect("height 1"));
+        fs::write(root.join("headers").join(format!("{h1}.bin")), [0x00]).expect("corrupt header");
+        let before = durable_state(&root);
+
+        let mut fresh = open_store_in(&dir);
+        let mut state = at_genesis;
+        let err = reconcile_chain_state_with_block_store(&mut state, &mut fresh, &cfg).unwrap_err();
+        assert_eq!(err, "target schedule history corrupt");
+        assert_eq!(
+            durable_state(&root),
+            before,
+            "reconcile added a durable write"
+        );
+        // `main.rs` reaches `chain_state.save` only AFTER reconcile returns Ok,
+        // so the fixture dir must hold no chainstate snapshot at all.
+        assert!(!crate::chainstate::chain_state_path(&dir).exists());
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The canonical index plus the block/header/undo artifact counts, so a
+    /// failing path can be shown to add no durable write of its own.
+    fn durable_state(root: &std::path::Path) -> (Vec<u8>, [usize; 3]) {
+        let index = fs::read(root.join("index.json")).expect("index");
+        let counts = ["blocks", "headers", "undo"]
+            .map(|name| fs::read_dir(root.join(name)).expect("artifact dir").count());
+        (index, counts)
     }
 }

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -17,7 +17,7 @@ use crate::coinbase::{
     build_coinbase_tx, default_mine_address, normalize_mine_address, parse_mine_address,
 };
 use crate::da_relay::{CompleteDaSetCandidate, CompleteDaSetProvider};
-use crate::sync::SyncEngine;
+use crate::sync::{target_schedule_error_message, SyncEngine};
 use crate::txpool::{
     apply_policy, TxPool, TxPoolConfig, DEFAULT_MEMPOOL_MIN_FEE_RATE, DEFAULT_MIN_DA_FEE_RATE,
 };
@@ -169,6 +169,9 @@ impl<'a> Miner<'a> {
         } else {
             [0u8; 32]
         };
+        // RUB-655: resolved BEFORE the MTP window, and used for BOTH header
+        // construction and the nonce search below.
+        let target = self.template_target(prev_hash, next_height)?;
         let remaining_weight = self.remaining_weight_budget(next_height)?;
         let candidates = self.candidate_transactions(txs);
         let prev_timestamps = self.sync.prev_timestamps_for_next_block()?;
@@ -201,9 +204,8 @@ impl<'a> Miner<'a> {
             txids.push(candidate.txid);
         }
         let merkle_root = merkle_root_txids(&txids).map_err(|e| e.to_string())?;
-        let block_without_nonce =
-            make_header_prefix(prev_hash, merkle_root, timestamp, self.cfg.target);
-        let (header_bytes, nonce) = mine_header_nonce(&block_without_nonce, self.cfg.target)?;
+        let block_without_nonce = make_header_prefix(prev_hash, merkle_root, timestamp, target);
+        let (header_bytes, nonce) = mine_header_nonce(&block_without_nonce, target)?;
         let block_bytes = assemble_block_bytes(&header_bytes, &coinbase, &parsed);
         let summary = self
             .sync
@@ -216,6 +218,25 @@ impl<'a> Miner<'a> {
             nonce,
             tx_count: 1 + parsed.len(),
         })
+    }
+
+    /// The target this post-genesis template commits to, for BOTH header
+    /// construction and the nonce search — the miner must never mine against a
+    /// target the apply path will then reject. `prev_hash` is the canonical tip
+    /// `mine_one` snapshotted (this template's authoritative selected parent)
+    /// and `next_height` the miner's own candidate height. On a stock Phase-0
+    /// devnet chain the derived target REPLACES the static `MinerConfig.target`,
+    /// so that field carries no authority there; everywhere else it is returned
+    /// unchanged, including `next_height == 0` (empty chain, no schedule target).
+    /// Mirror of Go `templateTarget`, whose nil-`m.sync` arm has no counterpart
+    /// here (the Rust `Miner` holds `&mut SyncEngine`).
+    fn template_target(&self, prev_hash: [u8; 32], next_height: u64) -> Result<[u8; 32], String> {
+        if next_height == 0 || !self.sync.stock_devnet_target_schedule() {
+            return Ok(self.cfg.target);
+        }
+        self.sync
+            .expected_target_for_candidate(prev_hash, next_height)
+            .map_err(target_schedule_error_message)
     }
 
     /// Flat candidate selection, mirroring Go `candidateTransactions`: individual DA
@@ -833,10 +854,10 @@ mod tests {
 
     use super::{
         assemble_block_bytes, build_witness_commitment, canonical_tx_weight,
-        choose_valid_timestamp, default_mine_address, make_header_prefix, mtp_median,
-        parse_complete_da_set_candidate, parse_mine_address_arg, parse_mining_candidate,
-        pick_flat_candidate_raw, updated_policy_da_bytes, validate_complete_da_set_candidate_shape,
-        Miner, MinerConfig,
+        choose_valid_timestamp, default_mine_address, make_header_prefix, mine_header_nonce,
+        mtp_median, parse_complete_da_set_candidate, parse_mine_address_arg,
+        parse_mining_candidate, pick_flat_candidate_raw, updated_policy_da_bytes,
+        validate_complete_da_set_candidate_shape, Miner, MinerConfig,
     };
 
     use std::path::Path;
@@ -1894,5 +1915,76 @@ mod tests {
         assert_eq!(conflict_skipped.len(), 1);
         assert_eq!(conflict_skipped[0].raw, raw);
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ---- RUB-655 target-schedule runtime rows ----
+
+    /// On a stock devnet chain the template IGNORES a deliberately wrong static
+    /// `MinerConfig.target` for BOTH header construction and the nonce search —
+    /// otherwise `mine_one`'s own `apply_block` would reject the block the miner
+    /// just mined. At a retarget BOUNDARY it commits to the retargeted value; on
+    /// a non-stock configuration the static target is verbatim.
+    #[test]
+    fn target_schedule_runtime_miner_uses_derived_target() {
+        use crate::sync::{boundary_chain_for_test, stock_devnet_engine_for_test};
+        use rubin_consensus::constants::{POW_LIMIT, WINDOW_SIZE};
+
+        // Two leading zero bytes: far HARDER than the derived POW_LIMIT, so a
+        // nonce searched against it lands nowhere near the first nonce that
+        // satisfies the derived target.
+        let mut wrong = POW_LIMIT;
+        wrong[0] = 0x00;
+        wrong[1] = 0x00;
+        #[rustfmt::skip]
+        let cfg = MinerConfig { target: wrong, ..Default::default() };
+
+        // End to end: `mine_one` mines AND applies, so a template that kept the
+        // wrong static target could not have produced an accepted block.
+        let (mut sync, dir) = stock_devnet_engine_for_test("rubin-ts-miner", |_| {});
+        let mined = {
+            let mut miner = Miner::new(&mut sync, None, cfg.clone()).expect("miner");
+            miner.mine_one(&[]).expect("mine one")
+        };
+        let store = sync.block_store_snapshot().expect("store");
+        let header = store.get_header_by_hash(mined.hash).expect("mined header");
+        let parsed = rubin_consensus::parse_block_header_bytes(&header).expect("parse header");
+        assert_eq!(parsed.target, POW_LIMIT, "template kept the static target");
+        // The NONCE SEARCH must take the derived target too, not just the
+        // header field: the mined nonce has to be the FIRST that satisfies the
+        // derived value, which a search against the static one would skip.
+        let (_, first) = mine_header_nonce(&header[..108], POW_LIMIT).expect("first nonce");
+        assert_eq!(
+            mined.nonce, first,
+            "nonce searched against the static target"
+        );
+        fs::remove_dir_all(&dir).expect("cleanup");
+
+        // One height below the boundary the parent's own target binds, so the
+        // boundary row is not a tautology; height 0 is the empty-chain path and
+        // keeps the configured value; a non-stock chain keeps it too.
+        let (mut boundary, boundary_dir, times) = boundary_chain_for_test("rubin-ts-mnbound");
+        let want = rubin_consensus::retarget_v1_clamped(POW_LIMIT, &times).expect("reference");
+        let parent = boundary.chain_state.tip_hash;
+        {
+            let miner = Miner::new(&mut boundary, None, cfg.clone()).expect("boundary miner");
+            #[rustfmt::skip]
+            let rows = [(WINDOW_SIZE, want), (WINDOW_SIZE - 1, POW_LIMIT), (0, wrong)];
+            for (height, expected) in rows {
+                let got = miner.template_target(parent, height);
+                assert_eq!(got, Ok(expected), "{height}");
+            }
+        }
+        drop(boundary);
+        fs::remove_dir_all(&boundary_dir).expect("cleanup");
+
+        let (mut regtest, regtest_dir) =
+            stock_devnet_engine_for_test("rubin-ts-mnregtest", |c| c.network = "regtest".into());
+        let regtest_parent = regtest.chain_state.tip_hash;
+        {
+            let miner = Miner::new(&mut regtest, None, cfg).expect("regtest miner");
+            assert_eq!(miner.template_target(regtest_parent, 1), Ok(wrong));
+        }
+        drop(regtest);
+        fs::remove_dir_all(&regtest_dir).expect("cleanup");
     }
 }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1071,7 +1071,18 @@ impl PeerSession {
             self.bump_ban(100, &err.to_string());
             return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
         }
+        // RUB-655: under the exact stock Phase-0 devnet predicate the OPTIONAL
+        // static expected-target equality is SKIPPED, so the reconstructed
+        // block reaches `SyncEngine::apply_block_with_reorg`, the authoritative
+        // path that derives the target from the selected parent and the
+        // candidate height. Parse, PoW range, PoW work and the peer disposition
+        // stay untouched; when the predicate is false this comparison and its
+        // peer outcome are byte-identical to pre-RUB-655.
+        //
+        // The predicate is the same two config-only startup terms every other
+        // layer uses; the startup identity check owns genesis-hash verification.
         if matches!(sync_engine.cfg.expected_target, Some(expected) if parsed_header.target != expected)
+            && !sync_engine.stock_devnet_target_schedule()
         {
             self.bump_ban(100, "target mismatch");
             return Err(invalid_data("target mismatch"));
@@ -1504,9 +1515,9 @@ impl PeerSession {
                 .has_block(parsed.header.prev_block_hash)
                 .map_err(io::Error::other)?
         {
-            return self.retain_or_resolve_orphan(
+            return self.retain_relayed_orphan_if_valid(
+                &parsed,
                 block_hash_bytes,
-                parsed.header.prev_block_hash,
                 block_bytes,
                 sync_engine,
                 relay_ctx,
@@ -1539,11 +1550,55 @@ impl PeerSession {
                     accepted_blocks,
                 })
             }
-            Err(err) if is_parent_not_found_err(&err) => Err(io::Error::other(format!(
-                "unexpected missing-parent after precheck: {err}"
-            ))),
+            // RUB-655: the apply path now DERIVES a target, so it can report
+            // the parent-not-found class even after the precheck passed — the
+            // precheck tests the CANDIDATE's prev hash while derivation asks
+            // for the prepared canonical tip, i.e. different hashes and
+            // different files, and `has_block` is a `Path::exists()` probe that
+            // conflates "missing" with a metadata error. A partially truncated
+            // or damaged store therefore disagrees with no concurrency at all.
+            // The precheck is an optimization and must not harden the outcome:
+            // route to the SAME orphan retention Go reaches from this position
+            // (`handlers_block.go` `retainRelayedOrphanIfValid`), instead of
+            // failing the peer message and losing the block.
+            Err(err) if is_parent_not_found_err(&err) => self.retain_relayed_orphan_if_valid(
+                &parsed,
+                block_hash_bytes,
+                block_bytes,
+                sync_engine,
+                relay_ctx,
+            ),
             Err(err) => Err(io::Error::other(err)),
         }
+    }
+
+    /// Mirror of Go `retainRelayedOrphanIfValid` (`handlers_block.go`): an
+    /// orphan candidate is PoW-gated against its OWN declared target BEFORE it
+    /// is admitted to the pool, so unvalidated peer data cannot take memory and
+    /// a bad-PoW block earns the same ban delta in both clients. Both orphan
+    /// entries — the pre-apply `has_block` precheck and the post-apply
+    /// parent-not-found arm — go through here; Go has no precheck, so its only
+    /// entry is the post-apply one and gating just that side would leave the
+    /// precheck path admitting what Go rejects.
+    fn retain_relayed_orphan_if_valid(
+        &mut self,
+        parsed: &rubin_consensus::ParsedBlock,
+        block_hash_bytes: [u8; 32],
+        block_bytes: &[u8],
+        sync_engine: &mut SyncEngine,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+    ) -> io::Result<RelayedBlockOutcome> {
+        if let Err(err) = rubin_consensus::pow_check(&parsed.header_bytes, parsed.header.target) {
+            self.bump_ban(100, &err.to_string());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
+        }
+        self.retain_or_resolve_orphan(
+            block_hash_bytes,
+            parsed.header.prev_block_hash,
+            block_bytes,
+            sync_engine,
+            relay_ctx,
+        )
     }
 
     fn retain_or_resolve_orphan(
@@ -7268,5 +7323,156 @@ mod tests {
 
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
+    }
+
+    // ---- RUB-655 target-schedule runtime rows ----
+
+    /// Compact payload for one block, prefilled so reconstruction needs no pool.
+    fn compact_payload_for_block(block: &[u8]) -> Vec<u8> {
+        let mut header = [0u8; BLOCK_HEADER_BYTES];
+        header.copy_from_slice(&block[..BLOCK_HEADER_BYTES]);
+        let txs = compact_block_transactions_by_index(block, &[0]).expect("prefilled tx");
+        encode_cmpctblock_payload(CmpctBlockPayload {
+            header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: Vec::new(),
+            prefilled: vec![PrefilledTxn {
+                index: 0,
+                tx: txs[0].clone(),
+            }],
+        })
+        .expect("encode cmpctblock")
+    }
+
+    /// RUB-655 item 2: the precheck is an OPTIMIZATION and must not harden the
+    /// outcome. `has_block` probes `headers/<hash>.bin`, while
+    /// `collect_branch_to_canonical` reads `blocks/<hash>.bin` — different
+    /// files, so a partially truncated or damaged store makes the precheck pass
+    /// and the apply report the parent-not-found class with NO concurrency at
+    /// all. Before this fix that arm returned a connection-level error and lost
+    /// the block; it must instead reach the same orphan retention Go reaches
+    /// from this position — retained, no error, no ban.
+    #[test]
+    fn target_schedule_runtime_precheck_apply_disagreement_retains_orphan() {
+        use crate::sync::{retarget_block_for_test, stock_devnet_engine_for_test};
+        let _metrics = orphan_pool_metrics_test_guard();
+        reset_orphan_pool_metrics_for_test();
+
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-precheck", |_| {});
+        let genesis = engine.chain_state.tip_hash;
+        let ts = engine.tip_timestamp + 1;
+
+        // A HEADER-ONLY artifact: the header probe the precheck uses succeeds,
+        // the block-bytes read the apply performs does not.
+        let mut header =
+            crate::test_helpers::build_block_bytes(genesis, [0u8; 32], POW_LIMIT, ts, &[]);
+        header.truncate(BLOCK_HEADER_BYTES);
+        let orphan_parent = block_hash(&header).expect("parent hash");
+        let root = crate::blockstore::block_store_path(&dir);
+        let leaf = format!("{}.bin", hex::encode(orphan_parent));
+        fs::write(root.join("headers").join(&leaf), &header).expect("write header-only artifact");
+        assert!(engine.has_block(orphan_parent).expect("precheck probe"));
+        assert!(!root.join("blocks").join(&leaf).exists());
+
+        let child = retarget_block_for_test(
+            coinbase_only_block_with_gen(2, 0, orphan_parent, ts + 1),
+            POW_LIMIT,
+        );
+        let child_hash = block_hash(&child[..BLOCK_HEADER_BYTES]).expect("child hash");
+        let (mut session, _client) = test_peer_session();
+        session
+            .handle_block(&child, &mut engine)
+            .expect("disagreement must not fail the peer message");
+        assert_eq!(
+            session.orphans.len(),
+            1,
+            "block must be retained as an orphan"
+        );
+        assert!(session.orphans.by_hash.contains_key(&child_hash));
+        assert_eq!(session.state().ban_score, 0, "retention must not ban");
+        assert_eq!(engine.chain_state.height, 0, "nothing became canonical");
+
+        // Go PoW-gates BEFORE retaining (`retainRelayedOrphanIfValid`), so a
+        // bad-PoW orphan must be rejected with the same ban delta and must not
+        // take pool memory — on BOTH orphan entries, the pre-apply precheck
+        // (parent absent) and the post-apply parent-not-found arm.
+        for (row, parent) in [(0u8, orphan_parent), (1, [0xab; 32])] {
+            let mut bad = coinbase_only_block_with_gen(2, 0, parent, ts + 2);
+            bad[76..108].copy_from_slice(&[0u8; 32]);
+            bad[107] = 0x01;
+            let (mut session, _client) = test_peer_session();
+            let err = session
+                .handle_block(&bad, &mut engine)
+                .expect_err("bad PoW must not be retained");
+            assert!(err.to_string().contains("pow invalid"), "row {row}: {err}");
+            assert_eq!(session.state().ban_score, 100, "row {row}");
+            assert_eq!(
+                session.orphans.len(),
+                0,
+                "row {row}: bad PoW took pool memory"
+            );
+        }
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The compact-relay gate, BOTH ways. Under the stock predicate the OPTIONAL
+    /// static expected-target equality is skipped, so the reconstructed block
+    /// reaches the authoritative apply path and is accepted with no ban; with ANY
+    /// term broken the static rejection and its peer disposition (`target
+    /// mismatch`, ban 100) are unchanged. PoW is enforced either way.
+    #[test]
+    fn target_schedule_runtime_compact_static_target_gate() {
+        use crate::sync::{next_candidate_block_for_test, stock_devnet_engine_for_test};
+        const POW_LIMIT: [u8; 32] = rubin_consensus::constants::POW_LIMIT;
+
+        let mut wrong = POW_LIMIT; // deliberately not the candidate's target
+        wrong[1] = 0x7f;
+        let break_term: [fn(&mut SyncEngine); 2] = [
+            |engine| engine.cfg.network = "regtest".to_string(),
+            |engine| engine.cfg.chain_id = [0x01; 32],
+        ];
+
+        for (row, break_term) in break_term.into_iter().enumerate() {
+            let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-cmpct-off", |_| {});
+            let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+            engine.cfg.expected_target = Some(wrong);
+            break_term(&mut engine);
+            assert!(!engine.stock_devnet_target_schedule(), "row {row}");
+
+            let (mut session, _client) = test_peer_session();
+            let err = session
+                .handle_cmpctblock(&compact_payload_for_block(&block), &mut engine, None)
+                .expect_err("static target must still reject");
+            assert_eq!(err.to_string(), "target mismatch", "row {row}");
+            assert_eq!(session.state().ban_score, 100, "row {row}");
+            fs::remove_dir_all(&dir).expect("cleanup");
+        }
+
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-cmpct-on", |_| {});
+        let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        engine.cfg.expected_target = Some(wrong);
+        assert!(engine.stock_devnet_target_schedule());
+        let hash = block_hash(&block[..BLOCK_HEADER_BYTES]).expect("candidate hash");
+
+        let (mut session, _client) = test_peer_session();
+        let payload = compact_payload_for_block(&block);
+        let ok = session.handle_cmpctblock(&payload, &mut engine, None);
+        assert!(ok.is_ok(), "must defer to the apply path: {ok:?}");
+        assert_eq!(session.state().ban_score, 0);
+        assert_eq!(engine.has_block(hash), Ok(true), "apply path must accept");
+
+        // PoW is still enforced under the stock predicate: only the OPTIONAL
+        // static equality moved, nothing else.
+        let mut tiny = block;
+        tiny[76..108].copy_from_slice(&[0u8; 32]);
+        tiny[107] = 0x01;
+        let (mut session, _client) = test_peer_session();
+        let err = session
+            .handle_cmpctblock(&compact_payload_for_block(&tiny), &mut engine, None)
+            .expect_err("pow must still reject");
+        assert!(err.to_string().contains("pow invalid"), "{err}");
+        assert_eq!(session.state().ban_score, 100);
+        fs::remove_dir_all(&dir).expect("cleanup");
     }
 }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -11,6 +11,9 @@ use rubin_consensus::{RotationProvider, SuiteRegistry};
 use crate::blockstore::BlockStore;
 use crate::chainstate::{ChainState, ChainStateConnectSummary};
 use crate::chainstate_recovery::should_persist_chainstate_snapshot;
+use crate::genesis::devnet_genesis_chain_id;
+use crate::sync_reorg::PARENT_BLOCK_NOT_FOUND_ERR;
+use crate::target_schedule::{expected_target_for_candidate, TargetScheduleError};
 use crate::undo::build_block_undo;
 
 pub const DEFAULT_IBD_LAG_SECONDS: u64 = 24 * 60 * 60;
@@ -524,7 +527,150 @@ pub fn default_sync_config(
     }
 }
 
+/// Mirror of Go `normalizedNetworkName`: trim, lowercase, blank => `"devnet"`.
+fn normalized_network_name(network: &str) -> String {
+    let network = network.trim().to_ascii_lowercase();
+    #[rustfmt::skip]
+    return if network.is_empty() { "devnet".to_string() } else { network };
+}
+
+/// The exact stock Phase-0 devnet predicate — whether a candidate's expected
+/// target MUST come from the derived schedule instead of the static
+/// `SyncConfig.expected_target`. Exactly TWO immutable startup terms, identical
+/// in every layer of both clients, mirroring Go `stockDevnetTargetSchedule`:
+/// the network normalizes to `"devnet"` AND the chain id is the published
+/// devnet genesis chain id.
+///
+/// There is deliberately no genesis-HASH term. The devnet chain id is the
+/// SHA3-256 commitment over the published genesis bytes; in THIS client both
+/// sides are compiled-in constants whose equality `genesis.rs` pins with a test
+/// (`derive_devnet_genesis_chain_id`) rather than an init-time re-derivation,
+/// so chain-id equality already identifies the published genesis. A canonical[0]
+/// term added no guarantee while making rule selection depend on chain state
+/// (an empty or recovering store flipped it), forcing a canonical-index read
+/// per untrusted peer message, and having no single realizable form across
+/// layers — which is what produced a cross-client divergence. Genesis identity
+/// on the wire stays with the p2p handshake's genesis-hash comparison and is
+/// not duplicated here. Being config-only, the predicate cannot fail.
+pub(crate) fn stock_devnet_target_schedule(network: &str, chain_id: [u8; 32]) -> bool {
+    normalized_network_name(network) == "devnet" && chain_id == devnet_genesis_chain_id()
+}
+
+/// An already-resolved expected target, from a caller that owns the (selected
+/// parent, candidate height) pair. `expected` is `None` ONLY when the predicate
+/// fails AND `SyncConfig.expected_target` is itself `None`: a derivation
+/// failure is always an `Err`, never a missing target.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CanonicalApplyTarget {
+    pub(crate) expected: Option<[u8; 32]>,
+}
+
+/// Resolve the expected target for ONE candidate. The CALLER owns both inputs:
+/// `parent_hash` MUST be the authoritative selected parent, `candidate_height`
+/// the caller's own height. Height 0 is the published-genesis path.
+///
+/// Once the predicate holds the derived target is the ONLY binding rule, so a
+/// caller with no block store is refused rather than silently falling back to
+/// the static value — fail-closed, never an unbound target.
+pub(crate) fn target_context_for_candidate(
+    block_store: Option<&BlockStore>,
+    cfg: &SyncConfig,
+    parent_hash: [u8; 32],
+    candidate_height: u64,
+) -> Result<CanonicalApplyTarget, String> {
+    #[cfg(test)]
+    TARGET_CONTEXT_CALLS.with(|calls| calls.set(calls.get() + 1));
+    #[rustfmt::skip]
+    let static_target = CanonicalApplyTarget { expected: cfg.expected_target };
+    if candidate_height == 0 || !stock_devnet_target_schedule(&cfg.network, cfg.chain_id) {
+        return Ok(static_target);
+    }
+    let store = block_store.ok_or(UNBOUND_DEVNET_TARGET_ERR)?;
+    let target = expected_target_for_candidate(store, parent_hash, candidate_height)
+        .map_err(target_schedule_error_message)?;
+    #[rustfmt::skip]
+    return Ok(CanonicalApplyTarget { expected: Some(target) });
+}
+
+const UNBOUND_DEVNET_TARGET_ERR: &str =
+    "target schedule context: stock devnet predicate holds but there is no block store";
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only seam counting `target_context_for_candidate` entries on THIS
+    /// thread, so a row can pin HOW MANY times a caller derives: one per
+    /// applied block, one per branch row per phase (preview and commit are
+    /// distinct, mirroring Go), never quadratic. Thread-local because the test
+    /// harness runs rows in parallel and derivation never leaves the calling
+    /// thread — the PV shadow lane runs under `catch_unwind`, not a worker.
+    static TARGET_CONTEXT_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_target_context_calls() {
+    TARGET_CONTEXT_CALLS.with(|calls| calls.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn target_context_calls() -> u64 {
+    TARGET_CONTEXT_CALLS.with(std::cell::Cell::get)
+}
+
+/// Render a `TargetScheduleError` as the node-layer error string. ONLY
+/// `ParentUnknown` maps onto `PARENT_BLOCK_NOT_FOUND_ERR` — the class
+/// `p2p_runtime::is_parent_not_found_err` matches byte-for-byte (Go's
+/// `targetScheduleReadError`); every other variant keeps its own distinct
+/// category and cause (Go's `errTarget*` set).
+pub(crate) fn target_schedule_error_message(err: TargetScheduleError) -> String {
+    match err {
+        TargetScheduleError::ParentUnknown => PARENT_BLOCK_NOT_FOUND_ERR.to_string(),
+        TargetScheduleError::HistoryMissing => "target schedule history unavailable".to_string(),
+        TargetScheduleError::HistoryCorrupt => "target schedule history corrupt".to_string(),
+        TargetScheduleError::HeightInvalid => "target schedule height invalid".to_string(),
+        TargetScheduleError::Retarget(cause) => format!("target schedule retarget failed: {cause}"),
+        TargetScheduleError::LocalIo(cause) => format!("target schedule local I/O: {cause}"),
+    }
+}
+
 impl SyncEngine {
+    /// The stock predicate on this engine's own config.
+    pub(crate) fn stock_devnet_target_schedule(&self) -> bool {
+        stock_devnet_target_schedule(&self.cfg.network, self.cfg.chain_id)
+    }
+
+    pub(crate) fn target_context_for_candidate(
+        &self,
+        parent: [u8; 32],
+        height: u64,
+    ) -> Result<CanonicalApplyTarget, String> {
+        let store = self.block_store.as_ref();
+        target_context_for_candidate(store, &self.cfg, parent, height)
+    }
+
+    /// THE canonical choke point for target-schedule context: every canonical
+    /// apply passes through it, so no live canonical path can reach
+    /// `connect_block_with_suite_context` with an unbound target. A supplied
+    /// context is used verbatim (caller acquired it ahead of its own MTP window,
+    /// or owns a branch-relative height the chainstate does not reflect yet),
+    /// keeping a boundary candidate to one `WINDOW_SIZE` walk instead of two;
+    /// otherwise the parent is the canonical tip and the height the chainstate's
+    /// next; at height 0 nothing is derived. Read-only, running before
+    /// `build_block_undo` — before any state-shaping work.
+    fn resolve_canonical_apply_target(
+        &self,
+        target: Option<CanonicalApplyTarget>,
+        next_height: u64,
+    ) -> Result<Option<[u8; 32]>, String> {
+        if let Some(target) = target {
+            return Ok(target.expected);
+        }
+        let has_tip = self.chain_state.has_tip;
+        let tip = self.chain_state.tip_hash;
+        let parent = if has_tip { tip } else { [0u8; 32] };
+        let resolved = self.target_context_for_candidate(parent, next_height)?;
+        Ok(resolved.expected)
+    }
+
     pub(crate) fn suite_context(&self) -> (Option<&dyn RotationProvider>, Option<&SuiteRegistry>) {
         match self.cfg.suite_context.as_ref() {
             Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
@@ -723,8 +869,29 @@ impl SyncEngine {
         block_bytes: &[u8],
         prev_timestamps: Option<&[u64]>,
     ) -> Result<ChainStateConnectSummary, String> {
+        self.apply_block_with_target(block_bytes, prev_timestamps, None)
+    }
+
+    /// `apply_block` with an OPTIONAL caller-resolved target context; `None`
+    /// resolves at the choke point (`resolve_canonical_apply_target`).
+    pub(crate) fn apply_block_with_target(
+        &mut self,
+        block_bytes: &[u8],
+        prev_timestamps: Option<&[u64]>,
+        target: Option<CanonicalApplyTarget>,
+    ) -> Result<ChainStateConnectSummary, String> {
         let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
         let block_hash_bytes = block_hash(&parsed.header_bytes).map_err(|e| e.to_string())?;
+        // Height and target context are acquired BEFORE the MTP window and
+        // before `build_block_undo` — ahead of the first state-shaping work.
+        // `checked_add` mirrors the `u64::MAX` guard in
+        // `prev_timestamps_for_next_block` / `ChainState::next_block_context`.
+        let mut next_height = 0u64;
+        if self.chain_state.has_tip {
+            let height = self.chain_state.height;
+            next_height = height.checked_add(1).ok_or("height overflow")?;
+        }
+        let expected_target = self.resolve_canonical_apply_target(target, next_height)?;
         let derived_prev_timestamps = if prev_timestamps.is_none() {
             self.prev_timestamps_for_next_block()?
         } else {
@@ -738,11 +905,6 @@ impl SyncEngine {
         let old_best_known_height = self.best_known_height;
 
         // Build undo record from the pre-mutation state.
-        let next_height = if self.chain_state.has_tip {
-            self.chain_state.height + 1
-        } else {
-            0
-        };
         let undo = build_block_undo(&self.chain_state, block_bytes, next_height)?;
 
         let suite_context = self.cfg.suite_context.clone();
@@ -753,7 +915,7 @@ impl SyncEngine {
             };
         let summary = match self.chain_state.connect_block_with_suite_context(
             block_bytes,
-            self.cfg.expected_target,
+            expected_target,
             prev_timestamps,
             self.cfg.chain_id,
             rotation,
@@ -765,7 +927,13 @@ impl SyncEngine {
                     self.pv_telemetry.record_block_validated();
                     let validate_start = Instant::now();
                     match run_pv_shadow_validation_guarded(|| {
-                        run_pv_shadow_validation(&snapshot, block_bytes, prev_timestamps, &self.cfg)
+                        run_pv_shadow_validation(
+                            &snapshot,
+                            block_bytes,
+                            prev_timestamps,
+                            expected_target,
+                            &self.cfg,
+                        )
                     }) {
                         Ok(Ok(_)) => {
                             self.record_pv_shadow_mismatch(format!(
@@ -810,7 +978,13 @@ impl SyncEngine {
             self.pv_telemetry.record_block_validated();
             let validate_start = Instant::now();
             match run_pv_shadow_validation_guarded(|| {
-                run_pv_shadow_validation(&snapshot, block_bytes, prev_timestamps, &self.cfg)
+                run_pv_shadow_validation(
+                    &snapshot,
+                    block_bytes,
+                    prev_timestamps,
+                    expected_target,
+                    &self.cfg,
+                )
             }) {
                 Ok(Ok(shadow_digest)) => {
                     let current_digest = self.chain_state.utxo_set_hash();
@@ -1151,10 +1325,18 @@ fn load_persisted_tip_timestamp(
     Ok(header.timestamp)
 }
 
+/// Shadow (parallel-validation) re-run of the sequential connect.
+///
+/// The shadow run MUST observe the same expected target as the sequential
+/// connect it shadows — the caller's already-resolved `expected_target`, never
+/// the static `SyncConfig.expected_target`. Feeding it a different target
+/// would make PV report a fabricated seq/par divergence at every retarget
+/// boundary.
 fn run_pv_shadow_validation(
     snapshot: &ChainState,
     block_bytes: &[u8],
     prev_timestamps: Option<&[u64]>,
+    expected_target: Option<[u8; 32]>,
     cfg: &SyncConfig,
 ) -> Result<[u8; 32], String> {
     let mut shadow_state = snapshot.clone();
@@ -1165,7 +1347,7 @@ fn run_pv_shadow_validation(
         };
     shadow_state.connect_block_with_suite_context(
         block_bytes,
-        cfg.expected_target,
+        expected_target,
         prev_timestamps,
         cfg.chain_id,
         rotation,
@@ -1179,6 +1361,116 @@ where
     F: FnOnce() -> Result<[u8; 32], String>,
 {
     catch_unwind(AssertUnwindSafe(run)).map_err(|_| "pv_shadow panic".to_string())
+}
+
+/// Test-only stock Phase-0 devnet fixture shared by every RUB-655 runtime row:
+/// a devnet-chain-id engine (so the predicate holds) whose store really does
+/// hold the PUBLISHED devnet genesis at canonical height 0, so MTP context,
+/// undo records and chain work behave as on a live chain.
+#[cfg(test)]
+pub(crate) fn stock_devnet_engine_for_test(
+    prefix: &str,
+    mutate: impl FnOnce(&mut SyncConfig),
+) -> (SyncEngine, std::path::PathBuf) {
+    let dir = crate::io_utils::unique_temp_path(prefix);
+    let store = BlockStore::open(crate::blockstore::block_store_path(&dir)).expect("open store");
+    let mut cfg = default_sync_config(None, devnet_genesis_chain_id(), None);
+    mutate(&mut cfg);
+    let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("engine");
+    let genesis = crate::genesis::devnet_genesis_block_bytes();
+    engine.apply_block(&genesis, None).expect("apply genesis");
+    (engine, dir)
+}
+
+/// Test-only: rewrite a block's target and search a nonce that genuinely
+/// satisfies PoW against it (shared builders pin nonce 0, which only works at
+/// POW_LIMIT-scale targets).
+#[cfg(test)]
+pub(crate) fn retarget_block_for_test(mut block: Vec<u8>, target: [u8; 32]) -> Vec<u8> {
+    // Header layout: .. | target @76..108 | nonce @108..116 |.
+    block[76..108].copy_from_slice(&target);
+    let mut nonce: u64 = 0;
+    loop {
+        block[108..116].copy_from_slice(&nonce.to_le_bytes());
+        if rubin_consensus::pow_check(&block[..116], target).is_ok() {
+            return block;
+        }
+        nonce += 1;
+    }
+}
+
+/// Test-only: the engine's next canonical candidate, mined against `target`.
+#[cfg(test)]
+pub(crate) fn next_candidate_block_for_test(
+    engine: &SyncEngine,
+    target: [u8; 32],
+    timestamp: u64,
+) -> Vec<u8> {
+    let block = crate::test_helpers::coinbase_only_block_with_gen(
+        engine.chain_state.height + 1,
+        engine.chain_state.already_generated,
+        engine.chain_state.tip_hash,
+        timestamp,
+    );
+    retarget_block_for_test(block, target)
+}
+
+/// Test-only: a stock devnet chain whose tip sits at `WINDOW_SIZE - 1`, so the
+/// next candidate lands exactly on a retarget boundary. Height 0 is the REAL
+/// published genesis applied through the normal path; heights `1..=WINDOW_SIZE-2`
+/// are synthetic HEADERS written straight into the header directory with a
+/// directly-written canonical index, mirroring the Go fixture — 10,078 real
+/// blocks would cost ~20k fsync'd atomic writes plus an O(n^2) index rewrite
+/// (~23 ms per `store_block`, measured), while the primitive reads only headers
+/// BY HASH and the MTP window only the last 11 canonical headers.
+///
+/// The TIP at `WINDOW_SIZE - 1` is then applied for real through the engine, so
+/// it owns block bytes and an undo record and a reorg forking below it can
+/// actually disconnect it — synthetic header-only entries cannot be
+/// disconnected. Timestamps are spaced at half the target interval so the
+/// retarget lands near `POW_LIMIT / 2` (inside the `/4` clamp) and the boundary
+/// candidate is bound to a target its parent does NOT carry — discriminating,
+/// not tautological. Returns the `0..WINDOW_SIZE-1` timestamps ascending.
+#[cfg(test)]
+pub(crate) fn boundary_chain_for_test(prefix: &str) -> (SyncEngine, std::path::PathBuf, Vec<u64>) {
+    use rubin_consensus::constants::{TARGET_BLOCK_INTERVAL, WINDOW_SIZE};
+    const SPACING: u64 = TARGET_BLOCK_INTERVAL / 2;
+
+    let (engine, dir) = stock_devnet_engine_for_test(prefix, |_| {});
+    let genesis_timestamp = engine.tip_timestamp;
+    let mut chain_state = engine.chain_state.clone();
+    let root = crate::blockstore::block_store_path(&dir);
+    drop(engine);
+
+    let headers = root.join("headers");
+    let mut times = vec![genesis_timestamp];
+    let mut canonical = vec![hex::encode(chain_state.tip_hash)];
+    let mut prev = chain_state.tip_hash;
+    for height in 1..WINDOW_SIZE - 1 {
+        let ts = genesis_timestamp + height * SPACING;
+        let mut raw = crate::test_helpers::build_block_bytes(prev, [0u8; 32], POW_LIMIT, ts, &[]);
+        raw.truncate(rubin_consensus::BLOCK_HEADER_BYTES);
+        let hash = block_hash(&raw).expect("synthetic header hash");
+        std::fs::write(headers.join(format!("{}.bin", hex::encode(hash))), &raw).expect("write");
+        times.push(ts);
+        canonical.push(hex::encode(hash));
+        prev = hash;
+    }
+    let index = serde_json::json!({ "version": 1, "canonical": canonical }).to_string();
+    std::fs::write(root.join("index.json"), index).expect("write canonical index");
+
+    chain_state.height = WINDOW_SIZE - 2;
+    chain_state.tip_hash = prev;
+    let store = BlockStore::open(&root).expect("reopen store");
+    let cfg = default_sync_config(None, devnet_genesis_chain_id(), None);
+    let mut engine = SyncEngine::new(chain_state, Some(store), cfg).expect("boundary engine");
+    let tip_timestamp = genesis_timestamp + (WINDOW_SIZE - 1) * SPACING;
+    let tip = next_candidate_block_for_test(&engine, POW_LIMIT, tip_timestamp);
+    engine
+        .apply_block_with_reorg(&tip, None)
+        .expect("apply the real boundary-chain tip");
+    times.push(tip_timestamp);
+    (engine, dir, times)
 }
 
 #[cfg(test)]
@@ -1205,8 +1497,10 @@ mod tests {
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::io_utils::unique_temp_path;
     use crate::sync::{
-        default_sync_config, run_pv_shadow_validation_guarded, SuiteContext, SyncEngine,
-        MAX_PV_SHADOW_MAX_SAMPLES,
+        boundary_chain_for_test, default_sync_config, next_candidate_block_for_test,
+        retarget_block_for_test, run_pv_shadow_validation_guarded, stock_devnet_engine_for_test,
+        target_context_for_candidate, CanonicalApplyTarget, SuiteContext, SyncEngine,
+        MAX_PV_SHADOW_MAX_SAMPLES, PARENT_BLOCK_NOT_FOUND_ERR, UNBOUND_DEVNET_TARGET_ERR,
     };
 
     /// Test-only rotation provider that counts how many times the
@@ -2010,5 +2304,245 @@ mod tests {
             body.contains(r#"rubin_pv_mode{mode="shadow\"} 1\n# HELP fake malicious\n# TYPE fake gauge\nfake 1"} 1"#),
             "rendered rubin_pv_mode line must carry the injected payload as an escaped label value, not as separate lines; body=\n{body}"
         );
+    }
+
+    // ---- RUB-655 target-schedule runtime rows ----
+
+    const TARGET_MISMATCH: &str = "BLOCK_ERR_TARGET_INVALID: target mismatch";
+
+    /// A target the schedule never yields here (the derived value is POW_LIMIT).
+    fn off_schedule_target() -> [u8; 32] {
+        let mut t = POW_LIMIT;
+        t[1] = 0x7f;
+        t
+    }
+
+    fn ctx(expected: Option<[u8; 32]>) -> Result<CanonicalApplyTarget, String> {
+        Ok(CanonicalApplyTarget { expected })
+    }
+
+    /// The published-genesis path derives NOTHING: no static `expected_target`
+    /// and an empty store, so a height-0 derivation would have failed on the
+    /// zero parent — bootstrap succeeding is the proof.
+    #[test]
+    fn target_schedule_runtime_published_genesis_unchanged() {
+        let (engine, dir) = stock_devnet_engine_for_test("rubin-ts-genesis", |_| {});
+        let store = engine.block_store_snapshot().expect("store");
+        assert_eq!(engine.cfg.expected_target, None);
+        assert_eq!(store.tip(), Ok(Some((0, engine.chain_state.tip_hash))));
+        assert!(engine.stock_devnet_target_schedule());
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Reject-then-valid at the SAME height: the mis-targeted candidate is
+    /// rejected by the DERIVED target and leaves storage and the canonical tip
+    /// untouched; the correctly targeted candidate is then accepted.
+    #[test]
+    fn target_schedule_runtime_direct_reject_then_valid_at_same_height() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-direct", |_| {});
+        let timestamp = engine.tip_timestamp + 1;
+        let stale = next_candidate_block_for_test(&engine, off_schedule_target(), timestamp);
+        let stale_hash = block_hash(&stale[..BLOCK_HEADER_BYTES]).expect("stale hash");
+        let err = engine.apply_block_with_reorg(&stale, None).unwrap_err();
+        assert_eq!(err, TARGET_MISMATCH);
+        assert_eq!(engine.has_block(stale_hash), Ok(false));
+        assert_eq!(engine.chain_state.height, 0);
+
+        let good = next_candidate_block_for_test(&engine, POW_LIMIT, timestamp);
+        let ok = engine.apply_block_with_reorg(&good, None).expect("derived");
+        assert_eq!(ok.summary.block_height, 1);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Public error PRIORITY on candidates violating several rules at once: PoW
+    /// range and PoW work both decide BEFORE target equality, and the DERIVED
+    /// target equality wins over prev-hash linkage (derivation resolves the
+    /// parent from the canonical tip, so a mis-linked candidate still gets a
+    /// target). Rows 0/1 keep the pinned nonce 0, so PoW fails.
+    #[test]
+    fn target_schedule_runtime_pow_precedes_target_precedes_linkage() {
+        const RANGE: &str = "BLOCK_ERR_TARGET_INVALID: target out of range";
+        const POW: &str = "BLOCK_ERR_POW_INVALID: pow invalid";
+        let mut tiny = [0u8; 32];
+        tiny[31] = 0x01;
+        #[rustfmt::skip]
+        let rows = [
+            (None::<[u8; 32]>, [0; 32], false, RANGE),
+            (None, tiny, false, POW),
+            (Some([0xab; 32]), off_schedule_target(), true, TARGET_MISMATCH),
+        ];
+        for (parent, target, search_nonce, want) in rows {
+            let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-prio", |_| {});
+            let prev = parent.unwrap_or(engine.chain_state.tip_hash);
+            let mut block =
+                crate::test_helpers::height_one_coinbase_only_block(prev, engine.tip_timestamp + 1);
+            block[76..108].copy_from_slice(&target);
+            if search_nonce {
+                block = retarget_block_for_test(block, target);
+            }
+            assert_eq!(engine.apply_block(&block, None).unwrap_err(), want);
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
+    }
+
+    /// The predicate GATES derivation: under the stock configuration the derived
+    /// target binds and rejects a candidate carrying the configured static
+    /// value; with a term broken the static value binds and that candidate is
+    /// accepted exactly as before.
+    #[test]
+    fn target_schedule_runtime_predicate_gates_derivation() {
+        let static_target = off_schedule_target();
+        for (network, derived) in [("devnet", true), ("regtest", false)] {
+            let (mut engine, dir) =
+                stock_devnet_engine_for_test("rubin-ts-gate", |cfg| cfg.network = network.into());
+            // Installed AFTER genesis: at height 0 the static value still binds,
+            // so a deliberately wrong one would reject genesis itself.
+            engine.cfg.expected_target = Some(static_target);
+            let block =
+                next_candidate_block_for_test(&engine, static_target, engine.tip_timestamp + 1);
+            let err = engine.apply_block_with_reorg(&block, None).err();
+            assert_eq!(
+                err.as_deref(),
+                derived.then_some(TARGET_MISMATCH),
+                "{network}"
+            );
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
+
+        // The predicate is CONFIG-ONLY: emptying the canonical index cannot
+        // flip it, so rule selection never depends on chain state.
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-term3", |_| {});
+        let store = engine.block_store.as_mut().expect("store");
+        store.truncate_canonical(0).expect("truncate canonical");
+        assert!(engine.stock_devnet_target_schedule());
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Once the predicate holds the derived target is the ONLY binding rule, so
+    /// a storeless caller is refused — with or without a configured static
+    /// target — instead of silently falling back to it.
+    #[test]
+    fn target_schedule_runtime_storeless_devnet_refuses_unbound_target() {
+        let devnet = default_sync_config(None, devnet_genesis_chain_id(), None);
+        let mut with_static = devnet.clone();
+        with_static.expected_target = Some(POW_LIMIT);
+        let mut regtest = devnet.clone();
+        regtest.network = "regtest".to_string();
+        for cfg in [&devnet, &with_static] {
+            let got = target_context_for_candidate(None, cfg, [0x01; 32], 1);
+            assert_eq!(got, Err(UNBOUND_DEVNET_TARGET_ERR.to_string()));
+        }
+        // Height 0 is the published-genesis path and is never refused; a
+        // non-devnet chain keeps its fail-open behaviour verbatim.
+        #[rustfmt::skip]
+        let rows = [(&devnet, 0, ctx(None)), (&with_static, 0, ctx(Some(POW_LIMIT))), (&regtest, 1, ctx(None))];
+        for (cfg, height, want) in rows {
+            let got = target_context_for_candidate(None, cfg, [0x01; 32], height);
+            assert_eq!(got, want);
+        }
+    }
+
+    /// The PV shadow lane must observe the SAME derived target as the sequential
+    /// connect. The static value is deliberately wrong: had the shadow run still
+    /// read `SyncConfig.expected_target` it would reject the block the
+    /// sequential run accepts and record a fabricated divergence.
+    #[test]
+    fn target_schedule_runtime_parallel_validation_sees_derived_target() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-pv", |cfg| {
+            cfg.parallel_validation_mode = "shadow".to_string();
+        });
+        engine.cfg.expected_target = Some(off_schedule_target());
+        assert!(engine.pv_shadow_active(), "fixture is not in IBD");
+        let before = engine.pv_telemetry_snapshot().blocks_validated;
+        let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        engine.apply_block_with_reorg(&block, None).expect("shadow");
+        assert_eq!(engine.pv_shadow_stats(), (0, Vec::new()));
+        let after = engine.pv_telemetry_snapshot().blocks_validated;
+        assert_eq!(after, before + 1, "pv shadow did not run at all");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The PV shadow-on-ERROR lane must bind the SAME derived target as the
+    /// failing sequential connect. The candidate carries the deliberately wrong
+    /// STATIC target, so the sequential run rejects it against the derived one;
+    /// had the shadow kept reading `SyncConfig.expected_target` it would have
+    /// ACCEPTED the block and recorded a fabricated seq_err/shadow_ok
+    /// divergence. Zero mismatches with the shadow proven to have run is the
+    /// evidence.
+    #[test]
+    fn target_schedule_runtime_parallel_validation_error_lane_sees_derived_target() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-pverr", |cfg| {
+            cfg.parallel_validation_mode = "shadow".to_string();
+        });
+        let wrong = off_schedule_target();
+        engine.cfg.expected_target = Some(wrong);
+        assert!(engine.pv_shadow_active(), "fixture is not in IBD");
+        let before = engine.pv_telemetry_snapshot().blocks_validated;
+        let block = next_candidate_block_for_test(&engine, wrong, engine.tip_timestamp + 1);
+        let err = engine.apply_block_with_reorg(&block, None).unwrap_err();
+        assert_eq!(err, TARGET_MISMATCH);
+        assert_eq!(engine.pv_shadow_stats(), (0, Vec::new()));
+        let after = engine.pv_telemetry_snapshot().blocks_validated;
+        assert_eq!(after, before + 1, "pv shadow error lane did not run at all");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Acquisition order is target-then-MTP. At height 1 the selected-parent
+    /// header and the whole MTP window are the SAME missing genesis header, so
+    /// the error class says which was acquired first — target wins, with the
+    /// orphan-routing class. At height 2 with that header still missing the
+    /// non-boundary derivation reads only the height-1 header and SUCCEEDS, so
+    /// the failure comes from the MTP window: the ordering is real, not an
+    /// artifact of one shared file.
+    #[test]
+    fn target_schedule_runtime_target_context_precedes_mtp() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-mtp", |_| {});
+        let genesis_header = crate::blockstore::block_store_path(&dir)
+            .join("headers")
+            .join(format!("{}.bin", hex::encode(engine.chain_state.tip_hash)));
+        let saved = std::fs::read(&genesis_header).expect("read genesis header");
+        let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        std::fs::remove_file(&genesis_header).expect("remove genesis header");
+        let err = engine.apply_block_with_reorg(&block, None).unwrap_err();
+        assert_eq!(err, PARENT_BLOCK_NOT_FOUND_ERR);
+
+        std::fs::write(&genesis_header, &saved).expect("restore genesis header");
+        assert!(engine.apply_block_with_reorg(&block, None).is_ok());
+        let next = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        std::fs::remove_file(&genesis_header).expect("remove genesis header again");
+        let err = engine.apply_block_with_reorg(&next, None).unwrap_err();
+        assert!(
+            err.contains("read header"),
+            "want the MTP read error, got: {err}"
+        );
+        assert_ne!(err, PARENT_BLOCK_NOT_FOUND_ERR);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The retarget BOUNDARY: the resolver returns the parent's own target one
+    /// height below it and the retargeted value ON it, and that derived value
+    /// binds the candidate (reject-then-valid at the boundary height).
+    #[test]
+    fn target_schedule_runtime_boundary_binds_retargeted_value() {
+        use rubin_consensus::constants::WINDOW_SIZE;
+        let (mut engine, dir, times) = boundary_chain_for_test("rubin-ts-boundary");
+        let parent = engine.chain_state.tip_hash;
+        let want = rubin_consensus::retarget_v1_clamped(POW_LIMIT, &times).expect("reference");
+        assert_ne!(want, POW_LIMIT, "boundary fixture is tautological");
+        for (height, expected) in [(WINDOW_SIZE - 1, POW_LIMIT), (WINDOW_SIZE, want)] {
+            let got = engine.target_context_for_candidate(parent, height);
+            assert_eq!(got, ctx(Some(expected)), "height {height}");
+        }
+
+        let timestamp = times.last().expect("window") + 1;
+        let stale = next_candidate_block_for_test(&engine, POW_LIMIT, timestamp);
+        let err = engine.apply_block_with_reorg(&stale, None).unwrap_err();
+        assert_eq!(err, TARGET_MISMATCH);
+        let good = next_candidate_block_for_test(&engine, want, timestamp);
+        let ok = engine
+            .apply_block_with_reorg(&good, None)
+            .expect("boundary");
+        assert_eq!(ok.summary.block_height, WINDOW_SIZE);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 }

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -12,6 +12,17 @@ use crate::txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxSource};
 
 pub(crate) const PARENT_BLOCK_NOT_FOUND_ERR: &str = "parent block not found";
 
+/// Caller-owned candidate height of branch row `index` above the common
+/// ancestor — Go's `commonAncestorHeight + 1 + i`, with the additions checked so
+/// a corrupt ancestor height cannot wrap into a LOWER candidate height (which
+/// would pick the wrong retarget boundary).
+fn branch_row_height(common_ancestor_height: u64, index: usize) -> Result<u64, String> {
+    let offset = u64::try_from(index).map_err(|_| "branch index overflow".to_string())?;
+    let base = common_ancestor_height.checked_add(1);
+    base.and_then(|first| first.checked_add(offset))
+        .ok_or_else(|| "height overflow".to_string())
+}
+
 /// Slide the MTP window forward by one block: prepend `new_ts` and keep at
 /// most 11 entries.  Mirrors Go `advancePrevTimestamps`.
 fn advance_prev_timestamps(prev: Option<&[u64]>, new_ts: u64) -> Vec<u64> {
@@ -320,6 +331,16 @@ impl SyncEngine {
             // invalid side-chain blocks never reach the blockstore (B.2 fix,
             // issue #1168).
             let candidate = branch.last().ok_or("empty side branch")?;
+            // RUB-655: target context BEFORE the MTP window, so its failure
+            // short-circuits without reading MTP state. Selected parent is the
+            // candidate's own prev_hash (already resolved against stored
+            // ancestry by `collect_branch_to_canonical`); the height is the
+            // caller-owned `candidate_height`, which the chainstate does not
+            // reflect for a non-canonical branch. Full validation still precedes
+            // `store_block`, so an invalid side-branch target reaches neither
+            // stored state nor fork choice.
+            let target_ctx =
+                self.target_context_for_candidate(candidate.prev_hash, candidate_height)?;
             let ts = self.side_branch_prev_timestamps(&branch, common_ancestor_height)?;
             // Thread the engine's rotation provider so an active CORE_SIMPLICITY
             // (0x0106) side-branch block is accepted, mirroring Go sync_reorg.go.
@@ -327,7 +348,7 @@ impl SyncEngine {
             validate_block_basic_with_context_at_height_and_rotation(
                 &candidate.block_bytes,
                 Some(candidate.prev_hash),
-                self.cfg.expected_target,
+                target_ctx.expected,
                 candidate_height,
                 ts.as_deref(),
                 rotation,
@@ -393,7 +414,18 @@ impl SyncEngine {
         }
 
         if parsed.header.prev_block_hash == self.chain_state.tip_hash {
-            let summary = self.apply_block(block_bytes, prev_timestamps)?;
+            // RUB-655 acquisition order is target-then-MTP: `apply_block`
+            // derives the canonical MTP window when the caller passes `None`, so
+            // the target context is acquired here, ahead of it. Selected parent
+            // is the canonical tip, height the caller-owned next height under
+            // the same `u64::MAX` guard `prev_timestamps_for_next_block` uses.
+            // The height-0 genesis branch above never reaches this arm.
+            let height = self.chain_state.height;
+            let next_height = height.checked_add(1).ok_or("height overflow")?;
+            let target =
+                self.target_context_for_candidate(self.chain_state.tip_hash, next_height)?;
+            let summary =
+                self.apply_block_with_target(block_bytes, prev_timestamps, Some(target))?;
             return Ok(Some(summary));
         }
 
@@ -462,10 +494,27 @@ impl SyncEngine {
         // Connect the preferred branch.  Pass None so apply_block derives
         // fresh timestamps from the (updated) canonical index for each block,
         // instead of reusing the stale caller value (B.9 fix, issue #1166).
+        //
+        // RUB-655: both context windows are re-derived per iteration — the
+        // canonical index moved when the previous row committed, and a branch can
+        // cross a retarget boundary (the target half of the same B.9 argument).
+        // Target context comes first, so its failure short-circuits before
+        // `apply_block_with_target` reads the MTP window.
         let mut last_summary = None;
         let mut canonical_applied_blocks: Vec<CanonicalAppliedBlock> = Vec::new();
-        for item in &branch {
-            match self.apply_block(&item.block_bytes, None) {
+        for (index, item) in branch.iter().enumerate() {
+            let target = match branch_row_height(common_ancestor_height, index)
+                .and_then(|height| self.target_context_for_candidate(item.prev_hash, height))
+            {
+                Ok(target) => target,
+                Err(err) => {
+                    return Err(Self::err_with_rollback(
+                        err,
+                        self.rollback_apply_block(rollback),
+                    ));
+                }
+            };
+            match self.apply_block_with_target(&item.block_bytes, None, Some(target)) {
                 Ok(mut summary) => {
                     // branch is in ascending canonical (height) order, so this
                     // accumulates every newly-canonical block in canonical order.
@@ -528,10 +577,23 @@ impl SyncEngine {
         // re-deriving from the store each iteration (B.9 fix, issue #1166).
         let mut sliding_ts = self.prev_timestamps_for_height(common_ancestor_height + 1)?;
         let (rotation, registry) = self.suite_context();
-        for item in branch {
+        for (index, item) in branch.iter().enumerate() {
+            // RUB-655 per-row derivation: a branch can cross a retarget
+            // boundary. Unlike the MTP window this needs no sliding workaround —
+            // the derivation reads headers BY HASH, never the canonical index,
+            // so it is safe during preview, and every ancestor it needs is
+            // already stored (`collect_branch_to_canonical` fetched
+            // branch[0..n-2]; the common ancestor is canonical). This preview is
+            // the only pre-mutation slot — it runs before
+            // `disconnect_canonical_to_ancestor`, so every branch row is
+            // target-validated before any disconnect.
+            let target_ctx = self.target_context_for_candidate(
+                item.prev_hash,
+                branch_row_height(common_ancestor_height, index)?,
+            )?;
             preview_state.connect_block_with_suite_context(
                 &item.block_bytes,
-                self.cfg.expected_target,
+                target_ctx.expected,
                 sliding_ts.as_deref(),
                 self.cfg.chain_id,
                 rotation,
@@ -718,7 +780,10 @@ mod tests {
     use crate::chainstate::{chain_state_path, ChainState};
     use crate::devnet_genesis_chain_id;
     use crate::io_utils::unique_temp_path;
-    use crate::sync::{default_sync_config, SuiteContext, SyncEngine};
+    use crate::sync::{
+        boundary_chain_for_test, default_sync_config, next_candidate_block_for_test,
+        retarget_block_for_test, stock_devnet_engine_for_test, SuiteContext, SyncEngine,
+    };
     use crate::test_helpers::{
         block_with_txs, coinbase_only_block, coinbase_only_block_with_gen, genesis_info,
         height_one_coinbase_only_block, signed_conflicting_p2pk_state_and_txs,
@@ -2069,5 +2134,273 @@ mod tests {
             "duplicate failed requeue must not replace the existing Local entry as Reorg"
         );
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    // ---- RUB-655 target-schedule runtime rows ----
+
+    const TARGET_MISMATCH: &str = "BLOCK_ERR_TARGET_INVALID: target mismatch";
+
+    /// A competing height-1 branch declaring a quarter of `POW_LIMIT` carries
+    /// MORE chain work than the two canonical blocks, so fork choice SELECTS it
+    /// and the reorg PREVIEW must reject it — before any disconnect, store write
+    /// or contribution to chain work.
+    #[test]
+    fn target_schedule_runtime_side_branch_rejected_before_storage_and_fork_choice() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-side", |_| {});
+        let genesis_hash = engine.chain_state.tip_hash;
+        let generated = engine.chain_state.already_generated;
+        for _ in 0..2 {
+            let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+            assert!(engine.apply_block_with_reorg(&block, None).is_ok());
+        }
+        let before_tip = engine.chain_state.tip_hash;
+        let before_height = engine.chain_state.height;
+        let store = engine.block_store_snapshot().expect("store");
+        let before_len = store.canonical_len();
+
+        let mut heavier = POW_LIMIT;
+        heavier[0] = 0x3f;
+        let ts = engine.tip_timestamp + 9;
+        let base = coinbase_only_block_with_gen(1, generated, genesis_hash, ts);
+        let side = retarget_block_for_test(base, heavier);
+        let side_hash = block_hash(&side[..BLOCK_HEADER_BYTES]).expect("side hash");
+
+        // Evidence, not argument, that the REORG PREVIEW is the rejecting site:
+        // fork choice really does select this branch, and the preview — the only
+        // pre-mutation slot, running before `disconnect_canonical_to_ancestor` —
+        // rejects it, isolated from the commit loop.
+        let (branch, ancestor, _) = engine
+            .collect_branch_to_canonical(side_hash, &side)
+            .expect("collect branch");
+        let switch = engine.should_switch_to_branch(&branch, ancestor);
+        assert_eq!(switch, Ok((true, 1)));
+        let preview = engine.prepare_preferred_branch(&branch, 0).unwrap_err();
+        assert_eq!(preview, TARGET_MISMATCH);
+
+        let err = engine.apply_block_with_reorg(&side, None).unwrap_err();
+        assert_eq!(err, TARGET_MISMATCH);
+        assert_eq!(engine.has_block(side_hash), Ok(false));
+        assert_eq!(engine.chain_state.tip_hash, before_tip);
+        assert_eq!(engine.chain_state.height, before_height);
+        let store = engine.block_store_snapshot().expect("store");
+        assert_eq!(store.canonical_len(), before_len);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The reorg PREVIEW and the reorg COMMIT loop both derive per row: an
+    /// equal-work competing height-1 branch with the smaller tip wins fork
+    /// choice, so the preview validates it and `apply_preferred_branch`
+    /// disconnects and re-applies it through `apply_block_with_target` with a
+    /// freshly derived context. The wrong static `expected_target` installed
+    /// after genesis makes the row discriminating: if ANY of those sites read
+    /// the config value instead, both applies would be rejected.
+    #[test]
+    fn target_schedule_runtime_reorg_commit_derives_per_row() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-commit", |_| {});
+        let mut wrong = POW_LIMIT;
+        wrong[1] = 0x7f;
+        engine.cfg.expected_target = Some(wrong);
+        let (higher, higher_hash, lower, lower_hash) = timestamp_ordered_equal_work_height_one_pair(
+            engine.chain_state.tip_hash,
+            engine.tip_timestamp,
+            std::cmp::Ordering::Less,
+        );
+        assert!(engine.apply_block_with_reorg(&higher, None).is_ok());
+        assert_eq!(engine.chain_state.tip_hash, higher_hash);
+        let summary = engine.apply_block_with_reorg(&lower, None).expect("reorg");
+        assert_eq!(summary.summary.block_height, 1);
+        assert_eq!(engine.chain_state.tip_hash, lower_hash);
+        assert_eq!(engine.reorg_count(), 1);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Two missing-parent shapes, both ending in the class
+    /// `p2p_runtime::is_parent_not_found_err` routes to orphan retention —
+    /// byte-exact equality here IS the routing claim, since that predicate is a
+    /// string comparison against this constant. Row 0 is pre-existing; row 1 is
+    /// the RUB-655 reclassification: target derivation now precedes the MTP
+    /// window on the direct-tip path, so a missing selected-parent header
+    /// surfaces as the unknown-IMMEDIATE-parent class instead of the raw storage
+    /// read error the later MTP read produced — the Go outcome (orphan, not an
+    /// apply-error record). Nothing is stored and the tip does not move.
+    #[test]
+    fn target_schedule_runtime_missing_parent_stays_parent_not_found() {
+        for remove_tip_header in [false, true] {
+            let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-orphan", |_| {});
+            let ts = engine.tip_timestamp + 1;
+            let block = if remove_tip_header {
+                let tip = hex::encode(engine.chain_state.tip_hash);
+                let headers = block_store_path(&dir).join("headers");
+                let candidate = next_candidate_block_for_test(&engine, POW_LIMIT, ts);
+                std::fs::remove_file(headers.join(format!("{tip}.bin"))).expect("rm header");
+                candidate
+            } else {
+                coinbase_only_block(1, [0xab; 32], ts)
+            };
+            let hash = block_hash(&block[..BLOCK_HEADER_BYTES]).expect("candidate hash");
+            let err = engine.apply_block_with_reorg(&block, None).unwrap_err();
+            assert_eq!(err, PARENT_BLOCK_NOT_FOUND_ERR, "{remove_tip_header}");
+            assert_eq!(engine.has_block(hash), Ok(false));
+            assert_eq!(engine.chain_state.height, 0);
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
+    }
+
+    /// The store-but-NOT-switch path: fork choice DECLINES this lighter
+    /// side branch, so `store_side_block_and_summary` is the rejecting site. A
+    /// wrong declared target must be rejected BEFORE `store_block`, leaving no
+    /// artifact, no canonical-index change and no chain-work contribution.
+    #[test]
+    fn target_schedule_runtime_side_branch_rejected_before_store_without_switch() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-noswitch", |_| {});
+        let genesis_hash = engine.chain_state.tip_hash;
+        let generated = engine.chain_state.already_generated;
+        for _ in 0..2 {
+            let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+            assert!(engine.apply_block_with_reorg(&block, None).is_ok());
+        }
+        let before_len = engine
+            .block_store_snapshot()
+            .expect("store")
+            .canonical_len();
+
+        let mut wrong = POW_LIMIT;
+        wrong[1] = 0x7f;
+        let base =
+            coinbase_only_block_with_gen(1, generated, genesis_hash, engine.tip_timestamp + 9);
+        let side = retarget_block_for_test(base, wrong);
+        let side_hash = block_hash(&side[..BLOCK_HEADER_BYTES]).expect("side hash");
+
+        // One block cannot outweigh the two canonical ones, so fork choice
+        // declines and the store path — not the reorg preview — must reject.
+        let (branch, ancestor, _) = engine
+            .collect_branch_to_canonical(side_hash, &side)
+            .expect("collect branch");
+        let switch = engine.should_switch_to_branch(&branch, ancestor);
+        assert_eq!(switch, Ok((false, 1)));
+
+        let err = engine.apply_block_with_reorg(&side, None).unwrap_err();
+        assert_eq!(err, TARGET_MISMATCH);
+        let store = engine.block_store_snapshot().expect("store");
+        assert!(
+            !store.has_block(side_hash),
+            "rejected side block was stored"
+        );
+        assert_eq!(store.canonical_len(), before_len);
+        assert!(
+            store.chain_work(side_hash).is_err(),
+            "contributed chain work"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// A reorg branch CROSSING a retarget boundary — the only path where the
+    /// boundary walk starts inside BRANCH ancestry instead of the canonical
+    /// index. The branch forks at `WINDOW_SIZE - 2`, so its second row sits on
+    /// the boundary and its `WINDOW_SIZE`-header walk begins at the first
+    /// branch row. The canonical-ancestry retarget value is therefore the WRONG
+    /// answer here, and the row pins that: mis-targeting with it is rejected,
+    /// and only the branch-derived value is accepted.
+    #[test]
+    fn target_schedule_runtime_reorg_across_retarget_boundary_uses_branch_ancestry() {
+        use rubin_consensus::constants::WINDOW_SIZE;
+        let (mut engine, dir, times) = boundary_chain_for_test("rubin-ts-xboundary");
+        let window = usize::try_from(WINDOW_SIZE).expect("window fits usize");
+        let canonical_tip = engine.chain_state.tip_hash;
+        let canonical_want =
+            rubin_consensus::retarget_v1_clamped(POW_LIMIT, &times).expect("canonical retarget");
+        let store = engine.block_store_snapshot().expect("store");
+        let fork_parent = store
+            .canonical_hash(WINDOW_SIZE - 2)
+            .expect("read")
+            .expect("fork parent");
+        let generated = engine.chain_state.already_generated;
+
+        // Row 0 competes with the real canonical tip at equal work, so its
+        // timestamp is chosen to keep its hash ABOVE that tip's — otherwise it
+        // would win fork choice alone and never form a two-row branch.
+        let (row0, row0_ts) = (1u64..1024)
+            .find_map(|delta| {
+                let ts = times[window - 2] + delta;
+                let raw = coinbase_only_block_with_gen(WINDOW_SIZE - 1, generated, fork_parent, ts);
+                let hash = block_hash(&raw[..BLOCK_HEADER_BYTES]).expect("row0 hash");
+                (hash > canonical_tip).then_some((raw, ts))
+            })
+            .expect("no row0 timestamp keeps the branch from winning alone");
+        let row0_hash = block_hash(&row0[..BLOCK_HEADER_BYTES]).expect("row0 hash");
+        assert!(engine.apply_block_with_reorg(&row0, None).is_ok());
+        assert_eq!(engine.chain_state.tip_hash, canonical_tip, "row0 switched");
+
+        // The boundary target row 1 must carry: same window, but ending at
+        // row0's timestamp instead of the canonical tip's.
+        let mut branch_times = times[..window - 1].to_vec();
+        branch_times.push(row0_ts);
+        let branch_want = rubin_consensus::retarget_v1_clamped(POW_LIMIT, &branch_times)
+            .expect("branch retarget");
+        assert_ne!(
+            branch_want, canonical_want,
+            "fixture cannot tell the two apart"
+        );
+
+        let row1 = |target| {
+            let raw = coinbase_only_block_with_gen(WINDOW_SIZE, generated, row0_hash, row0_ts + 1);
+            retarget_block_for_test(raw, target)
+        };
+        let err = engine
+            .apply_block_with_reorg(&row1(canonical_want), None)
+            .unwrap_err();
+        assert_eq!(
+            err, TARGET_MISMATCH,
+            "canonical ancestry must not bind here"
+        );
+        let good = row1(branch_want);
+        let summary = engine
+            .apply_block_with_reorg(&good, None)
+            .expect("branch-derived boundary target");
+        assert_eq!(summary.summary.block_height, WINDOW_SIZE);
+        assert_eq!(engine.reorg_count(), 1);
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// HOW MANY times a caller derives: exactly one per applied block, and one
+    /// per branch row per phase — the reorg preview and the commit loop are
+    /// distinct phases (Go derives in both), so an N-row branch costs 2N, never
+    /// 3N and never N². The commit loop passing its resolved context into
+    /// `apply_block_with_target` is what keeps the second derivation from
+    /// happening inside the apply. Read counts INSIDE the primitive are its own
+    /// merged tests' business and are not re-pinned here.
+    #[test]
+    fn target_schedule_runtime_derivation_is_invoked_once_per_row() {
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-ts-count", |_| {});
+        let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        crate::sync::reset_target_context_calls();
+        assert!(engine.apply_block_with_reorg(&block, None).is_ok());
+        assert_eq!(crate::sync::target_context_calls(), 1, "direct apply");
+
+        // Equal-work single-row reorg: 1 preview + 1 commit.
+        let (mut engine, reorg_dir) = stock_devnet_engine_for_test("rubin-ts-count2", |_| {});
+        let (higher, _, lower, _) = timestamp_ordered_equal_work_height_one_pair(
+            engine.chain_state.tip_hash,
+            engine.tip_timestamp,
+            std::cmp::Ordering::Less,
+        );
+        assert!(engine.apply_block_with_reorg(&higher, None).is_ok());
+        crate::sync::reset_target_context_calls();
+        assert!(engine.apply_block_with_reorg(&lower, None).is_ok());
+        assert_eq!(
+            crate::sync::target_context_calls(),
+            2,
+            "1 preview + 1 commit"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+        std::fs::remove_dir_all(&reorg_dir).expect("cleanup");
+    }
+
+    #[test]
+    fn target_schedule_runtime_branch_row_height_is_checked() {
+        let overflow = Err("height overflow".to_string());
+        assert_eq!(branch_row_height(7, 3), Ok(11));
+        assert_eq!(branch_row_height(u64::MAX, 0), overflow);
+        assert_eq!(branch_row_height(u64::MAX - 1, 1), overflow);
     }
 }


### PR DESCRIPTION
## Issue
- Linear: RUB-655
- GitHub Issue mirror (non-authoritative): #2286

Refs: Q-TARGET-SCHEDULE-ATOMIC-INTEGRATION-01

## Summary
On a stock Phase-0 devnet chain the expected block target is now derived from the caller-authoritative selected parent and the caller-owned candidate height on every live validation path in both clients, replacing a static configured field that is nil/None in production. Derivation calls the already-merged private primitives from #2280 and #2281, whose signatures are unchanged.

The stock predicate is two immutable startup terms — normalized network is `devnet` and the chain id equals the published devnet genesis chain id — evaluated by one accessor that every layer of each client calls, reading no chain state. Derivation precedes every mutation: before rollback capture on the canonical apply path, before `StoreBlock` on a stored side branch, before the disconnect in the reorg preview, per row in the reorg commit loop, per block in startup replay, and before both header construction and nonce search in the miner. Under the predicate the compact header precheck skips only the static optional target equality, keeping parse, target range, proof of work and peer disposition, so the reconstructed block reaches the authoritative apply path. A stock devnet identity with no block store is refused rather than falling back to the static target, and a relayed block whose parent is missing is proof-of-work gated before orphan retention.

## Invariant
Every exact stock Phase-0 devnet candidate is checked against the target derived from the caller-authoritative selected parent and caller-owned candidate height on every live Go and Rust path before storage or acceptance, and both clients acquire that behavior in one PR.

## Scope
- Changed files: 15
- Surfaces: clients/go, clients/rust
- Non-scope: no primitive signature edit; no SyncConfig/MinerConfig/CLI/config/BlockStore schema change; no consensus formula, constant, genesis, specification, conformance fixture, formal or generated artifact change; no mainnet, testnet or custom-network work
- Consensus rules unchanged: NO — a stock Phase-0 devnet candidate whose target does not follow the derived schedule is now rejected with the existing `BLOCK_ERR_TARGET_INVALID: target mismatch`; previously the static field was nil in production and that equality was never evaluated. Public error ordering is unchanged.
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `go test -race -timeout=20m -shuffle=on -count=1 ./...` — PASS; `cargo nextest run --workspace --all-targets` — PASS; `cargo test --workspace --doc` — PASS; `go test ./...` — PASS; `go vet ./...` — PASS; `cargo clippy --workspace --all-targets -- -D warnings` — PASS; `cargo fmt --check` — PASS; `python3 conformance/runner/run_cv_bundle.py` — PASS (525 vectors); `python3 tools/gen_conformance_matrix.py --check` — PASS

## Follow-ups / Waivers
- None
