### PR TITLE
RUB-881: mirror bounded canonical-applied summaries and verified branch loads

### DIFF
--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -365,6 +365,28 @@ impl BlockStore {
         )))
     }
 
+    /// Kind-preserving sibling of [`BlockStore::get_block_by_hash`]: it returns
+    /// the raw [`std::io::Error`], so a caller can tell a genuinely absent block
+    /// ([`std::io::ErrorKind::NotFound`]) apart from every other read failure
+    /// (permissions, a directory planted where a file belongs, EIO).
+    ///
+    /// `get_block_by_hash` formats that error into a `String`, which erases the
+    /// kind; re-deriving the distinction by matching on the rendered text is
+    /// OS-dependent and must not be used. The side-branch walk
+    /// (`sync_reorg::load_verified_branch_ancestor`) needs the distinction
+    /// because only `NotFound` may keep the parent-not-found / orphan-retention
+    /// outcome — every other read failure is local store corruption. Go reaches
+    /// the same split with `errors.Is(err, os.ErrNotExist)` in
+    /// `clients/go/node/sync_reorg.go`.
+    pub fn read_block_file_by_hash(
+        &self,
+        block_hash_bytes: [u8; 32],
+    ) -> Result<Vec<u8>, std::io::Error> {
+        // E.10: see `get_block_by_hash` for the safe-leaf-name rationale.
+        let name = format!("{}.bin", hex::encode(block_hash_bytes));
+        read_file_from_dir(&self.blocks_dir, &name)
+    }
+
     pub fn get_block_by_hash(&self, block_hash_bytes: [u8; 32]) -> Result<Vec<u8>, String> {
         // E.10: route through `read_file_from_dir` so the leaf name is
         // validated against the same traversal / absolute-path / empty-name
@@ -373,7 +395,7 @@ impl BlockStore {
         // guard removes the entire class of "leaf name from on-disk
         // index drift becomes a traversal" without runtime cost.
         let name = format!("{}.bin", hex::encode(block_hash_bytes));
-        read_file_from_dir(&self.blocks_dir, &name)
+        self.read_block_file_by_hash(block_hash_bytes)
             .map_err(|e| format!("read block {}: {e}", self.blocks_dir.join(&name).display()))
     }
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -28,10 +28,21 @@ pub struct ChainState {
     pub utxos: HashMap<Outpoint, UtxoEntry>,
 }
 
+/// Identifies one block a canonical apply committed, plus the complete DA-set
+/// IDs that block carries. It deliberately holds NO raw block bytes: a reorg
+/// summary accumulates one record per newly-canonical block, and a block is up
+/// to `MAX_BLOCK_BYTES`, so retaining bytes made summary size grow with reorg
+/// depth times block size. `complete_da_ids` is bounded by
+/// `MAX_DA_BATCHES_PER_BLOCK` fixed-width IDs, which is all any consumer ever
+/// needed from the bytes.
+///
+/// The no-bytes bound is on the SHAPE, not on a field name: no byte-slice field
+/// of any name may be reintroduced here. Go twin:
+/// `clients/go/node/chainstate.go` `CanonicalAppliedBlock`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CanonicalAppliedBlock {
     pub hash: [u8; 32],
-    pub block_bytes: Vec<u8>,
+    pub complete_da_ids: Vec<[u8; 32]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -42,6 +53,15 @@ pub struct ChainStateConnectSummary {
     pub already_generated: u64,
     pub already_generated_n1: u64,
     pub utxo_count: u64,
+    /// Populated ONLY by the `SyncEngine` canonical-apply path
+    /// (`SyncEngine::apply_block_with_target`), in canonical order: a direct
+    /// apply reports the single connected block, a reorg reports every
+    /// newly-canonical branch block, and a stored-but-not-switched side branch
+    /// reports none. The `ChainState` connect entry points leave it EMPTY —
+    /// connecting to an in-memory state is not by itself a canonical-application
+    /// event, and both the reorg preview (`prepare_preferred_branch`) and the
+    /// startup replay (`chainstate_recovery`) connect blocks that must never be
+    /// reported. Go twin: `ChainStateConnectSummary.CanonicalAppliedBlocks`.
     pub canonical_applied_blocks: Vec<CanonicalAppliedBlock>,
 }
 
@@ -176,10 +196,12 @@ impl ChainState {
             already_generated_n1: u64::try_from(connect_summary.already_generated_n1)
                 .map_err(|_| "already_generated_n1 overflow".to_string())?,
             utxo_count: connect_summary.utxo_count,
-            canonical_applied_blocks: vec![CanonicalAppliedBlock {
-                hash: tip_hash,
-                block_bytes: block_bytes.to_vec(),
-            }],
+            // Left EMPTY on purpose: connecting to an in-memory chain state is
+            // not a canonical-application event. Only the SyncEngine
+            // canonical-apply site mints these records, so the reorg preview,
+            // the startup replay, and side-branch connects — all of which land
+            // here — structurally cannot report a canonical-applied block.
+            canonical_applied_blocks: Vec::new(),
         })
     }
 
@@ -877,6 +899,14 @@ mod tests {
         let summary = st
             .connect_block(&block1, Some(POW_LIMIT), None, [0u8; 32])
             .expect("connect height 1");
+        // The connect entry point mints NO canonical-applied record: connecting
+        // to an in-memory chain state is not a canonical-application event, and
+        // the reorg preview and startup replay both land here. Only the
+        // SyncEngine canonical-apply site populates this field.
+        assert!(
+            summary.canonical_applied_blocks.is_empty(),
+            "the connect layer must not report canonical-applied blocks"
+        );
         assert_eq!(summary.block_height, 1);
         assert_eq!(summary.already_generated, 0);
         assert_eq!(summary.already_generated_n1, block_subsidy(1, 0));

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 
-use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_BATCHES_PER_BLOCK, MAX_DA_CHUNK_COUNT};
 use rubin_consensus::constants::{COV_TYPE_DA_COMMIT, TX_WIRE_VERSION};
-use rubin_consensus::{parse_block_bytes, parse_tx, Tx, TxError};
+use rubin_consensus::{parse_block_bytes, parse_tx, ParsedBlock, Tx};
 use sha3::{Digest, Sha3_256};
 
 pub const DA_ORPHAN_POOL_BYTES: u64 = 64 << 20;
@@ -1207,25 +1207,65 @@ fn sha3_256(input: &[u8]) -> [u8; 32] {
     Sha3_256::digest(input).into()
 }
 
-/// Deterministically extract the `da_id` of every COMPLETE DA set carried by an
-/// already-accepted block, in ascending `da_id` order. A set is complete when
-/// the block contains exactly one DA commit for the `da_id` whose `chunk_count`
-/// is in `(0, MAX_DA_CHUNK_COUNT]`, plus a DA chunk tx for every index
-/// `0..chunk_count`. Read-only: it parses block bytes and never mutates relay
-/// state. Mirrors merged Go `extractAcceptedBlockDAIDs` (RUB-429).
-pub(crate) fn extract_accepted_block_da_ids(block_bytes: &[u8]) -> Result<Vec<[u8; 32]>, TxError> {
-    let parsed = parse_block_bytes(block_bytes)?;
+/// Returns the `da_id` of every COMPLETE DA set carried by an ALREADY-PARSED
+/// block, in ascending raw-byte order.
+///
+/// This is the single implementation of block-level complete-DA-set selection in
+/// the Rust tree; the bytes entry [`consume_accepted_block_da_sets`] parses
+/// untrusted bytes and delegates here, so the bytes-entry and the parsed-entry
+/// (canonical-apply) paths cannot select different DA sets for the same block.
+///
+/// A set counts as complete exactly when the block carries one `tx_kind=0x01`
+/// commit for that `da_id` (a second commit disqualifies it), the commit's
+/// `chunk_count` is in `1..=MAX_DA_CHUNK_COUNT`, and the block carries a
+/// `tx_kind=0x02` chunk for every index `0..chunk_count-1`. This mirrors the
+/// completeness rule consensus `connect_block_*` already enforces; it is
+/// repeated here because the caller may hand over a block that has NOT been
+/// validated.
+///
+/// Contract:
+/// - Output is ordered by raw ID bytes, never by hash-map iteration order, so it
+///   is deterministic for a given block.
+/// - At most `MAX_DA_BATCHES_PER_BLOCK` IDs are returned; a block that would
+///   yield more is reported as an ERROR rather than truncated. A block that
+///   passed consensus validation cannot reach that branch.
+/// - `parsed` is read-only; nothing here mutates the block or relay state.
+/// - A DA transaction missing its DA core is skipped, never a panic, since
+///   callers may pass a block that was assembled rather than parsed.
+///
+/// Go twin: `clients/go/node/chainstate.go`
+/// `CompleteDASetIDsFromParsedBlock` (RUB-880).
+pub(crate) fn complete_da_set_ids_from_parsed_block(
+    parsed: &ParsedBlock,
+) -> Result<Vec<[u8; 32]>, String> {
     let mut sets: BTreeMap<[u8; 32], AcceptedBlockDaSet> = BTreeMap::new();
     for tx in &parsed.txs {
         record_accepted_block_da_tx(&mut sets, tx);
     }
-    // BTreeMap iterates by ascending key, so the surviving da_ids are returned
-    // sorted and unique (one entry per da_id) without an explicit sort.
-    Ok(sets
+    // `BTreeMap<[u8; 32], _>` iterates in ascending raw-key order, so the
+    // surviving da_ids come out byte-sorted and unique (one entry per da_id).
+    // Ascending byte order is a PINNED contract of this function — Go sorts an
+    // unordered map with `bytes.Compare` to reach the same result — not an
+    // incidental property of the container: a container swap must preserve it,
+    // and a hash map here would make the output nondeterministic.
+    let ids: Vec<[u8; 32]> = sets
         .into_iter()
         .filter(|(_, set)| set.complete())
         .map(|(da_id, _)| da_id)
-        .collect())
+        .collect();
+    // Counted AFTER completeness filtering, exactly like Go: a block carrying
+    // MAX_DA_BATCHES_PER_BLOCK commits of which one set is incomplete yields one
+    // fewer ID and is accepted. Over the cap is an error, never a truncated
+    // list — a truncated list would silently leave the dropped sets' relay
+    // records pinned forever.
+    if ids.len() > MAX_DA_BATCHES_PER_BLOCK as usize {
+        return Err(format!(
+            "complete DA sets in block: {} exceeds MAX_DA_BATCHES_PER_BLOCK={}",
+            ids.len(),
+            MAX_DA_BATCHES_PER_BLOCK
+        ));
+    }
+    Ok(ids)
 }
 
 fn record_accepted_block_da_tx(sets: &mut BTreeMap<[u8; 32], AcceptedBlockDaSet>, tx: &Tx) {
@@ -1271,22 +1311,35 @@ impl AcceptedBlockDaSet {
     }
 }
 
-/// Consume every COMPLETE DA set included in an already-applied block: extract
-/// the block's complete DA ids (RUB-434) and consume each from the locked relay
-/// (RUB-433), aborting on the first error (fail-closed). Used by the Rust
-/// /mine_next consume wiring (RUB-435) — the mirror of Go
-/// `ConsumeAcceptedBlockDASets`.
+/// Consume every COMPLETE DA set carried by a block supplied as RAW BYTES. This
+/// is the entry point for callers that hold bytes and no canonical-apply summary
+/// — today the `/mine_next` RPC accepted-block hook (RUB-435). It parses, then
+/// delegates to the same [`complete_da_set_ids_from_parsed_block`] core the
+/// canonical-apply path uses, so the two entry points cannot select different DA
+/// sets for the same block. Mirror of Go `ConsumeAcceptedBlockDASets`.
 pub fn consume_accepted_block_da_sets(
     da_relay: &Mutex<DaRelayState>,
     block_bytes: &[u8],
 ) -> Result<(), String> {
-    let da_ids = extract_accepted_block_da_ids(block_bytes).map_err(|err| err.to_string())?;
+    let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
+    let da_ids = complete_da_set_ids_from_parsed_block(&parsed)?;
+    consume_complete_da_set_ids(da_relay, &da_ids)
+}
+
+/// Releases relay accounting for each ID in order and stops at the FIRST
+/// failure (fail-closed). Both consume entry points route through here, so the
+/// per-ID effect is identical whichever entry produced the IDs. Mirror of Go
+/// `consumeCompleteDASetIDs`.
+fn consume_complete_da_set_ids(
+    da_relay: &Mutex<DaRelayState>,
+    da_ids: &[[u8; 32]],
+) -> Result<(), String> {
     let mut relay = da_relay
         .lock()
         .map_err(|_| "DA relay lock poisoned during accepted-block DA consume".to_string())?;
     for da_id in da_ids {
         relay
-            .consume_complete_set(da_id)
+            .consume_complete_set(*da_id)
             .map_err(|err| format!("consume accepted DA set: {err:?}"))?;
     }
     Ok(())
@@ -1301,13 +1354,18 @@ pub fn consume_accepted_block_da_sets(
 /// cleanup for the remaining canonical blocks. Used by the Rust P2P
 /// accepted-block consume hook (RUB-437) — the mirror of Go
 /// `consumeCanonicalAppliedDASets`.
+///
+/// It consumes the IDs the apply path already extracted: the summary carries no
+/// block bytes and nothing here re-parses a block. The report is taken by
+/// immutable borrow, so a consume failure cannot rewrite what the apply already
+/// committed.
 pub fn consume_canonical_applied_da_sets(
     da_relay: &Mutex<DaRelayState>,
     canonical_applied_blocks: &[crate::chainstate::CanonicalAppliedBlock],
 ) -> Result<(), String> {
     let mut first_err: Option<String> = None;
     for block in canonical_applied_blocks {
-        if let Err(err) = consume_accepted_block_da_sets(da_relay, &block.block_bytes) {
+        if let Err(err) = consume_complete_da_set_ids(da_relay, &block.complete_da_ids) {
             first_err.get_or_insert_with(|| {
                 format!(
                     "consume canonical-applied DA sets for block {}: {err}",
@@ -1917,35 +1975,92 @@ mod tests {
         assert!(state.complete_da_set_candidates(0).is_empty());
     }
 
+    const CORE_PAYLOAD: &[u8] = b"da-payload";
+
+    /// In-memory DA commit transaction for `da_id` declaring `chunk_count`
+    /// chunks. Kept unmarshalled because the extraction core takes an
+    /// ALREADY-PARSED block and its contract explicitly admits a block that was
+    /// ASSEMBLED rather than parsed.
+    fn core_commit_tx(da_id: [u8; 32], chunk_count: u16) -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x01,
+            tx_nonce: 7,
+            inputs: Vec::new(),
+            outputs: vec![da_commit_output([2u8; 32])],
+            locktime: 0,
+            da_commit_core: Some(relay_commit_core(da_id, chunk_count)),
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        }
+    }
+
+    /// In-memory DA chunk transaction at `index` for `da_id`.
+    fn core_chunk_tx(da_id: [u8; 32], index: u16) -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x02,
+            tx_nonce: 7,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: Some(relay_chunk_core(da_id, index, CORE_PAYLOAD)),
+            witness: Vec::new(),
+            da_payload: CORE_PAYLOAD.to_vec(),
+        }
+    }
+
+    /// A DA-kind transaction carrying NO DA core. This shape cannot exist on the
+    /// wire — `marshal_tx` refuses to encode `tx_kind=0x01` without a commit
+    /// core — so it is reachable only through an assembled block, which is
+    /// exactly the caller class the core's panic-free skip exists for.
+    fn core_coreless_tx(tx_kind: u8) -> Tx {
+        let mut tx = core_commit_tx([0u8; 32], 1);
+        tx.tx_kind = tx_kind;
+        tx.da_commit_core = None;
+        tx.da_chunk_core = None;
+        tx
+    }
+
+    /// Wrap in-memory transactions in a `ParsedBlock` without encoding them: the
+    /// header comes from a real coinbase-only block so every other field is
+    /// well-formed. Mirrors Go's in-memory `[]*consensus.Tx` extraction rows.
+    fn assembled_block(txs: Vec<Tx>) -> ParsedBlock {
+        let base = crate::test_helpers::block_with_txs(1, 0, [0u8; 32], 1, &[]);
+        let mut parsed = parse_block_bytes(&base).expect("parse coinbase-only base block");
+        parsed.tx_count = txs.len() as u64;
+        parsed.txs = txs;
+        parsed
+    }
+
+    fn core_wire_tx(tx: &Tx) -> Vec<u8> {
+        rubin_consensus::marshal_tx(tx).expect("marshal DA test tx")
+    }
+
+    /// Parse a test block and run the single extraction core over it.
+    fn core_ids(block_bytes: &[u8]) -> Result<Vec<[u8; 32]>, String> {
+        let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
+        complete_da_set_ids_from_parsed_block(&parsed)
+    }
+
+    /// One `da_id` per index, distinct across the whole `u16` range used here.
+    fn core_boundary_da_id(index: u16) -> [u8; 32] {
+        let mut da_id = [0u8; 32];
+        da_id[0] = (index >> 8) as u8;
+        da_id[1] = (index & 0xff) as u8;
+        da_id
+    }
+
     #[test]
-    fn extract_accepted_block_da_ids_matrix() {
+    fn complete_da_set_ids_from_parsed_block_matrix() {
         use crate::test_helpers::block_with_txs;
         let prev = [0u8; 32];
-        let payload = b"da-payload".to_vec();
-        let commit_for = |da_id, chunk_count| {
-            relay_test_tx(
-                0x01,
-                vec![da_commit_output([2u8; 32])],
-                Some(relay_commit_core(da_id, chunk_count)),
-                None,
-                Vec::new(),
-            )
-        };
-        let chunk_for = |da_id, index| {
-            relay_test_tx(
-                0x02,
-                Vec::new(),
-                None,
-                Some(relay_chunk_core(da_id, index, &payload)),
-                payload.clone(),
-            )
-        };
 
         // Coinbase-only block carries no DA txs.
         let empty_block = block_with_txs(1, 0, prev, 1_000, &[]);
-        assert!(extract_accepted_block_da_ids(&empty_block)
-            .unwrap()
-            .is_empty());
+        assert!(core_ids(&empty_block).expect("no-DA block").is_empty());
 
         // One complete DA set for a single da_id.
         let one_id = [5u8; 32];
@@ -1954,15 +2069,18 @@ mod tests {
             0,
             prev,
             1_001,
-            &[commit_for(one_id, 1), chunk_for(one_id, 0)],
+            &[
+                core_wire_tx(&core_commit_tx(one_id, 1)),
+                core_wire_tx(&core_chunk_tx(one_id, 0)),
+            ],
         );
-        assert_eq!(
-            extract_accepted_block_da_ids(&one_block).unwrap(),
-            vec![one_id]
-        );
+        assert_eq!(core_ids(&one_block).expect("single set"), vec![one_id]);
 
-        // Two complete sets; the higher da_id is staged first in the block.
+        // Three complete sets declared high/low/mid ON THE WIRE come back in
+        // ascending raw-byte order. Ordering is a pinned contract of the core,
+        // not an artefact of the order the block happened to carry them in.
         let lo = [3u8; 32];
+        let mid = [6u8; 32];
         let hi = [9u8; 32];
         let multi_block = block_with_txs(
             1,
@@ -1970,26 +2088,234 @@ mod tests {
             prev,
             1_002,
             &[
-                commit_for(hi, 1),
-                chunk_for(hi, 0),
-                commit_for(lo, 1),
-                chunk_for(lo, 0),
+                core_wire_tx(&core_commit_tx(hi, 1)),
+                core_wire_tx(&core_chunk_tx(hi, 0)),
+                core_wire_tx(&core_commit_tx(lo, 1)),
+                core_wire_tx(&core_chunk_tx(lo, 0)),
+                core_wire_tx(&core_commit_tx(mid, 1)),
+                core_wire_tx(&core_chunk_tx(mid, 0)),
             ],
         );
         assert_eq!(
-            extract_accepted_block_da_ids(&multi_block).unwrap(),
-            vec![lo, hi]
+            core_ids(&multi_block).expect("three sets"),
+            vec![lo, mid, hi],
+            "IDs must be byte-sorted ascending, not in wire order"
         );
 
-        // Commit declares 2 chunks but only chunk index 0 is present.
+        // A nil/absent DA layout is not the only empty case: a block whose DA
+        // txs are all incomplete also yields an empty list, never an error.
         let inc = [7u8; 32];
-        let inc_block = block_with_txs(1, 0, prev, 1_003, &[commit_for(inc, 2), chunk_for(inc, 0)]);
-        assert!(extract_accepted_block_da_ids(&inc_block)
-            .unwrap()
-            .is_empty());
+        let inc_block = block_with_txs(
+            1,
+            0,
+            prev,
+            1_003,
+            &[
+                core_wire_tx(&core_commit_tx(inc, 2)),
+                core_wire_tx(&core_chunk_tx(inc, 0)),
+            ],
+        );
+        assert!(core_ids(&inc_block).expect("incomplete set").is_empty());
 
-        // Unparseable block bytes.
-        assert!(extract_accepted_block_da_ids(&[0x01, 0x02]).is_err());
+        // Unparseable bytes never reach the core: the bytes entry parses first.
+        assert!(core_ids(&[0x01, 0x02]).is_err());
+    }
+
+    /// Every branch of the completeness classifier that must EXCLUDE a da_id.
+    /// Mirrors Go `TestCompleteDASetIDsFromParsedBlockIncompleteShapes`. The
+    /// nil-transaction row Go carries is structurally unrepresentable here:
+    /// `ParsedBlock.txs` is a `Vec<Tx>`, not a `Vec<*Tx>`, so there is no null
+    /// element to skip. The missing-DA-core rows below cover the same
+    /// panic-free-skip obligation for Rust's `Option` cores.
+    #[test]
+    fn complete_da_set_ids_from_parsed_block_excludes_incomplete_shapes() {
+        let da_id = [7u8; 32];
+        // One past the largest legal chunk_count, saturating if the constant is
+        // wider than the wire field.
+        let over_cap_chunks =
+            u16::try_from(MAX_DA_CHUNK_COUNT.saturating_add(1)).unwrap_or(u16::MAX);
+
+        let rows: Vec<(&str, Vec<Tx>)> = vec![
+            (
+                "duplicate commit disqualifies",
+                vec![
+                    core_commit_tx(da_id, 1),
+                    core_commit_tx(da_id, 1),
+                    core_chunk_tx(da_id, 0),
+                ],
+            ),
+            ("zero chunk_count", vec![core_commit_tx(da_id, 0)]),
+            (
+                "chunk_count mismatch: declares 2, carries 1",
+                vec![core_commit_tx(da_id, 2), core_chunk_tx(da_id, 0)],
+            ),
+            (
+                "chunk index gap: declares 2, carries 0 and 2",
+                vec![
+                    core_commit_tx(da_id, 2),
+                    core_chunk_tx(da_id, 0),
+                    core_chunk_tx(da_id, 2),
+                ],
+            ),
+            (
+                // EVERY declared chunk is carried, so the length and
+                // index-coverage clauses both PASS and the `chunk_count >
+                // MAX_DA_CHUNK_COUNT` clause is the only one that can reject
+                // this set. Planting a single chunk would be rejected by the
+                // length clause first and would pin nothing about the cap.
+                "chunk_count over MAX_DA_CHUNK_COUNT",
+                std::iter::once(core_commit_tx(da_id, over_cap_chunks))
+                    .chain((0..over_cap_chunks).map(|index| core_chunk_tx(da_id, index)))
+                    .collect(),
+            ),
+            (
+                "chunks without any commit",
+                vec![core_chunk_tx(da_id, 0), core_chunk_tx(da_id, 1)],
+            ),
+            (
+                "commit with no DA core is skipped, not unwrapped",
+                vec![core_coreless_tx(0x01), core_chunk_tx(da_id, 0)],
+            ),
+            (
+                "chunk with no DA core is skipped, not unwrapped",
+                vec![core_commit_tx(da_id, 1), core_coreless_tx(0x02)],
+            ),
+        ];
+
+        for (name, txs) in rows {
+            let block = assembled_block(txs);
+            assert!(
+                complete_da_set_ids_from_parsed_block(&block)
+                    .expect(name)
+                    .is_empty(),
+                "{name}: da_id must not be reported complete"
+            );
+        }
+    }
+
+    /// The per-block cap is an ERROR, never a truncated list: a truncated list
+    /// would silently leave the dropped sets' relay records pinned forever.
+    #[test]
+    fn complete_da_set_ids_from_parsed_block_bounds_at_max_da_batches() {
+        let cap = MAX_DA_BATCHES_PER_BLOCK as usize;
+        let complete_sets = |count: usize, incomplete_last: bool| {
+            let mut txs = Vec::with_capacity(count * 2);
+            for index in 0..count {
+                let da_id = core_boundary_da_id(u16::try_from(index).expect("index fits u16"));
+                txs.push(core_commit_tx(da_id, 1));
+                // An incomplete last set carries its commit but not its chunk.
+                if !(incomplete_last && index + 1 == count) {
+                    txs.push(core_chunk_tx(da_id, 0));
+                }
+            }
+            assembled_block(txs)
+        };
+
+        // Exactly MAX_DA_BATCHES_PER_BLOCK complete sets: all returned, ascending.
+        let ids = complete_da_set_ids_from_parsed_block(&complete_sets(cap, false))
+            .expect("exactly the cap is accepted");
+        assert_eq!(ids.len(), cap);
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "cap-sized output stays byte-sorted");
+
+        // Cap-many commits with the last set incomplete: exactly cap-1 IDs. The
+        // cap is counted AFTER completeness filtering.
+        assert_eq!(
+            complete_da_set_ids_from_parsed_block(&complete_sets(cap, true))
+                .expect("cap commits with one incomplete set is under the cap")
+                .len(),
+            cap - 1
+        );
+
+        // One over the cap is an error, and the error names the bound.
+        let err = complete_da_set_ids_from_parsed_block(&complete_sets(cap + 1, false))
+            .expect_err("over the cap must error, not truncate");
+        assert!(
+            err.contains("MAX_DA_BATCHES_PER_BLOCK"),
+            "cap error names the bound: {err}"
+        );
+    }
+
+    /// The bytes entry and the parsed core cannot select different DA sets for
+    /// the same block: the bytes entry parses and delegates to the same core.
+    /// Mirrors Go `TestConsumeAcceptedBlockDASetsMatchesParsedCore`.
+    #[test]
+    fn consume_accepted_block_da_sets_matches_parsed_core() {
+        use crate::test_helpers::block_with_txs;
+        // `complete_id` is complete in the block; `commit_only_id` is staged in
+        // relay accounting but carries no chunk in the block, so the core must
+        // not select it and consume must leave its record alone.
+        let complete_id = [0x31; 32];
+        let commit_only_id = [0x32; 32];
+        let block = block_with_txs(
+            1,
+            0,
+            [0u8; 32],
+            4_000,
+            &[
+                core_wire_tx(&core_commit_tx(complete_id, 1)),
+                core_wire_tx(&core_chunk_tx(complete_id, 0)),
+                core_wire_tx(&core_commit_tx(commit_only_id, 1)),
+            ],
+        );
+
+        let parsed = parse_block_bytes(&block).expect("parse block");
+        let core_selected = complete_da_set_ids_from_parsed_block(&parsed).expect("core selection");
+        assert_eq!(core_selected, vec![complete_id]);
+
+        let payload: &[u8] = b"equivalence-payload";
+        let payload_wire = payload.len() as u64;
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        for (index, id) in [complete_id, commit_only_id].into_iter().enumerate() {
+            state
+                .stage_incomplete_da_commit(
+                    &format!("commit-{index}:8333"),
+                    DaRelayCommit {
+                        da_id: id,
+                        payload_commitment: payload_commitment(&[payload]),
+                        peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+                        chunk_count: 1,
+                        wire_bytes: payload_wire,
+                        tx_bytes: Arc::from(&b"commit-tx"[..]),
+                    },
+                )
+                .unwrap();
+            state
+                .stage_incomplete_da_chunk(
+                    &format!("chunk-{index}:8333"),
+                    DaRelayChunk {
+                        da_id: id,
+                        chunk_hash: sha3_256(payload),
+                        peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+                        chunk_index: 0,
+                        payload: Arc::from(payload),
+                        wire_bytes: payload_wire,
+                        tx_bytes: Arc::from(&b"chunk-tx"[..]),
+                    },
+                )
+                .unwrap();
+        }
+        let relay = Mutex::new(state);
+        consume_accepted_block_da_sets(&relay, &block).expect("bytes-entry consume");
+
+        let guard = relay.lock().unwrap();
+        assert!(
+            !guard.sets_by_da_id.contains_key(&complete_id),
+            "the core-selected set is consumed"
+        );
+        assert!(
+            guard.sets_by_da_id.contains_key(&commit_only_id),
+            "a set complete in relay accounting but INCOMPLETE in the block is not consumed"
+        );
+    }
+
+    /// Malformed bytes fail at the bytes entry before any relay accounting is
+    /// touched — the parse is the first thing the entry does.
+    #[test]
+    fn consume_accepted_block_da_sets_rejects_malformed_block_before_consuming() {
+        let relay = Mutex::new(DaRelayState::new(DaRelayCaps::default()).unwrap());
+        assert!(consume_accepted_block_da_sets(&relay, &[0x01, 0x02]).is_err());
     }
 
     #[test]
@@ -2071,7 +2397,6 @@ mod tests {
     #[test]
     fn consume_canonical_applied_da_sets_consumes_all_canonical_blocks() {
         use crate::chainstate::CanonicalAppliedBlock;
-        use crate::test_helpers::block_with_txs;
         let payload: &[u8] = b"p2p-accept-payload";
         let payload_wire = payload.len() as u64;
         let commit_tx = b"canonical-commit-tx";
@@ -2093,29 +2418,12 @@ mod tests {
             wire_bytes,
             tx_bytes: Arc::from(tx_bytes),
         };
-        let block_for = |da_id, ts| {
-            block_with_txs(
-                1,
-                0,
-                [0u8; 32],
-                ts,
-                &[
-                    relay_test_tx(
-                        0x01,
-                        vec![da_commit_output([2u8; 32])],
-                        Some(relay_commit_core(da_id, 1)),
-                        None,
-                        Vec::new(),
-                    ),
-                    relay_test_tx(
-                        0x02,
-                        Vec::new(),
-                        None,
-                        Some(relay_chunk_core(da_id, 0, payload)),
-                        payload.to_vec(),
-                    ),
-                ],
-            )
+        // The report carries IDs, not bytes: a canonical-applied record is the
+        // block hash plus the IDs the apply path already extracted, and nothing
+        // in the consume hook re-parses a block.
+        let record_for = |hash: [u8; 32], da_ids: Vec<[u8; 32]>| CanonicalAppliedBlock {
+            hash,
+            complete_da_ids: da_ids,
         };
 
         let id_a = [81u8; 32];
@@ -2140,34 +2448,37 @@ mod tests {
 
         // Both canonical-applied blocks consume their complete sets, in order.
         let blocks = vec![
-            CanonicalAppliedBlock {
-                hash: [0xa0; 32],
-                block_bytes: block_for(id_a, 1_000),
-            },
-            CanonicalAppliedBlock {
-                hash: [0xb0; 32],
-                block_bytes: block_for(id_b, 1_001),
-            },
+            record_for([0xa0; 32], vec![id_a]),
+            record_for([0xb0; 32], vec![id_b]),
         ];
         consume_canonical_applied_da_sets(&relay, &blocks).expect("consume canonical");
+        assert_eq!(
+            blocks,
+            vec![
+                record_for([0xa0; 32], vec![id_a]),
+                record_for([0xb0; 32], vec![id_b]),
+            ],
+            "the hook must not mutate the report it was handed"
+        );
         let guard = relay.lock().unwrap();
         assert!(!guard.sets_by_da_id.contains_key(&id_a));
         assert!(!guard.sets_by_da_id.contains_key(&id_b));
         assert_eq!(guard.pinned_payload_bytes, 0);
         drop(guard);
 
-        // Fail-closed: a malformed canonical block surfaces an error.
-        let relay2 = Mutex::new(DaRelayState::new(DaRelayCaps::default()).unwrap());
-        let bad = vec![CanonicalAppliedBlock {
-            hash: [0xee; 32],
-            block_bytes: vec![0x01, 0x02],
-        }];
-        assert!(consume_canonical_applied_da_sets(&relay2, &bad).is_err());
-
-        // Best-effort: a malformed block between two valid canonical blocks does
-        // not skip the others; the first error (naming that block) is surfaced.
+        // Best-effort: a block whose relay accounting fails does not skip the
+        // others; the FIRST error, naming that block, is surfaced. The failure
+        // is injected through relay accounting rather than through block bytes,
+        // because a canonical-applied record no longer carries bytes to malform.
+        // A set's pinned accounting grows with its chunk COUNT
+        // (`DA_COMPLETE_SET_CHUNK_FOOTPRINT` per chunk), so the middle set is
+        // given two chunks and the counter is rewound to cover only the two
+        // one-chunk sets: consuming the middle block underflows while the blocks
+        // on either side still succeed.
         let id_c = [83u8; 32];
         let id_d = [84u8; 32];
+        let id_bad = [85u8; 32];
+        let payload_b: &[u8] = b"p2p-accept-payload-second-chunk";
         let mut state3 = DaRelayState::new(DaRelayCaps::default()).unwrap();
         for (id, c, k) in [
             (id_c, "commit-c:8333", "chunk-c:8333"),
@@ -2180,37 +2491,70 @@ mod tests {
                 .stage_incomplete_da_chunk(k, chunk(id, 0, payload, payload_wire, chunk_tx))
                 .unwrap();
         }
+        // Exactly what the two small sets pinned — read from the relay rather
+        // than recomputed, so the row does not depend on the accounting formula.
+        let two_small_sets_pinned = state3.pinned_payload_bytes;
+        state3
+            .stage_incomplete_da_commit(
+                "commit-bad:8333",
+                commit(id_bad, &[payload, payload_b], payload_wire, commit_tx),
+            )
+            .unwrap();
+        state3
+            .stage_incomplete_da_chunk(
+                "chunk-bad-0:8333",
+                chunk(id_bad, 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        state3
+            .stage_incomplete_da_chunk(
+                "chunk-bad-1:8333",
+                chunk(id_bad, 1, payload_b, payload_b.len() as u64, chunk_tx),
+            )
+            .unwrap();
+        state3.pinned_payload_bytes = two_small_sets_pinned;
         let relay3 = Mutex::new(state3);
         let mixed = vec![
-            CanonicalAppliedBlock {
-                hash: [0xc0; 32],
-                block_bytes: block_for(id_c, 1_002),
-            },
-            CanonicalAppliedBlock {
-                hash: [0xee; 32],
-                block_bytes: vec![0x01, 0x02],
-            },
-            CanonicalAppliedBlock {
-                hash: [0xd0; 32],
-                block_bytes: block_for(id_d, 1_003),
-            },
+            record_for([0xc0; 32], vec![id_c]),
+            record_for([0xee; 32], vec![id_bad]),
+            record_for([0xd0; 32], vec![id_d]),
         ];
         let err = consume_canonical_applied_da_sets(&relay3, &mixed)
-            .expect_err("malformed middle block surfaces an error");
+            .expect_err("failing relay accounting surfaces an error");
         assert!(
             err.contains(&hex::encode([0xee; 32])),
-            "first error names the malformed block: {err}"
+            "first error names the failing block: {err}"
         );
         let guard3 = relay3.lock().unwrap();
         assert!(
             !guard3.sets_by_da_id.contains_key(&id_c),
-            "block before the malformed one is consumed"
+            "block before the failing one is consumed"
+        );
+        assert!(
+            guard3.sets_by_da_id.contains_key(&id_bad),
+            "the failing block's set is left staged"
         );
         assert!(
             !guard3.sets_by_da_id.contains_key(&id_d),
-            "block after the malformed one is still consumed (best-effort)"
+            "block after the failing one is still consumed (best-effort)"
         );
-        assert_eq!(guard3.pinned_payload_bytes, 0);
+    }
+
+    /// An absent relay is a silent no-op even with IDs present: a relay-disabled
+    /// node must not error on every canonical apply. The P2P hook reaches this
+    /// by skipping the call entirely when no relay context is wired; the row
+    /// below pins the ID-list side — an empty report consumes nothing.
+    #[test]
+    fn consume_canonical_applied_da_sets_no_ops_on_unknown_ids() {
+        use crate::chainstate::CanonicalAppliedBlock;
+        let relay = Mutex::new(DaRelayState::new(DaRelayCaps::default()).unwrap());
+        let blocks = vec![CanonicalAppliedBlock {
+            hash: [0x77; 32],
+            complete_da_ids: vec![[0x99; 32]],
+        }];
+        consume_canonical_applied_da_sets(&relay, &blocks)
+            .expect("IDs with no staged relay record are a no-op, not an error");
+        assert_eq!(relay.lock().unwrap().pinned_payload_bytes, 0);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3796,7 +3796,12 @@ impl Drop for OrphanBlockPool {
     }
 }
 
-fn is_parent_not_found_err(err: &str) -> bool {
+/// The exact predicate that routes an apply failure to orphan retention.
+/// `pub(crate)` so the side-branch walk's corruption rows can assert against
+/// THIS function rather than against a copy of its rule: a local-corruption
+/// error that started matching here would silently park an honest peer's block
+/// in the orphan pool.
+pub(crate) fn is_parent_not_found_err(err: &str) -> bool {
     err == PARENT_BLOCK_NOT_FOUND_ERR
 }
 
@@ -7413,6 +7418,67 @@ mod tests {
                 "row {row}: bad PoW took pool memory"
             );
         }
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// A CORRUPT LOCAL STORE must never change a peer's disposition. The peer
+    /// relayed a well-formed block; the defect is entirely ours, so the failure
+    /// is surfaced as a local error — not routed to orphan retention (which
+    /// would silently park an honest block forever) and not scored against the
+    /// peer. The routing predicate itself is asserted, not a copy of its rule.
+    #[test]
+    fn corrupt_branch_store_is_peer_neutral() {
+        use crate::sync::{retarget_block_for_test, stock_devnet_engine_for_test};
+        use crate::sync_reorg::BRANCH_STORE_CORRUPT_ERR;
+        let _metrics = orphan_pool_metrics_test_guard();
+        reset_orphan_pool_metrics_for_test();
+
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-corrupt-neutral", |_| {});
+        let genesis = engine.chain_state.tip_hash;
+        let ts = engine.tip_timestamp + 1;
+
+        // The header probe the pre-apply precheck uses succeeds, so the walk is
+        // reached; the block bytes it then reads are corrupt.
+        let mut header =
+            crate::test_helpers::build_block_bytes(genesis, [0u8; 32], POW_LIMIT, ts, &[]);
+        header.truncate(BLOCK_HEADER_BYTES);
+        let corrupt_parent = block_hash(&header).expect("parent hash");
+        let root = crate::blockstore::block_store_path(&dir);
+        let leaf = format!("{}.bin", hex::encode(corrupt_parent));
+        fs::write(root.join("headers").join(&leaf), &header).expect("write header artifact");
+        fs::write(root.join("blocks").join(&leaf), b"corrupt datadir bytes")
+            .expect("write corrupt block artifact");
+
+        let child = retarget_block_for_test(
+            coinbase_only_block_with_gen(2, 0, corrupt_parent, ts + 1),
+            POW_LIMIT,
+        );
+        let (mut session, _client) = test_peer_session();
+        let err = session
+            .handle_block(&child, &mut engine)
+            .expect_err("local corruption must surface, not be swallowed as an orphan");
+        let rendered = err.to_string();
+
+        assert!(
+            rendered.contains(BRANCH_STORE_CORRUPT_ERR),
+            "local corruption class: {rendered}"
+        );
+        assert!(
+            !is_parent_not_found_err(&rendered),
+            "the orphan router must not match local corruption: {rendered}"
+        );
+        assert_eq!(
+            session.state().ban_score,
+            0,
+            "a corrupt datadir must not raise the ban score of a peer that relayed an honest block"
+        );
+        assert_eq!(
+            session.orphans.len(),
+            0,
+            "no orphan retention on corruption"
+        );
+        assert_eq!(engine.chain_state.height, 0, "nothing became canonical");
+
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -9,8 +9,9 @@ use rubin_consensus::{block_hash, parse_block_bytes, parse_block_header_bytes};
 use rubin_consensus::{RotationProvider, SuiteRegistry};
 
 use crate::blockstore::BlockStore;
-use crate::chainstate::{ChainState, ChainStateConnectSummary};
+use crate::chainstate::{CanonicalAppliedBlock, ChainState, ChainStateConnectSummary};
 use crate::chainstate_recovery::should_persist_chainstate_snapshot;
+use crate::da_relay::complete_da_set_ids_from_parsed_block;
 use crate::genesis::devnet_genesis_chain_id;
 use crate::sync_reorg::PARENT_BLOCK_NOT_FOUND_ERR;
 use crate::target_schedule::{expected_target_for_candidate, TargetScheduleError};
@@ -913,7 +914,7 @@ impl SyncEngine {
                 Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
                 None => (None, None),
             };
-        let summary = match self.chain_state.connect_block_with_suite_context(
+        let mut summary = match self.chain_state.connect_block_with_suite_context(
             block_bytes,
             expected_target,
             prev_timestamps,
@@ -1018,6 +1019,38 @@ impl SyncEngine {
         } else {
             self.pv_telemetry.record_block_skipped();
         }
+
+        // This is the ONLY site that reports a block as canonical-applied, so
+        // the distinction between "connected to some chain state" and "made
+        // canonical" lives in exactly one place: the connect layer leaves the
+        // field empty, and the reorg loop above accumulates one record per
+        // newly-canonical block by calling back into here. Extraction runs on
+        // the already-parsed block — no re-parse of the bytes and no retained
+        // bytes — and only AFTER the connect succeeded, so an over-cap or
+        // malformed DA layout is rejected by consensus with its own public error
+        // code before this ever runs.
+        //
+        // Any error here is therefore a defensive assertion. It rolls the apply
+        // back rather than committing a block whose canonical-applied report
+        // could not be built: the connect already mutated the in-memory chain
+        // state, and returning without this restore would leave the in-memory
+        // tip advanced to a block that was never persisted and never reported.
+        // Rollback runs BEFORE `commit_canonical_block`, so no store rewind is
+        // needed — the persisted canonical tip has not moved yet. Go twin:
+        // `sync.go` `applyCanonicalParsedBlockTracked` + `rollbackApplyBlock`.
+        let complete_da_ids = match complete_da_set_ids_from_parsed_block(&parsed) {
+            Ok(ids) => ids,
+            Err(err) => {
+                self.chain_state = snapshot;
+                self.tip_timestamp = old_tip_timestamp;
+                self.best_known_height = old_best_known_height;
+                return Err(err);
+            }
+        };
+        summary.canonical_applied_blocks = vec![CanonicalAppliedBlock {
+            hash: block_hash_bytes,
+            complete_da_ids,
+        }];
 
         let commit_start = Instant::now();
         // `canonical_len_before` is the rewind target for the ONLY remaining

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -3,6 +3,7 @@ use rubin_consensus::{
     validate_block_basic_with_context_at_height_and_rotation, Outpoint, ParsedBlock,
     BLOCK_HEADER_BYTES,
 };
+use std::collections::BTreeSet;
 use std::ops::Deref;
 
 use crate::blockstore::BlockStore;
@@ -11,6 +12,100 @@ use crate::sync::SyncEngine;
 use crate::txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxSource};
 
 pub(crate) const PARENT_BLOCK_NOT_FOUND_ERR: &str = "parent block not found";
+
+/// Marks a LOCAL block-store defect observed while walking a side branch: a
+/// stored block that cannot be read, cannot be parsed, or does not hash to the
+/// hash it was looked up by, or an ancestry that revisits a hash already walked.
+///
+/// It is deliberately distinct from [`PARENT_BLOCK_NOT_FOUND_ERR`]: only a
+/// genuinely absent ancestor may keep the parent-not-found outcome, which the
+/// P2P layer turns into normal orphan retention. Classifying our corrupt datadir
+/// as parent-not-found would silently park an honest peer's block in the orphan
+/// pool forever.
+///
+/// The cause is carried as PRE-RENDERED TEXT inside the message and is never
+/// chained: `parse_block_bytes` fails with a `TxError` (the consensus fault
+/// type), and a corruption error that a peer-facing classifier could reach
+/// through a `From` / `#[from]` / `source()` chain would attribute OUR local
+/// defect to the peer that relayed a perfectly well-formed block. Errors on this
+/// path are `String`s, so rendering the cause with `{err}` drops the chain by
+/// construction — that is the property, not an accident of the error type. Go
+/// reaches the same result by rendering the cause with `%v` instead of `%w`,
+/// because `errors.As` unwraps `%w` chains (`sync_reorg.go`
+/// `errBranchStoreCorrupt`).
+pub(crate) const BRANCH_STORE_CORRUPT_ERR: &str =
+    "block store corruption during side-branch collection";
+
+/// Builds a local-corruption error carrying `detail` as pre-rendered text. See
+/// [`BRANCH_STORE_CORRUPT_ERR`] for why the cause is text and never a chained
+/// error value.
+pub(crate) fn branch_store_corrupt(detail: String) -> String {
+    format!("{BRANCH_STORE_CORRUPT_ERR}: {detail}")
+}
+
+/// Reads one stored ancestor and PROVES it is the block that was asked for. A
+/// plain file read cannot: [`BlockStore::get_block_by_hash`] returns whatever
+/// bytes sit at the path named by the hash, so a corrupt — or hostile — datadir
+/// can answer every lookup with a block that points somewhere else entirely.
+///
+/// Every way the stored bytes can fail to be the requested block — unreadable,
+/// unparseable, unhashable, or hashing to something else — is one local
+/// corruption class. Bytes that cannot even yield a header certainly do not hash
+/// to their lookup key, so a parse failure is not a separate verdict. Only an
+/// underlying [`std::io::ErrorKind::NotFound`] means the ancestor is genuinely
+/// absent, which keeps the pre-existing [`PARENT_BLOCK_NOT_FOUND_ERR`] outcome.
+///
+/// Go twin: `clients/go/node/sync_reorg.go` `loadVerifiedBranchAncestor`.
+fn load_verified_branch_ancestor(
+    block_store: &BlockStore,
+    parent_hash: [u8; 32],
+) -> Result<(ParsedBlock, Vec<u8>), String> {
+    let parent_bytes = match block_store.read_block_file_by_hash(parent_hash) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(PARENT_BLOCK_NOT_FOUND_ERR.to_string());
+        }
+        Err(err) => {
+            return Err(branch_store_corrupt(format!(
+                "stored block for {} is unreadable: {err}",
+                hex::encode(parent_hash)
+            )));
+        }
+    };
+    let parent_parsed = parse_block_bytes(&parent_bytes).map_err(|err| {
+        branch_store_corrupt(format!(
+            "stored block for {} does not parse: {err}",
+            hex::encode(parent_hash)
+        ))
+    })?;
+    let observed_hash = block_hash(&parent_parsed.header_bytes).map_err(|err| {
+        branch_store_corrupt(format!(
+            "stored block for {} does not hash: {err}",
+            hex::encode(parent_hash)
+        ))
+    })?;
+    if observed_hash != parent_hash {
+        return Err(branch_store_corrupt(format!(
+            "stored block for {} hashes to {}",
+            hex::encode(parent_hash),
+            hex::encode(observed_hash)
+        )));
+    }
+    Ok((parent_parsed, parent_bytes))
+}
+
+/// One collected branch row built from an already-parsed block.
+fn branch_row(hash: [u8; 32], parsed: &ParsedBlock, block_bytes: Vec<u8>) -> ReorgBranchBlock {
+    ReorgBranchBlock {
+        hash,
+        header_bytes: parsed.header_bytes,
+        block_bytes,
+        prev_hash: parsed.header.prev_block_hash,
+        target: parsed.header.target,
+        timestamp: parsed.header.timestamp,
+        txids: parsed.txids.clone(),
+    }
+}
 
 /// Caller-owned candidate height of branch row `index` above the common
 /// ancestor — Go's `commonAncestorHeight + 1 + i`, with the additions checked so
@@ -611,6 +706,35 @@ impl SyncEngine {
     /// Walk backward from the given block along parent pointers until we find
     /// a block on the canonical chain. Returns the branch blocks in
     /// ancestor-to-tip order, plus the common ancestor hash and height.
+    ///
+    /// Two independent guards bound the walk, and their relationship is NOT
+    /// redundancy — do not remove either one on that theory:
+    ///
+    /// - Per-ancestor verification ([`load_verified_branch_ancestor`]) is the
+    ///   live guard. It is what actually stops a corrupt or hostile store file
+    ///   whose `prev_block_hash` points at itself, or at another file that
+    ///   points back: such a file cannot also hash to the name it was fetched
+    ///   under, so it is rejected on the first read. Without it this loop runs
+    ///   forever, appending the same block bytes on every pass, since nothing
+    ///   else in the walk bounds it.
+    /// - The `walked` set below is defense-in-depth that the verification guard
+    ///   makes UNREACHABLE today. Reaching it needs an ancestry that returns to
+    ///   an already-walked hash while every loaded block still hashes to its own
+    ///   lookup key — i.e. a SHA3-256 cycle. It exists so the walk stays bounded
+    ///   if the verification guard is ever weakened, reordered, or removed.
+    ///
+    /// Because it is unreachable, the `walked` branch cannot be pinned by a test
+    /// against the shipped code, and a line-coverage tool WILL report it
+    /// uncovered. That is expected, not a gap: the relationship is demonstrated
+    /// by mutation — removing the verification guard alone leaves the `walked`
+    /// set catching both the self-referencing and the two-file cycle shapes, and
+    /// removing both hangs the walk.
+    ///
+    /// With either guard in place the walk is bounded by the number of distinct
+    /// blocks actually on disk, so NO explicit depth limit is needed: an honest
+    /// branch still terminates at the canonical index or at
+    /// [`PARENT_BLOCK_NOT_FOUND_ERR`]. Go twin: `sync_reorg.go`
+    /// `collectBranchToCanonical`.
     fn collect_branch_to_canonical(
         &self,
         block_hash_bytes: [u8; 32],
@@ -622,16 +746,14 @@ impl SyncEngine {
             .ok_or("sync engine has no blockstore")?;
 
         let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
-        let mut branch = vec![ReorgBranchBlock {
-            hash: block_hash_bytes,
-            header_bytes: parsed.header_bytes,
-            block_bytes: block_bytes.to_vec(),
-            prev_hash: parsed.header.prev_block_hash,
-            target: parsed.header.target,
-            timestamp: parsed.header.timestamp,
-            txids: parsed.txids.clone(),
-        }];
+        let mut branch = vec![branch_row(block_hash_bytes, &parsed, block_bytes.to_vec())];
 
+        // Seeded with the candidate so an ancestry looping back to the candidate
+        // itself is caught by the same rule as any other repeat. A `BTreeSet` is
+        // used rather than a hash set so nothing on this path depends on hash
+        // iteration behaviour; it is only ever probed, never iterated.
+        let mut walked: BTreeSet<[u8; 32]> = BTreeSet::new();
+        walked.insert(block_hash_bytes);
         let mut parent_hash = parsed.header.prev_block_hash;
 
         loop {
@@ -641,22 +763,21 @@ impl SyncEngine {
                 return Ok((branch, parent_hash, height));
             }
 
-            // Load the parent block from the side-chain store.
-            let parent_bytes = block_store
-                .get_block_by_hash(parent_hash)
-                .map_err(|_| PARENT_BLOCK_NOT_FOUND_ERR.to_string())?;
-            let parent_parsed = parse_block_bytes(&parent_bytes).map_err(|e| e.to_string())?;
+            // Unreachable while `load_verified_branch_ancestor` stands; see the
+            // guard relationship on this function.
+            if !walked.insert(parent_hash) {
+                return Err(branch_store_corrupt(format!(
+                    "ancestor {} already walked",
+                    hex::encode(parent_hash)
+                )));
+            }
 
-            branch.push(ReorgBranchBlock {
-                hash: parent_hash,
-                header_bytes: parent_parsed.header_bytes,
-                block_bytes: parent_bytes,
-                prev_hash: parent_parsed.header.prev_block_hash,
-                target: parent_parsed.header.target,
-                timestamp: parent_parsed.header.timestamp,
-                txids: parent_parsed.txids.clone(),
-            });
+            // Load the parent block from the side-chain store and prove it is
+            // the block that was asked for.
+            let (parent_parsed, parent_bytes) =
+                load_verified_branch_ancestor(block_store, parent_hash)?;
 
+            branch.push(branch_row(parent_hash, &parent_parsed, parent_bytes));
             parent_hash = parent_parsed.header.prev_block_hash;
         }
     }
@@ -1211,9 +1332,487 @@ mod tests {
         assert_eq!(summary.canonical_applied_blocks.len(), 1);
         assert_eq!(summary.canonical_applied_blocks[0].hash, block1_hash);
         assert_eq!(summary.canonical_applied_blocks[0].hash, summary.block_hash);
-        assert_eq!(summary.canonical_applied_blocks[0].block_bytes, block1);
+        // A coinbase-only block carries no DA set, so the ID list is empty —
+        // and the record owns no block payload at all.
+        assert!(summary.canonical_applied_blocks[0]
+            .complete_da_ids
+            .is_empty());
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Funds `count` independently spendable P2PK outputs owned by `keypair`
+    /// directly in the engine's chain state. They are NOT coinbase outputs, so
+    /// no maturity wait is needed — the DA transactions below still go through
+    /// real signing and full consensus validation, which is what these rows are
+    /// about; the funding route is not.
+    fn fund_p2pk_outputs(
+        engine: &mut SyncEngine,
+        keypair: &Mldsa87Keypair,
+        count: u8,
+    ) -> Vec<Outpoint> {
+        let covenant_data = p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes());
+        (0..count)
+            .map(|index| {
+                let outpoint = Outpoint {
+                    txid: [0xd0 + index; 32],
+                    vout: 0,
+                };
+                engine.chain_state.utxos.insert(
+                    outpoint.clone(),
+                    UtxoEntry {
+                        value: 200_000,
+                        covenant_type: rubin_consensus::constants::COV_TYPE_P2PK,
+                        covenant_data: covenant_data.clone(),
+                        creation_height: 0,
+                        created_by_coinbase: false,
+                    },
+                );
+                outpoint
+            })
+            .collect()
+    }
+
+    /// Signed wire bytes for one COMPLETE DA set (a single-chunk commit plus its
+    /// chunk) for `da_id`. Each transaction spends one funded output entirely as
+    /// fee, mirroring the devnet DA tx generator's shape.
+    fn signed_complete_da_set(
+        engine: &SyncEngine,
+        keypair: &Mldsa87Keypair,
+        da_id: [u8; 32],
+        coins: &[Outpoint],
+        nonce_base: u64,
+        payload: &[u8],
+    ) -> Vec<Vec<u8>> {
+        use sha3::{Digest, Sha3_256};
+        let digest = |bytes: &[u8]| -> [u8; 32] { Sha3_256::digest(bytes).into() };
+        let input_for = |coin: &Outpoint| TxInput {
+            prev_txid: coin.txid,
+            prev_vout: coin.vout,
+            script_sig: Vec::new(),
+            sequence: 0,
+        };
+        let base = |tx_kind: u8, tx_nonce: u64, coin: &Outpoint| Tx {
+            version: rubin_consensus::constants::TX_WIRE_VERSION,
+            tx_kind,
+            tx_nonce,
+            inputs: vec![input_for(coin)],
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        };
+
+        let mut commit = base(0x01, nonce_base, &coins[0]);
+        commit.outputs = vec![TxOutput {
+            value: 0,
+            covenant_type: rubin_consensus::constants::COV_TYPE_DA_COMMIT,
+            // Single chunk, so the commitment is over that chunk's payload.
+            covenant_data: digest(payload).to_vec(),
+        }];
+        commit.da_commit_core = Some(rubin_consensus::DaCommitCore {
+            da_id,
+            chunk_count: 1,
+            retl_domain_id: [0x10; 32],
+            batch_number: 1,
+            tx_data_root: [0x11; 32],
+            state_root: [0x12; 32],
+            withdrawals_root: [0x13; 32],
+            batch_sig_suite: 0,
+            batch_sig: Vec::new(),
+        });
+        commit.da_payload = vec![0xa1];
+
+        let mut chunk = base(0x02, nonce_base + 1, &coins[1]);
+        chunk.da_chunk_core = Some(rubin_consensus::DaChunkCore {
+            da_id,
+            chunk_index: 0,
+            chunk_hash: digest(payload),
+        });
+        chunk.da_payload = payload.to_vec();
+
+        [commit, chunk]
+            .into_iter()
+            .map(|mut tx| {
+                sign_transaction(
+                    &mut tx,
+                    &engine.chain_state.utxos,
+                    engine.cfg.chain_id,
+                    keypair,
+                )
+                .expect("sign DA tx");
+                marshal_tx(&tx).expect("marshal DA tx")
+            })
+            .collect()
+    }
+
+    /// A direct canonical apply reports the block's OWN complete DA-set IDs,
+    /// byte-sorted, extracted from the block the apply already parsed. The two
+    /// sets are laid out on the wire high-`da_id` first, so wire order cannot be
+    /// mistaken for sorted order.
+    #[test]
+    fn apply_block_with_reorg_reports_complete_da_sets_on_direct_apply() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-canon-da-direct");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        engine.cfg.chain_id = devnet_genesis_chain_id();
+
+        let keypair = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable");
+        let coins = fund_p2pk_outputs(&mut engine, &keypair, 4);
+        let da_lo = [0x21u8; 32];
+        let da_hi = [0x91u8; 32];
+        let mut txs =
+            signed_complete_da_set(&engine, &keypair, da_hi, &coins[0..2], 100, b"hi-pay");
+        txs.extend(signed_complete_da_set(
+            &engine,
+            &keypair,
+            da_lo,
+            &coins[2..4],
+            200,
+            b"lo-pay",
+        ));
+
+        let block1 = block_with_txs(1, 0, genesis_hash, gen_ts + 1, &txs);
+        let block1_hash = block_header_hash(&block1);
+        let outcome = engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("DA-carrying block applies");
+
+        assert_eq!(outcome.summary.canonical_applied_blocks.len(), 1);
+        let record = &outcome.summary.canonical_applied_blocks[0];
+        assert_eq!(record.hash, block1_hash);
+        assert_eq!(
+            record.complete_da_ids,
+            vec![da_lo, da_hi],
+            "the record carries this block's own complete DA IDs, byte-sorted"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// On a reorg each newly-canonical block reports ITS OWN complete DA sets:
+    /// a single accumulated set, or a last-block-wins report, would leave the
+    /// other blocks' relay records pinned forever.
+    #[test]
+    fn apply_block_with_reorg_attributes_complete_da_sets_per_block() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-canon-da-reorg");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        engine.cfg.chain_id = devnet_genesis_chain_id();
+
+        let keypair = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable");
+        let coins = fund_p2pk_outputs(&mut engine, &keypair, 4);
+        let da_first = [0x41u8; 32];
+        let da_second = [0x42u8; 32];
+
+        // Canonical single block, so the two-block branch below outweighs it.
+        let block1 = coinbase_only_block(1, genesis_hash, gen_ts + 1);
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 canonical");
+
+        // Branch block 1 carries the first DA set; branch block 2 the second.
+        let alt1_txs =
+            signed_complete_da_set(&engine, &keypair, da_first, &coins[0..2], 300, b"branch-1");
+        let alt1 = block_with_txs(1, 0, genesis_hash, gen_ts + 2, &alt1_txs);
+        let alt1_hash = block_header_hash(&alt1);
+        engine
+            .block_store
+            .as_ref()
+            .expect("blockstore")
+            .store_block(
+                alt1_hash,
+                &alt1[..rubin_consensus::BLOCK_HEADER_BYTES],
+                &alt1,
+            )
+            .expect("store alt1 as side branch");
+
+        let alt2_txs =
+            signed_complete_da_set(&engine, &keypair, da_second, &coins[2..4], 400, b"branch-2");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let alt2 = block_with_txs(2, subsidy1, alt1_hash, gen_ts + 3, &alt2_txs);
+        let alt2_hash = block_header_hash(&alt2);
+
+        let outcome = engine
+            .apply_block_with_reorg(&alt2, None)
+            .expect("reorg to the heavier DA-carrying branch");
+
+        assert_eq!(engine.chain_state.tip_hash, alt2_hash);
+        let records = &outcome.summary.canonical_applied_blocks;
+        assert_eq!(records.len(), 2, "one record per newly canonical block");
+        assert_eq!(records[0].hash, alt1_hash);
+        assert_eq!(records[0].complete_da_ids, vec![da_first]);
+        assert_eq!(records[1].hash, alt2_hash);
+        assert_eq!(records[1].complete_da_ids, vec![da_second]);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Plants arbitrary bytes at the block-store path a given hash resolves to.
+    /// The store read is a plain file read, so this is exactly what a corrupt
+    /// datadir — or anything with write access to it — hands the branch walk.
+    fn plant_raw_store_block(dir: &std::path::Path, hash: [u8; 32], bytes: &[u8]) {
+        let path = block_store_path(dir)
+            .join("blocks")
+            .join(format!("{}.bin", hex::encode(hash)));
+        std::fs::write(&path, bytes).expect("plant raw store block");
+    }
+
+    /// Pins the failure class of a corrupt-store branch walk: a local-corruption
+    /// error, distinct from the parent-not-found class, that the P2P orphan
+    /// router does NOT match. The router check is the consequential one — it is
+    /// what keeps our own bad datadir from parking an honest peer's block in the
+    /// orphan pool instead of surfacing the local defect.
+    fn assert_branch_store_corruption(err: &str) {
+        assert!(
+            !crate::p2p_runtime::is_parent_not_found_err(err),
+            "the P2P orphan router must not match local corruption: {err}"
+        );
+        assert_ne!(
+            err, PARENT_BLOCK_NOT_FOUND_ERR,
+            "not the absent-ancestor class"
+        );
+        assert!(
+            err.starts_with(BRANCH_STORE_CORRUPT_ERR),
+            "expected the local-corruption class, got: {err}"
+        );
+    }
+
+    /// Engine holding genesis + one canonical block, ready for a side-branch
+    /// candidate at height 2. Returns the engine, its data dir, and the
+    /// already-generated subsidy at height 1.
+    fn engine_with_canonical_tip(suffix: &str) -> (SyncEngine, std::path::PathBuf, u64, u64) {
+        let (mut engine, dir) = engine_with_store(suffix);
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 canonical");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        (engine, dir, subsidy1, gen_ts)
+    }
+
+    /// Drives the branch walk against a block store whose files lie. NONE of
+    /// these shapes is self-consistent — a stored block that really hashed to
+    /// the name it also points at would be a SHA3-256 cycle — so every one of
+    /// them is caught by the per-ancestor verification, terminating instead of
+    /// walking forever.
+    #[test]
+    fn apply_block_with_reorg_rejects_corrupt_store_ancestry() {
+        // A fabricated ancestor hash the candidate will point at.
+        let missing_parent = [0x5c_u8; 32];
+        let second_hop = [0x5d_u8; 32];
+        let honest_elsewhere = coinbase_only_block(1, [0x6a; 32], 10_000);
+
+        // Each row plants files, then the walk is driven through the public
+        // reorg entry with a candidate whose prev hash names the first file.
+        type PlantedStoreFiles = Vec<([u8; 32], Vec<u8>)>;
+        let rows: Vec<(&str, PlantedStoreFiles)> = vec![
+            (
+                // The former NON-TERMINATION reproduction: a stored file whose
+                // prev pointer names itself. Without verification the walk
+                // re-reads it forever.
+                "self-referencing stored ancestor",
+                vec![(
+                    missing_parent,
+                    coinbase_only_block(1, missing_parent, 10_001),
+                )],
+            ),
+            (
+                "two-file store cycle",
+                vec![
+                    (missing_parent, coinbase_only_block(1, second_hop, 10_002)),
+                    (second_hop, coinbase_only_block(1, missing_parent, 10_003)),
+                ],
+            ),
+            (
+                "stored ancestor present but unparseable",
+                vec![(missing_parent, b"not a block at all".to_vec())],
+            ),
+            (
+                "real block truncated mid-encoding",
+                vec![(
+                    missing_parent,
+                    honest_elsewhere[..honest_elsewhere.len() / 2].to_vec(),
+                )],
+            ),
+            (
+                "well-formed block stored under another block's hash",
+                vec![(missing_parent, honest_elsewhere.clone())],
+            ),
+        ];
+
+        for (index, (name, planted)) in rows.into_iter().enumerate() {
+            let (mut engine, dir, subsidy1, gen_ts) =
+                engine_with_canonical_tip(&format!("rubin-reorg-corrupt-{index}"));
+            for (hash, bytes) in &planted {
+                plant_raw_store_block(&dir, *hash, bytes);
+            }
+            let candidate = coinbase_only_block_with_gen(
+                2,
+                subsidy1,
+                missing_parent,
+                gen_ts + 20 + index as u64,
+            );
+            let err = engine
+                .apply_block_with_reorg(&candidate, None)
+                .expect_err(name);
+            assert_branch_store_corruption(&err);
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
+    }
+
+    /// A store read failure that is NOT `NotFound` is local corruption, never
+    /// the absent-ancestor class. A directory planted where the block file
+    /// belongs produces exactly that: the read fails with a non-`NotFound` kind.
+    /// This is the row the kind-preserving store accessor exists for — the
+    /// `String`-formatting accessor erases the kind, and matching on rendered
+    /// io-error text is OS-dependent.
+    #[test]
+    fn apply_block_with_reorg_reports_corruption_for_non_not_found_read_error() {
+        let (mut engine, dir, subsidy1, gen_ts) =
+            engine_with_canonical_tip("rubin-reorg-corrupt-readerr");
+        let blocked_parent = [0x5e_u8; 32];
+        let path = block_store_path(&dir)
+            .join("blocks")
+            .join(format!("{}.bin", hex::encode(blocked_parent)));
+        std::fs::create_dir_all(&path).expect("plant a directory where a block file belongs");
+
+        let candidate = coinbase_only_block_with_gen(2, subsidy1, blocked_parent, gen_ts + 40);
+        let err = engine
+            .apply_block_with_reorg(&candidate, None)
+            .expect_err("a non-NotFound read error must fail the walk");
+        assert_branch_store_corruption(&err);
+        assert!(
+            err.contains("unreadable"),
+            "the read-failure shape is named in the message: {err}"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// A genuinely absent ancestor keeps the parent-not-found outcome — and so
+    /// keeps orphan retention — from both the walk and the public reorg entry.
+    #[test]
+    fn apply_block_with_reorg_keeps_parent_not_found_for_absent_ancestor() {
+        let (mut engine, dir, subsidy1, gen_ts) =
+            engine_with_canonical_tip("rubin-reorg-absent-ancestor");
+        let absent_parent = [0x5f_u8; 32];
+        let candidate = coinbase_only_block_with_gen(2, subsidy1, absent_parent, gen_ts + 50);
+        let candidate_hash = block_header_hash(&candidate);
+
+        // `ReorgBranchBlock` is not `Debug`, so match rather than `expect_err`.
+        let Err(walk_err) = engine.collect_branch_to_canonical(candidate_hash, &candidate) else {
+            panic!("an absent ancestor must fail the walk");
+        };
+        assert_eq!(walk_err, PARENT_BLOCK_NOT_FOUND_ERR);
+        assert!(crate::p2p_runtime::is_parent_not_found_err(&walk_err));
+
+        let apply_err = engine
+            .apply_block_with_reorg(&candidate, None)
+            .expect_err("absent ancestor through the public entry");
+        assert_eq!(apply_err, PARENT_BLOCK_NOT_FOUND_ERR);
+        assert!(
+            !apply_err.starts_with(BRANCH_STORE_CORRUPT_ERR),
+            "a missing ancestor is not local corruption"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Verification adds NO false positives: an honest stored multi-block branch
+    /// still collects in canonical order with the correct common ancestor, and
+    /// the reorg that follows still applies and reports one record per block.
+    #[test]
+    fn collect_branch_to_canonical_accepts_honest_multi_block_branch() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-honest-branch");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 canonical");
+
+        // A two-block branch off genesis, the first block honestly stored.
+        let alt1 = coinbase_only_block(1, genesis_hash, gen_ts + 2);
+        let alt1_hash = block_header_hash(&alt1);
+        engine
+            .block_store
+            .as_ref()
+            .expect("blockstore")
+            .store_block(
+                alt1_hash,
+                &alt1[..rubin_consensus::BLOCK_HEADER_BYTES],
+                &alt1,
+            )
+            .expect("store alt1");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let alt2 = coinbase_only_block_with_gen(2, subsidy1, alt1_hash, gen_ts + 3);
+        let alt2_hash = block_header_hash(&alt2);
+
+        // `ReorgBranchBlock` is not `Debug`, so destructure rather than `expect`.
+        let Ok((branch, ancestor_hash, ancestor_height)) =
+            engine.collect_branch_to_canonical(alt2_hash, &alt2)
+        else {
+            panic!("honest branch must collect, verification adds no false positives");
+        };
+        assert_eq!(ancestor_hash, genesis_hash);
+        assert_eq!(ancestor_height, 0);
+        assert_eq!(
+            branch.iter().map(|row| row.hash).collect::<Vec<_>>(),
+            vec![alt1_hash, alt2_hash],
+            "branch is oldest-first"
+        );
+
+        let outcome = engine
+            .apply_block_with_reorg(&alt2, None)
+            .expect("honest branch applies");
+        assert_eq!(engine.chain_state.tip_hash, alt2_hash);
+        assert_eq!(engine.chain_state.height, 2);
+        assert_eq!(
+            outcome
+                .summary
+                .canonical_applied_blocks
+                .iter()
+                .map(|record| record.hash)
+                .collect::<Vec<_>>(),
+            vec![alt1_hash, alt2_hash]
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// The no-bytes bound is on the SHAPE of the record, not on a field name:
+    /// this destructuring is exhaustive, so ADDING any field — a `Vec<u8>` of
+    /// block bytes under any name included — fails to compile here. That is the
+    /// Rust stand-in for Go's reflective field inventory
+    /// (`TestCanonicalAppliedBlockCarriesNoBlockBytes`), which Rust cannot do at
+    /// runtime. Each retained item is a fixed-width hash or a bounded list of
+    /// fixed-width IDs, so a canonical-applied report grows with block COUNT,
+    /// never with block SIZE.
+    #[test]
+    fn canonical_applied_block_carries_no_block_bytes() {
+        let record = CanonicalAppliedBlock {
+            hash: [0x11; 32],
+            complete_da_ids: vec![[0x22; 32]],
+        };
+        let CanonicalAppliedBlock {
+            hash,
+            complete_da_ids,
+        } = record;
+        assert_eq!(hash, [0x11; 32]);
+        assert_eq!(complete_da_ids, vec![[0x22; 32]]);
     }
 
     #[test]
@@ -1292,9 +1891,12 @@ mod tests {
         // Every block that became canonical, in ascending canonical order.
         assert_eq!(summary.canonical_applied_blocks.len(), 2);
         assert_eq!(summary.canonical_applied_blocks[0].hash, block1_alt_hash);
-        assert_eq!(summary.canonical_applied_blocks[0].block_bytes, block1_alt);
         assert_eq!(summary.canonical_applied_blocks[1].hash, block2_alt_hash);
-        assert_eq!(summary.canonical_applied_blocks[1].block_bytes, block2_alt);
+        // Coinbase-only branch blocks carry no DA sets; the records are the two
+        // hashes and nothing else.
+        for record in &summary.canonical_applied_blocks {
+            assert!(record.complete_da_ids.is_empty());
+        }
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -1762,6 +2364,14 @@ mod tests {
             .apply_block_with_reorg(&block2_alt, None)
             .unwrap_err();
 
+        // No chain-state assertion here on purpose: this shape fails inside
+        // `disconnect_canonical_to_ancestor` BEFORE the in-memory chain state
+        // moves, so "height/tip unchanged" holds trivially and stays green even
+        // with the rollback deleted outright (measured). The untouched-chain
+        // half of the failed-reorg obligation is pinned by
+        // `apply_preferred_branch_connect_fail_undo_readonly`, where the connect
+        // has already advanced the state and the rollback is what restores it.
+
         // Restore permissions for cleanup.
         let mut perms = std::fs::metadata(&dir).expect("dir meta").permissions();
         #[allow(clippy::permissions_set_readonly_false)]
@@ -1825,9 +2435,20 @@ mod tests {
         perms.set_readonly(true);
         std::fs::set_permissions(&undo_dir, perms).expect("set ro");
 
+        // A failed branch apply must leave the canonical chain exactly where it
+        // was — the other half of "a failed reorg reports nothing".
+        let before_height = engine.chain_state.height;
+        let before_tip = engine.chain_state.tip_hash;
+
         let err = engine
             .apply_block_with_reorg(&block2_alt, None)
             .unwrap_err();
+
+        assert_eq!(
+            engine.chain_state.height, before_height,
+            "height rolled back"
+        );
+        assert_eq!(engine.chain_state.tip_hash, before_tip, "tip rolled back");
 
         // Restore permissions for cleanup.
         let mut perms = std::fs::metadata(&undo_dir)


### PR DESCRIPTION
## Issue
- Linear: RUB-881

Refs: Q-SEC-RUST-SYNC-CANONICAL-SUMMARY-BOUNDS-01

## Summary
The Rust mirror of merged Go c436bb6. A canonical-apply summary no longer owns raw block bytes: `CanonicalAppliedBlock` carries the block hash plus the complete DA-set IDs that block contributes, so a reorg summary grows with the number of newly canonical blocks rather than with their size.

The IDs are extracted from the block the apply path has already parsed, at the single `SyncEngine` site that distinguishes "connected to a chain state" from "made canonical". The `ChainState` connect entry points no longer mint canonical-applied records at all, so the reorg preview, the startup replay, and stored-but-not-switched side branches structurally cannot report one. One implementation of complete-DA-set selection serves both entry points: the bytes entry parses and delegates to the same parsed-block core, and the cap of `MAX_DA_BATCHES_PER_BLOCK` complete sets is an error rather than a truncated list.

Side-branch collection verifies what it loads. Every ancestor read from the block store is parsed and re-hashed against the hash it was fetched under, and a hash may be walked only once; a stored file whose parent pointer refers to itself previously made the walk run forever while appending the same bytes. Every local-corruption shape reports one node-private error whose cause is pre-rendered text, so no error chain reaches a consensus error type and a corrupt datadir cannot raise the ban score of a peer that relayed an honest block. Telling a genuinely absent ancestor from an unreadable one needs the block store's `io::ErrorKind`, which the existing `String`-formatting accessor erases; an additive kind-preserving read accessor supplies it, and a genuinely absent ancestor keeps its parent-not-found outcome and orphan retention.

## Invariant
A Rust `ChainStateConnectSummary` owns no raw block bytes — canonical-applied reporting carries, per canonical block, its hash plus at most `MAX_DA_BATCHES_PER_BLOCK` (128) fixed-width complete-DA-set IDs extracted from the already-parsed block at the single `SyncEngine` canonical-apply site, in exact canonical order, with complete-DA-set consumption semantics preserved — and side-branch collection verifies every ancestor loaded from the block store against its lookup hash and fails with a node-private local-corruption error on any mismatch, unparseable load, non-`NotFound` read error, or repeated lookup, so neither summaries nor the branch walk can grow without bound and local datadir corruption never changes a peer disposition.

## Scope
- Changed files: 6
- Surfaces: clients/rust
- Non-scope: no change to which blocks become canonical, to fork choice, or to whether a complete DA set is consumed; no consensus rule, wire format, persistent store format, or generated artifact touched; no Go edit; no reorg-depth limit; no new source file; no ban-policy change; no body/merkle verification of stored ancestors; no replacement of the reorg working set
- Consensus rules unchanged: YES — accept/reject outcomes, public error codes and their ordering are untouched; the new local-corruption error is node-private, is not a consensus error type, and replaces a path that previously did not terminate
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `cargo test --workspace` — PASS; `cargo test -p rubin-node sync_reorg` — PASS (42); `cargo test -p rubin-node da_relay` — PASS (26); `cargo test -p rubin-node p2p_runtime` — PASS (77); `cargo test -p rubin-node chainstate` — PASS (36); `cargo fmt --check` — PASS; `cargo clippy --workspace --all-targets -- -D warnings` — PASS; `git diff --check` — PASS

## Follow-ups / Waivers
- Per-ID consume ordering within one block and first-versus-last error selection are pinned in neither client; the missing row is a block carrying two IDs whose first consume fails. Cross-client gap, owned by a follow-up contract rather than this mirror.
- RUB-882 owns the reorg working set (branch bytes and orphan-pool bytes), which is inherent to applying blocks.
- The RUB-1050 family owns body-substituted stored blocks; this slice verifies header identity only, exactly as the Go reference does.
