### PR TITLE
RUB-1053: make store creation explicit and fail closed on damaged state

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -99,7 +99,7 @@ func mineGenesisBlockBytes(t *testing.T) (blockBytes []byte, headerBytes []byte)
 	chainStatePath := node.ChainStatePath(dir)
 
 	chainState := node.NewChainState()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -35,9 +35,9 @@ func mustRPCStateAtDir(t *testing.T, dir string, withGenesis bool) *devnetRPCSta
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
@@ -125,9 +125,9 @@ func mustRPCStateWithSpendableUTXOsAndMempoolConfig(
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
@@ -2085,9 +2085,9 @@ func TestDevnetRPCMineNextMineOneError(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
@@ -2171,9 +2171,9 @@ func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
@@ -2282,9 +2282,9 @@ func mustRPCMineNextState(t *testing.T) *devnetRPCState {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
@@ -2345,9 +2345,9 @@ func TestDevnetRPCMineNextLogsAnnounceBlockError(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
 	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/bits"
 	"os"
 	"os/signal"
@@ -228,6 +230,51 @@ func loadLegacyExposureScanChainState(path string) (*node.ChainState, error) {
 	return chainState, nil
 }
 
+// createOrOpenBlockStore selects the explicit create path or the strict
+// open-existing path. In create mode the CLI owns the preconditions: the
+// blockstore root must be absent (its error wins) and the chainstate must be
+// absent, both checked before the datadir or any store artifact is created.
+func createOrOpenBlockStore(dataDir, chainStatePath string, createStore bool, stderr io.Writer) (*node.BlockStore, int) {
+	rootPath := node.BlockStorePath(dataDir)
+	if !createStore {
+		blockStore, err := node.OpenBlockStore(rootPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "blockstore open failed: %v\n", err)
+			return nil, 2
+		}
+		return blockStore, 0
+	}
+	if err := requireAbsentPath("blockstore root", rootPath); err != nil {
+		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, 2
+	}
+	if err := requireAbsentPath("chainstate", chainStatePath); err != nil {
+		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, 2
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		_, _ = fmt.Fprintf(stderr, "datadir create failed: %v\n", err)
+		return nil, 2
+	}
+	blockStore, err := node.CreateBlockStore(rootPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, 2
+	}
+	return blockStore, 0
+}
+
+// requireAbsentPath rejects any existing filesystem entry at path. Lstat, not
+// Stat, so a dangling symlink counts as present rather than as "not found".
+func requireAbsentPath(label, path string) error {
+	if _, err := os.Lstat(path); err == nil {
+		return fmt.Errorf("%s already exists: %s", label, path)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stat %s %s: %w", label, path, err)
+	}
+	return nil
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
@@ -263,6 +310,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.Var(&legacySuiteIDs, "legacy-suite-id", "legacy suite_id to watch (decimal or 0xNN); repeatable")
 	legacyExposureIncludeOutpoints := fs.Bool("legacy-exposure-include-outpoints", false, "include deterministic outpoint lists in legacy exposure report")
 	dryRun := fs.Bool("dry-run", false, "print effective config and exit")
+	createStore := fs.Bool("create-store", false, "create a new blockstore (default: strictly open an existing one)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -279,7 +327,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	// pv-mode is untrusted operator input: reject an invalid mode BEFORE
 	// the legacy-exposure-scan branch (its chainstate read below) and
-	// BEFORE the first filesystem mutation (os.MkdirAll below), so the
+	// BEFORE the storage lifecycle (createOrOpenBlockStore below), so the
 	// process exits on an untouched filesystem with no service started.
 	// Everything above this guard is pure parse/normalize over argv.
 	// NewSyncEngine re-parses the same value internally (defense in
@@ -301,6 +349,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 	} else if len(legacySuiteIDs) > 0 || *legacyExposureIncludeOutpoints {
 		_, _ = fmt.Fprintln(stderr, "legacy exposure flags require --legacy-exposure-scan")
+		return 2
+	}
+	// --create-store mutates storage; --dry-run and --legacy-exposure-scan are
+	// read-only. Reject the combination after the existing config/legacy-suite
+	// validation and before genesis loading, the scan's chainstate read, and
+	// every filesystem write: exit 2 on an untouched filesystem.
+	if *createStore && (*dryRun || *legacyExposureScan) {
+		_, _ = fmt.Fprintln(stderr, "--create-store cannot be combined with --dry-run or --legacy-exposure-scan")
 		return 2
 	}
 	chainStatePath := node.ChainStatePath(cfg.DataDir)
@@ -326,8 +382,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "invalid genesis file: %v\n", err)
 		return 2
 	}
-	// Genesis-identity guards run BEFORE the first filesystem mutation
-	// (os.MkdirAll(cfg.DataDir) below). A wrong devnet chain_id /
+	// Genesis-identity guards run BEFORE the storage lifecycle
+	// (createOrOpenBlockStore below). A wrong devnet chain_id /
 	// genesis_hash, or a misconfigured mainnet runtime, must reject on a
 	// clean filesystem so operators do not end up with partial datadir /
 	// chainstate / blockstore artifacts that the next startup would have
@@ -344,9 +400,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "mainnet genesis guard failed: %v\n", err)
 		return 2
 	}
-	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
-		_, _ = fmt.Fprintf(stderr, "datadir create failed: %v\n", err)
-		return 2
+	// Storage lifecycle runs BEFORE the chainstate load: an uninitialized or
+	// half-initialized store must reject before anything reads or writes
+	// chainstate. Ordinary startup performs no mkdir at all.
+	blockStore, storeExit := createOrOpenBlockStore(cfg.DataDir, chainStatePath, *createStore, stderr)
+	if storeExit != 0 {
+		return storeExit
 	}
 	chainState, err := node.LoadChainState(chainStatePath)
 	if err != nil {
@@ -367,18 +426,13 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	chainState.Rotation = rotation
 	chainState.Registry = registry
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(cfg.DataDir))
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "blockstore open failed: %v\n", err)
-		return 2
-	}
 	syncCfg := node.DefaultSyncConfig(nil, chainIDFromGenesis, chainStatePath)
 	syncCfg.Network = cfg.Network
 	applySuiteContextToSyncConfig(&syncCfg, rotation, registry)
 	syncCfg.ParallelValidationMode = *pvMode
 	syncCfg.PVShadowMaxSamples = *pvShadowMax
 	// Genesis-identity guards (devnet ValidateDevnetGenesisIdentity and
-	// mainnet ValidateMainnetGenesisGuard) ran above before MkdirAll, so
+	// mainnet ValidateMainnetGenesisGuard) ran above the storage lifecycle, so
 	// any malformed pack or misconfigured mainnet runtime has already
 	// rejected on a clean filesystem. NewSyncEngine still re-runs the
 	// mainnet guard internally for embedded / test callers that

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -296,8 +296,21 @@ func TestLegacyExposureExampleFixtureMatchesFrozenContract(t *testing.T) {
 	}
 }
 
+// seedBlockStore initializes a store the way an operator would with
+// --create-store, for tests whose subject is a later startup step.
+func seedBlockStore(t *testing.T, dataDir string) {
+	t.Helper()
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatalf("mkdir datadir: %v", err)
+	}
+	if _, err := node.CreateBlockStore(node.BlockStorePath(dataDir)); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+}
+
 func TestRunDryRunOK(t *testing.T) {
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 
@@ -341,6 +354,7 @@ func symlinkTraversalDataDir(t *testing.T) (raw string, cleaned string, escaped 
 
 func TestRunNormalizesDataDirBeforeChainStateAndBlockStorePathDerivation(t *testing.T) {
 	raw, cleaned, escaped := symlinkTraversalDataDir(t)
+	seedBlockStore(t, cleaned)
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
@@ -374,7 +388,7 @@ func TestRunCreatesPrivatePersistencePaths(t *testing.T) {
 
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	code := run([]string{"--dry-run", "--datadir", datadir}, &out, &errOut)
+	code := run([]string{"--create-store", "--datadir", datadir, "--mine-blocks", "1", "--mine-exit"}, &out, &errOut)
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, errOut.String())
 	}
@@ -1151,6 +1165,7 @@ func TestRunRejectsInvalidPVModeBeforeStorage(t *testing.T) {
 
 	t.Run("preexisting_datadir_byte_identical", func(t *testing.T) {
 		datadir := filepath.Join(t.TempDir(), "data")
+		seedBlockStore(t, datadir)
 		var out, errOut bytes.Buffer
 		if code := run([]string{"--dry-run", "--datadir", datadir}, &out, &errOut); code != 0 {
 			t.Fatalf("seed dry-run exit code %d (stderr=%q)", code, errOut.String())
@@ -1230,6 +1245,7 @@ func TestRunRejectsInvalidPVModeBeforeStorage(t *testing.T) {
 	t.Run("valid_modes_preserved", func(t *testing.T) {
 		for _, mode := range []string{"off", "shadow", "on", "", "OFF", " on "} {
 			datadir := filepath.Join(t.TempDir(), "data")
+			seedBlockStore(t, datadir)
 			var out, errOut bytes.Buffer
 			code := run([]string{"--dry-run", "--datadir", datadir, "--pv-mode", mode}, &out, &errOut)
 			if code != 0 {
@@ -1278,9 +1294,9 @@ func TestSaturatingAddUint64(t *testing.T) {
 func TestRunDryRunReconcilesChainStateFromBlockStore(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := node.ChainStatePath(dir)
-	store, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	store, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	state := node.NewChainState()
@@ -1482,6 +1498,7 @@ func TestRunDryRunUsesDevnetGenesisChainIDByDefault(t *testing.T) {
 	t.Cleanup(func() { newSyncEngineFn = prev })
 
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	code := run([]string{"--dry-run", "--datadir", dir}, &out, &errOut)
@@ -1507,6 +1524,7 @@ func TestRunPassesMempoolLimitsToMempoolAndPrintsConfig(t *testing.T) {
 	t.Cleanup(func() { newMempoolFn = prev })
 
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	code := run([]string{"--dry-run", "--datadir", dir, "--mempool-max-txs", "7", "--mempool-max-bytes", "4096"}, &out, &errOut)
@@ -1537,6 +1555,7 @@ func TestRunWiresP2PToCanonicalMempool(t *testing.T) {
 	t.Cleanup(func() { newP2PServiceFn = prev })
 
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	var errOut bytes.Buffer
 	code := run([]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", ""}, io.Discard, &errOut)
 	if code != 2 {
@@ -1601,7 +1620,7 @@ func TestApplySuiteContextToSyncConfig_NilConfig(t *testing.T) {
 func TestRunDryRunShowsTipWhenBlockstoreHasTip(t *testing.T) {
 	dir := t.TempDir()
 
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -1628,9 +1647,9 @@ func TestRunDryRunShowsTipWhenBlockstoreHasTip(t *testing.T) {
 
 func TestRunDryRunFailsWhenChainstateReconcileFails(t *testing.T) {
 	dir := t.TempDir()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	parsed, err := consensus.ParseBlockBytes(node.DevnetGenesisBlockBytes())
 	if err != nil {
@@ -1656,9 +1675,9 @@ func TestRunDryRunFailsWhenChainstateReconcileFails(t *testing.T) {
 func TestRunDryRunFailsWhenChainstateSaveFails(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := node.ChainStatePath(dir)
-	store, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	store, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	state := node.NewChainState()
@@ -1732,7 +1751,7 @@ func TestRunMineBlocksExitOK(t *testing.T) {
 	var errOut bytes.Buffer
 
 	code := run(
-		[]string{"--datadir", dir, "--mine-blocks", "1", "--mine-exit"},
+		[]string{"--create-store", "--datadir", dir, "--mine-blocks", "1", "--mine-exit"},
 		&out,
 		&errOut,
 	)
@@ -1746,6 +1765,7 @@ func TestRunMineBlocksExitOK(t *testing.T) {
 
 func TestRunMineBlocksResetsDirtyChainStateWhenBlockstoreEmpty(t *testing.T) {
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	chainState := node.NewChainState()
 	chainState.HasTip = true
 	chainState.Height = math.MaxUint64
@@ -1823,7 +1843,7 @@ func TestRunMineBlocksPassesMineAddressToMiner(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	code := run(
-		[]string{"--datadir", dir, "--mine-blocks", "1", "--mine-exit", "--mine-address", strings.Repeat("11", 32)},
+		[]string{"--create-store", "--datadir", dir, "--mine-blocks", "1", "--mine-exit", "--mine-address", strings.Repeat("11", 32)},
 		&out,
 		&errOut,
 	)
@@ -1878,9 +1898,9 @@ func TestRunMainnetFailsWithoutGenesisFileBeforeExplicitTargetCheck(t *testing.T
 func TestRunMainnetFailsBeforeReconcilingChainState(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := node.ChainStatePath(dir)
-	store, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	store, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	state := node.NewChainState()
@@ -1916,6 +1936,7 @@ func TestRunMainnetFailsBeforeReconcilingChainState(t *testing.T) {
 
 func TestRunDryRunEmitsRPCBindAddrWhenPresent(t *testing.T) {
 	dir := t.TempDir()
+	seedBlockStore(t, dir)
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	code := run([]string{"--dry-run", "--datadir", dir, "--rpc-bind", "127.0.0.1:19112"}, &out, &errOut)
@@ -2023,6 +2044,7 @@ func TestRunFailsWhenBlockStoreOpenFails(t *testing.T) {
 
 func TestRunPrintConfigFailsWhenStdoutFails(t *testing.T) {
 	datadir := t.TempDir()
+	seedBlockStore(t, datadir)
 	var errOut bytes.Buffer
 	code := run([]string{"--dry-run", "--datadir", datadir}, failWriter{}, &errOut)
 	if code != 1 {
@@ -2043,6 +2065,7 @@ func TestNowUnixU64ReturnsZeroWhenUnixTimeNonPositive(t *testing.T) {
 func TestMainExitCodeIs0OnDryRun(t *testing.T) {
 	if os.Getenv("RUBIN_NODE_CHILD") == "1" {
 		datadir := t.TempDir()
+		seedBlockStore(t, datadir)
 		os.Args = []string{"rubin-node", "--dry-run", "--datadir", datadir}
 		main()
 		return
@@ -2068,7 +2091,7 @@ func TestRunNonDryRunExitsOnSignal(t *testing.T) {
 			p, _ := os.FindProcess(os.Getpid())
 			_ = p.Signal(syscall.SIGINT)
 		}()
-		code := run([]string{"--datadir", dir, "--bind", "127.0.0.1:0"}, os.Stdout, os.Stderr)
+		code := run([]string{"--create-store", "--datadir", dir, "--bind", "127.0.0.1:0"}, os.Stdout, os.Stderr)
 		os.Exit(code)
 		return
 	}
@@ -2096,7 +2119,7 @@ func TestRunFailsWhenRPCBindPortUnavailable(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	code := run(
-		[]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", listener.Addr().String()},
+		[]string{"--create-store", "--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", listener.Addr().String()},
 		&out,
 		&errOut,
 	)
@@ -2120,7 +2143,7 @@ func TestRunNonDryRunWithRPCBindExitsOnSignal(t *testing.T) {
 			_ = p.Signal(syscall.SIGINT)
 		}()
 		code := run(
-			[]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"},
+			[]string{"--create-store", "--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"},
 			os.Stdout,
 			os.Stderr,
 		)
@@ -2170,7 +2193,7 @@ func TestRunRPCBindReadyEndpointReportsLifecycle(t *testing.T) {
 	if os.Getenv("RUBIN_NODE_READY_LIFECYCLE_CHILD") == "1" {
 		dir := t.TempDir()
 		code := run(
-			[]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"},
+			[]string{"--create-store", "--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"},
 			os.Stdout,
 			os.Stderr,
 		)
@@ -2338,6 +2361,7 @@ func TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr(t *testing.T) {
 		badSuiteMineAddr := "00" + strings.Repeat("00", 32)
 		code := run(
 			[]string{
+				"--create-store",
 				"--datadir", dir,
 				"--bind", "127.0.0.1:0",
 				"--rpc-bind", "127.0.0.1:0",
@@ -2424,6 +2448,7 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 		}()
 		code := run(
 			[]string{
+				"--create-store",
 				"--datadir", dir,
 				"--bind", "127.0.0.1:0",
 				"--rpc-bind", "127.0.0.1:0",
@@ -2475,6 +2500,7 @@ func TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr(t *testing.T) {
 		}()
 		code := run(
 			[]string{
+				"--create-store",
 				"--datadir", dir,
 				"--bind", "127.0.0.1:0",
 				"--rpc-bind", "127.0.0.1:0",
@@ -2601,5 +2627,138 @@ func TestMaybeFlipReadyOnStartup_NilServerNoOp(t *testing.T) {
 	maybeFlipReadyOnStartup(nil, &buf)
 	if got := buf.String(); got != "" {
 		t.Fatalf("expected no output for nil server, got %q", got)
+	}
+}
+
+func runCLI(args ...string) (int, string) {
+	var out, errOut bytes.Buffer
+	code := run(args, &out, &errOut)
+	return code, errOut.String()
+}
+
+// create_open_state_machine rule 2 + parity row 4: --create-store is
+// incompatible with the read-only modes and rejects before any filesystem
+// access. Rust mirror: `create_store_rejects_flag_combinations_before_any_storage_access`.
+func TestRunCreateStoreRejectsFlagCombinationsBeforeStorage(t *testing.T) {
+	for _, extra := range [][]string{
+		{"--dry-run"},
+		{"--legacy-exposure-scan", "--legacy-suite-id", "1"},
+	} {
+		dir := filepath.Join(t.TempDir(), "data")
+		code, stderr := runCLI(append([]string{"--datadir", dir, "--create-store"}, extra...)...)
+		if code != 2 {
+			t.Fatalf("%v: exit %d, want 2", extra, code)
+		}
+		if want := "--create-store cannot be combined with --dry-run or --legacy-exposure-scan"; !strings.Contains(stderr, want) {
+			t.Fatalf("%v: stderr = %q, want %q", extra, stderr, want)
+		}
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Fatalf("%v: no filesystem entry may be created: %v", extra, err)
+		}
+	}
+}
+
+// Parity rows 1-3 + rejected cases: create commits the tree, refuses an existing
+// root (whose error wins over chainstate), refuses an existing chainstate
+// without touching the root. Rust mirror:
+// `create_store_creates_tree_and_rejects_existing_root_or_chainstate`.
+func TestRunCreateStoreCreatesTreeAndRejectsExisting(t *testing.T) {
+	create := func(dir string) []string {
+		return []string{"--datadir", dir, "--create-store", "--mine-blocks", "1", "--mine-exit"}
+	}
+	dir := filepath.Join(t.TempDir(), "data")
+	if code, stderr := runCLI(create(dir)...); code != 0 {
+		t.Fatalf("create exit %d (stderr=%q)", code, stderr)
+	}
+	root := node.BlockStorePath(dir)
+	for _, sub := range []string{"blocks", "headers", "undo"} {
+		if info, err := os.Stat(filepath.Join(root, sub)); err != nil || !info.IsDir() {
+			t.Fatalf("%s: %v %v", sub, info, err)
+		}
+	}
+	markerBefore, err := os.ReadFile(filepath.Join(root, "index.json")) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+
+	code, stderr := runCLI(create(dir)...)
+	if code != 2 || !strings.Contains(stderr, "blockstore root already exists") {
+		t.Fatalf("re-create: exit %d stderr %q", code, stderr)
+	}
+	markerAfter, err := os.ReadFile(filepath.Join(root, "index.json")) // #nosec G304 -- test-local path.
+	if err != nil || string(markerAfter) != string(markerBefore) {
+		t.Fatalf("existing store must be untouched: %v %v", markerAfter, err)
+	}
+
+	csDir := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(csDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(node.ChainStatePath(csDir), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed chainstate: %v", err)
+	}
+	code, stderr = runCLI(create(csDir)...)
+	if code != 2 || !strings.Contains(stderr, "chainstate already exists") {
+		t.Fatalf("chainstate present: exit %d stderr %q", code, stderr)
+	}
+	if _, err := os.Stat(node.BlockStorePath(csDir)); !os.IsNotExist(err) {
+		t.Fatalf("root must not be created: %v", err)
+	}
+
+	both := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(node.BlockStorePath(both), 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.WriteFile(node.ChainStatePath(both), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed chainstate: %v", err)
+	}
+	if code, stderr := runCLI(create(both)...); code != 2 || !strings.Contains(stderr, "blockstore root already exists") {
+		t.Fatalf("both present: exit %d stderr %q (root error must win)", code, stderr)
+	}
+
+	// hostile: a DANGLING symlink at either path is present (lstat), not absent.
+	for _, target := range []string{"blockstore root", "chainstate"} {
+		dir := filepath.Join(t.TempDir(), "data")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		link := node.BlockStorePath(dir)
+		if target == "chainstate" {
+			link = node.ChainStatePath(dir)
+		}
+		if err := os.Symlink(filepath.Join(dir, "nowhere"), link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		if code, stderr := runCLI(create(dir)...); code != 2 || !strings.Contains(stderr, target+" already exists") {
+			t.Fatalf("dangling %s symlink: exit %d stderr %q", target, code, stderr)
+		}
+	}
+}
+
+// Parity rows 5-9: ordinary startup strictly opens. Rust mirror:
+// `open_existing_startup_never_synthesizes_a_store`.
+func TestRunOpenExistingStartupDoesNotSynthesizeStore(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	code, stderr := runCLI("--datadir", dir, "--dry-run")
+	if code != 2 || !strings.Contains(stderr, "blockstore open failed") {
+		t.Fatalf("missing store: exit %d stderr %q", code, stderr)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("ordinary startup must not create the datadir: %v", err)
+	}
+
+	code, stderr = runCLI("--datadir", dir, "--legacy-exposure-scan", "--legacy-suite-id", "1")
+	if code != 2 || !strings.Contains(stderr, "legacy exposure scan requires an existing chainstate") {
+		t.Fatalf("legacy scan: exit %d stderr %q", code, stderr)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("legacy scan must not create a store: %v", err)
+	}
+
+	if code, stderr := runCLI("--datadir", dir, "--create-store", "--mine-blocks", "1", "--mine-exit"); code != 0 {
+		t.Fatalf("create exit %d (stderr=%q)", code, stderr)
+	}
+	if code, stderr := runCLI("--datadir", dir, "--dry-run"); code != 0 {
+		t.Fatalf("reopen exit %d (stderr=%q)", code, stderr)
 	}
 }

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -1,13 +1,16 @@
 package node
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -50,43 +53,100 @@ func BlockStorePath(dataDir string) string {
 	return filepath.Join(dataDir, blockStoreDirName)
 }
 
+type blockStorePaths struct {
+	root    string
+	index   string
+	blocks  string
+	headers string
+	undo    string
+}
+
+func newBlockStorePaths(rootPath string) blockStorePaths {
+	return blockStorePaths{
+		root:    rootPath,
+		index:   filepath.Join(rootPath, "index.json"),
+		blocks:  filepath.Join(rootPath, "blocks"),
+		headers: filepath.Join(rootPath, "headers"),
+		undo:    filepath.Join(rootPath, "undo"),
+	}
+}
+
+// CreateBlockStore initializes a fresh blockstore at rootPath: the only
+// constructor that writes. The root is created exclusively (an existing root of
+// any kind fails; two racing creates cannot both win) and index.json is written
+// LAST as the creation commit marker, so a crash before it leaves a partial root
+// both constructors reject. Owns only rootPath, never chainstate.
+func CreateBlockStore(rootPath string) (*BlockStore, error) {
+	paths := newBlockStorePaths(rootPath)
+	if err := os.Mkdir(paths.root, 0o700); err != nil {
+		return nil, fmt.Errorf("create blockstore root: %w", err)
+	}
+	for _, dir := range []string{paths.blocks, paths.headers, paths.undo} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("create blockstore directory: %w", err)
+		}
+	}
+	index := blockStoreIndexDisk{Version: blockStoreIndexVersion, Canonical: []string{}}
+	if err := saveBlockStoreIndex(paths.index, index); err != nil {
+		return nil, fmt.Errorf("commit blockstore index: %w", err)
+	}
+	return newBlockStore(paths, index)
+}
+
+// OpenBlockStore opens an already-initialized blockstore. Strict: no mkdir, no
+// marker synthesis, no fallback. A missing root/subdirectory/marker, a malformed
+// marker, or a resolved path of the wrong kind is an error, never a fresh empty
+// store. Symlinks resolve normally; no runtime path-identity claim is made.
 func OpenBlockStore(rootPath string) (*BlockStore, error) {
-	indexPath := filepath.Join(rootPath, "index.json")
-	blocksDir := filepath.Join(rootPath, "blocks")
-	headersDir := filepath.Join(rootPath, "headers")
-	undoDir := filepath.Join(rootPath, "undo")
-
-	if err := os.MkdirAll(blocksDir, 0o700); err != nil {
+	paths := newBlockStorePaths(rootPath)
+	if err := paths.requireInitialized(); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(headersDir, 0o700); err != nil {
-		return nil, err
-	}
-	if err := os.MkdirAll(undoDir, 0o700); err != nil {
-		return nil, err
-	}
-
-	index, err := loadBlockStoreIndex(indexPath)
+	index, err := loadBlockStoreIndex(paths.index)
 	if err != nil {
 		return nil, err
 	}
+	return newBlockStore(paths, index)
+}
+
+// requireInitialized checks the resolved filesystem kind of every path the store
+// needs. Stat, not Lstat: symlinks resolve normally on open.
+func (p blockStorePaths) requireInitialized() error {
+	for _, dir := range []string{p.root, p.blocks, p.headers, p.undo} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			return fmt.Errorf("blockstore directory %s: %w", dir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("blockstore path is not a directory: %s", dir)
+		}
+	}
+	info, err := os.Stat(p.index)
+	if err != nil {
+		return fmt.Errorf("blockstore index %s: %w", p.index, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("blockstore index is not a regular file: %s", p.index)
+	}
+	return nil
+}
+
+func newBlockStore(paths blockStorePaths, index blockStoreIndexDisk) (*BlockStore, error) {
 	canonicalHeightByHash, err := buildCanonicalHeightIndex(index.Canonical)
 	if err != nil {
 		return nil, err
 	}
-
-	bs := &BlockStore{
-		rootPath:   rootPath,
-		indexPath:  indexPath,
-		blocksDir:  blocksDir,
-		headersDir: headersDir,
-		undoDir:    undoDir,
+	return &BlockStore{
+		rootPath:   paths.root,
+		indexPath:  paths.index,
+		blocksDir:  paths.blocks,
+		headersDir: paths.headers,
+		undoDir:    paths.undo,
 		index:      index,
 
 		canonicalHeightByHash: canonicalHeightByHash,
 		chainWorkByHash:       make(map[[32]byte]*big.Int),
-	}
-	return bs, nil
+	}, nil
 }
 
 func (bs *BlockStore) PutBlock(height uint64, blockHash [32]byte, headerBytes []byte, blockBytes []byte) error {
@@ -448,30 +508,112 @@ func (bs *BlockStore) GetUndo(blockHash [32]byte) (*BlockUndo, error) {
 	return unmarshalBlockUndo(raw)
 }
 
+// loadBlockStoreIndex reads the sole initialization marker. A missing marker is
+// an error, never an implicit empty index.
 func loadBlockStoreIndex(path string) (blockStoreIndexDisk, error) {
 	raw, err := readFileByPath(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return blockStoreIndexDisk{
-			Version:   blockStoreIndexVersion,
-			Canonical: []string{},
-		}, nil
-	}
 	if err != nil {
 		return blockStoreIndexDisk{}, err
 	}
-	var index blockStoreIndexDisk
-	if err := json.Unmarshal(raw, &index); err != nil {
+	index, err := decodeBlockStoreIndex(raw)
+	if err != nil {
 		return blockStoreIndexDisk{}, fmt.Errorf("decode blockstore index: %w", err)
 	}
-	if index.Version != blockStoreIndexVersion {
-		return blockStoreIndexDisk{}, fmt.Errorf("unsupported blockstore index version: %d", index.Version)
+	return index, nil
+}
+
+// decodeBlockStoreIndex accepts exactly one JSON object with exactly one
+// "version" and one "canonical" field, in either order. Duplicate/unknown/missing
+// fields, a null or non-array canonical, an entry that is not 64 lowercase hex
+// characters, a version other than 1, and any trailing JSON value are rejected.
+// Rust mirror: load_blockstore_index in crates/rubin-node/src/blockstore.rs.
+func decodeBlockStoreIndex(raw []byte) (blockStoreIndexDisk, error) {
+	if err := requireExactIndexFields(raw); err != nil {
+		return blockStoreIndexDisk{}, err
 	}
-	for i, hashHex := range index.Canonical {
-		if _, err := parseHex32(fmt.Sprintf("canonical[%d]", i), hashHex); err != nil {
-			return blockStoreIndexDisk{}, err
+	var index blockStoreIndexDisk
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	if err := dec.Decode(&index); err != nil {
+		return blockStoreIndexDisk{}, err
+	}
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return blockStoreIndexDisk{}, errors.New("unexpected trailing JSON value")
+	}
+	return index, validateBlockStoreIndex(index)
+}
+
+// requireExactIndexFields requires the top-level key multiset to be exactly
+// {canonical, version}: struct decoding alone catches none of duplicate,
+// unknown or missing fields.
+func requireExactIndexFields(raw []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return errors.New("blockstore index must be a JSON object")
+	}
+	keys, err := collectIndexFieldNames(dec)
+	if err != nil {
+		return err
+	}
+	sort.Strings(keys)
+	if len(keys) != 2 || keys[0] != "canonical" || keys[1] != "version" {
+		return fmt.Errorf("blockstore index fields must be exactly canonical and version, got %q", keys)
+	}
+	return nil
+}
+
+// collectIndexFieldNames drains the top-level object, returning its key names in
+// encounter order (duplicates included, so the caller can reject them).
+func collectIndexFieldNames(dec *json.Decoder) ([]string, error) {
+	keys := make([]string, 0, 2)
+	for dec.More() {
+		key, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		name, _ := key.(string)
+		keys = append(keys, name)
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, err
 		}
 	}
-	return index, nil
+	return keys, nil
+}
+
+func validateBlockStoreIndex(index blockStoreIndexDisk) error {
+	if index.Version != blockStoreIndexVersion {
+		return fmt.Errorf("unsupported blockstore index version: %d", index.Version)
+	}
+	// The "canonical" key is present (requireExactIndexFields), so a nil slice
+	// here can only come from a JSON null.
+	if index.Canonical == nil {
+		return errors.New("canonical must not be null")
+	}
+	for i, hashHex := range index.Canonical {
+		if !validCanonicalHashHex(hashHex) {
+			return fmt.Errorf("canonical[%d]: not 64 lowercase hex characters: %q", i, hashHex)
+		}
+	}
+	return nil
+}
+
+// validCanonicalHashHex: 64 lowercase hex characters (hex decoding alone would
+// accept uppercase).
+func validCanonicalHashHex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {

--- a/clients/go/node/blockstore_additional_test.go
+++ b/clients/go/node/blockstore_additional_test.go
@@ -73,14 +73,14 @@ func TestLoadBlockStoreIndex_Errors(t *testing.T) {
 }
 
 func TestBlockStorePutBlock_RejectsInvalidHeaderLen(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if err := store.PutBlock(0, [32]byte{}, []byte{0x01}, []byte("b")); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
 func TestBlockStorePutBlock_RejectsHeaderHashMismatch(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(1, 1)
 	var wrong [32]byte
 	wrong[0] = 0x01
@@ -90,7 +90,7 @@ func TestBlockStorePutBlock_RejectsHeaderHashMismatch(t *testing.T) {
 }
 
 func TestBlockStoreSetCanonicalTip_SameHashIdempotent(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	payload := []byte("block-0")
 	hash0, header0 := mustPutBlock(t, store, 0, 1, 11, payload)
 
@@ -114,7 +114,7 @@ func TestBlockStoreRewindToHeight_Errors(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if err := store.RewindToHeight(0); err != nil {
 		t.Fatalf("expected ok on empty store: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestBlockStoreRewindToHeight_Errors(t *testing.T) {
 }
 
 func TestBlockStoreCanonicalHash_Errors(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if _, ok, err := store.CanonicalHash(0); err != nil || ok {
 		t.Fatalf("expected ok=false no error; ok=%v err=%v", ok, err)
 	}
@@ -138,7 +138,7 @@ func TestBlockStoreCanonicalHash_Errors(t *testing.T) {
 }
 
 func TestBlockStoreTip_Errors(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	store.index.Canonical = []string{"zz"}
 	if _, _, _, err := store.Tip(); err == nil {
 		t.Fatalf("expected error")
@@ -188,7 +188,7 @@ func TestWriteFileIfAbsent_ExistingSameContentOk(t *testing.T) {
 func TestBlockStorePutBlock_RejectsComputedHashMismatch(t *testing.T) {
 	// Coverage for consensus.BlockHash error path is hard to hit (header len checked),
 	// but computedHash != blockHash is reachable by passing the wrong hash.
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(1, 2)
 	hash := mustHeaderHash(t, header)
 	hash[0] ^= 0xff
@@ -205,7 +205,7 @@ func TestBlockStoreGetHeaderByHash_Nil(t *testing.T) {
 }
 
 func TestBlockStorePutBlock_CallsSetCanonicalTip(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(9, 9)
 	hash := mustHeaderHash(t, header)
 	if err := store.PutBlock(0, hash, header, []byte("blk")); err != nil {
@@ -238,14 +238,14 @@ func TestCommitCanonicalBlock_RejectsNilInputs(t *testing.T) {
 		t.Fatalf("expected nil blockstore error")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if err := store.CommitCanonicalBlock(0, hash, header, blockBytes, nil); err == nil {
 		t.Fatalf("expected nil undo error")
 	}
 }
 
 func TestCommitCanonicalBlock_PropagatesStoreBlockFailure(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(15, 15)
 	hash := mustHeaderHash(t, header)
 	header[0] ^= 0xff
@@ -255,7 +255,7 @@ func TestCommitCanonicalBlock_PropagatesStoreBlockFailure(t *testing.T) {
 }
 
 func TestBlockStoreStoreBlockAndChainWork(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if work, err := store.ChainWork([32]byte{}); err != nil {
 		t.Fatalf("ChainWork(zero): %v", err)
 	} else if work.Cmp(big.NewInt(0)) != 0 {
@@ -292,7 +292,7 @@ func TestBlockStoreStoreBlockAndChainWork(t *testing.T) {
 }
 
 func TestBlockStoreChainWorkCachesAndHelperCoverage(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 
 	header0 := testHeaderBytes(9, 1)
 	for i := 4; i < 36; i++ {
@@ -353,7 +353,7 @@ func TestBlockStoreCanonicalIndexHelpersAndUndoErrors(t *testing.T) {
 		t.Fatalf("expected nil GetUndo error")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	store.index.Canonical = []string{"zz"}
 	if _, err := store.CanonicalIndexSnapshot(); err == nil {
 		t.Fatalf("expected invalid canonical snapshot error")
@@ -377,7 +377,7 @@ func TestBlockStoreCanonicalIndexHelpersAndUndoErrors(t *testing.T) {
 }
 
 func TestBlockStoreChainWorkCachesCanonicalOnly(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 
 	header0 := testHeaderBytes(0x31, 1)
 	for i := 4; i < 36; i++ {
@@ -427,7 +427,7 @@ func TestBlockStoreChainWorkCachesCanonicalOnly(t *testing.T) {
 }
 
 func TestBlockStoreChainWorkRejectsInvalidTargetWithCachedAncestor(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 
 	header0 := testHeaderBytes(0x41, 1)
 	for i := 4; i < 36; i++ {
@@ -457,7 +457,7 @@ func TestBlockStoreChainWorkRejectsInvalidTargetWithCachedAncestor(t *testing.T)
 }
 
 func TestBlockStoreChainWorkRejectsInvalidTargetWithoutCachedAncestor(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 
 	header := testHeaderBytes(0x43, 3)
 	for i := 4; i < 36; i++ {
@@ -477,7 +477,7 @@ func TestBlockStoreChainWorkRejectsInvalidTargetWithoutCachedAncestor(t *testing
 }
 
 func TestBlockStoreChainWorkParentCycle(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(7, 3)
 	hash := mustHeaderHash(t, header)
 	if err := store.StoreBlock(hash, header, []byte("blk")); err != nil {
@@ -505,7 +505,7 @@ func TestBlockStoreStoreBlockAndChainWorkErrors(t *testing.T) {
 		t.Fatalf("expected nil ChainWork error")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if _, err := store.ChainWork(hash); err == nil {
 		t.Fatalf("expected missing header error")
 	}
@@ -518,7 +518,7 @@ func TestBlockStoreStoreBlockAndChainWorkErrors(t *testing.T) {
 		t.Fatalf("expected invalid header parse error")
 	}
 
-	cycleStore := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "cycle"))
+	cycleStore := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "cycle"))
 	cycleHeader := append([]byte(nil), testHeaderBytes(8, 8)...)
 	cycleHash := mustHeaderHash(t, cycleHeader)
 	copy(cycleHeader[4:36], cycleHash[:])
@@ -573,7 +573,7 @@ func TestBlockStoreCanonicalStateHelpers(t *testing.T) {
 		t.Fatalf("nil dropCanonicalStateFromLocked: %v", err)
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	store.index.Canonical = []string{hex.EncodeToString(hash0[:]), hex.EncodeToString(hash1[:])}
 	store.canonicalHeightByHash = map[[32]byte]uint64{hash0: 0, hash1: 1}
 	store.chainWorkByHash = map[[32]byte]*big.Int{hash0: big.NewInt(10), hash1: big.NewInt(20)}
@@ -626,7 +626,7 @@ func TestBlockStoreCanonicalAndTruncateErrorBranches(t *testing.T) {
 		t.Fatalf("expected nil TruncateCanonical error")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	if err := store.TruncateCanonical(1); err == nil {
 		t.Fatalf("expected truncate out-of-range error")
 	}

--- a/clients/go/node/blockstore_commit_unix_test.go
+++ b/clients/go/node/blockstore_commit_unix_test.go
@@ -27,7 +27,7 @@ func TestCommitCanonicalBlock_DoesNotAdvanceTipWhenUndoWriteFails(t *testing.T) 
 		t.Skip("running as root: chmod-based permission check does not apply")
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(13, 13)
 	hash := mustHeaderHash(t, header)
 	blockBytes := []byte("blk")

--- a/clients/go/node/blockstore_p2p_test.go
+++ b/clients/go/node/blockstore_p2p_test.go
@@ -13,9 +13,9 @@ import (
 func setupBlockStoreForP2P(t *testing.T, blockCount int) (*BlockStore, *SyncEngine, *ChainState) {
 	t.Helper()
 	dir := t.TempDir()
-	bs, err := OpenBlockStore(BlockStorePath(dir))
+	bs, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	cs := NewChainState()
 	target := consensus.POW_LIMIT
@@ -90,7 +90,7 @@ func TestFindCanonicalHeight_NilBlockStore(t *testing.T) {
 }
 
 func TestFindCanonicalHeight_ReorgRebuildsCache(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	hash0, _ := mustPutBlock(t, store, 0, 0x10, 1, []byte("b0"))
 	hash1a, _ := mustPutBlock(t, store, 1, 0x11, 2, []byte("b1a"))
 	hash1b, _ := mustPutBlock(t, store, 1, 0x12, 3, []byte("b1b"))
@@ -121,7 +121,7 @@ func TestFindCanonicalHeight_ReorgRebuildsCache(t *testing.T) {
 }
 
 func TestFindCanonicalHeight_UsesCachedHeightAndRepairsStaleIndex(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	_, _ = mustPutBlock(t, store, 0, 0x20, 1, []byte("b0"))
 	hash1, _ := mustPutBlock(t, store, 1, 0x21, 2, []byte("b1"))
 
@@ -153,7 +153,7 @@ func TestFindCanonicalHeight_UsesCachedHeightAndRepairsStaleIndex(t *testing.T) 
 }
 
 func TestFindCanonicalHeight_PreservesCanonicalHashParsingSemantics(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	hash0, _ := mustPutBlock(t, store, 0, 0x30, 1, []byte("b0"))
 
 	store.index.Canonical[0] = strings.ToUpper(hex.EncodeToString(hash0[:]))

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -24,6 +24,15 @@ func mustOpenBlockStore(t *testing.T, path string) *BlockStore {
 	return store
 }
 
+func mustCreateBlockStore(t *testing.T, path string) *BlockStore {
+	t.Helper()
+	store, err := CreateBlockStore(path)
+	if err != nil {
+		t.Fatalf("create blockstore: %v", err)
+	}
+	return store
+}
+
 func assertNodePathMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)
@@ -54,9 +63,9 @@ func mustPutBlock(t *testing.T, store *BlockStore, height uint64, seed byte, non
 	return hash, header
 }
 
-func TestOpenBlockStoreCreatesPrivateDirsAndFiles(t *testing.T) {
+func TestCreateBlockStoreCreatesPrivateDirsAndFiles(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "blockstore")
-	store := mustOpenBlockStore(t, root)
+	store := mustCreateBlockStore(t, root)
 
 	assertNodePathMode(t, root, 0o700)
 	assertNodePathMode(t, store.blocksDir, 0o700)
@@ -87,7 +96,7 @@ func TestOpenBlockStoreCreatesPrivateDirsAndFiles(t *testing.T) {
 }
 
 func TestBlockStorePutGetAndTip(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	block0 := []byte("block-0")
 	hash0, _ := mustPutBlock(t, store, 0, 1, 11, block0)
 
@@ -129,7 +138,7 @@ func TestBlockStorePutGetAndTip(t *testing.T) {
 }
 
 func TestBlockStoreReorgAndRewindHooks(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	hash0, _ := mustPutBlock(t, store, 0, 10, 1, []byte("b0"))
 	_, _ = mustPutBlock(t, store, 1, 11, 2, []byte("b1a"))
 	hash1b, _ := mustPutBlock(t, store, 1, 12, 3, []byte("b1b"))
@@ -156,7 +165,7 @@ func TestBlockStoreReorgAndRewindHooks(t *testing.T) {
 }
 
 func TestBlockStoreRejectsHeightGap(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	header := testHeaderBytes(3, 33)
 	hash := mustHeaderHash(t, header)
 	if err := store.PutBlock(2, hash, header, []byte("gapped")); err == nil {
@@ -166,7 +175,7 @@ func TestBlockStoreRejectsHeightGap(t *testing.T) {
 
 func TestBlockStorePersistsIndex(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "blockstore")
-	store := mustOpenBlockStore(t, root)
+	store := mustCreateBlockStore(t, root)
 	hash, _ := mustPutBlock(t, store, 0, 7, 77, []byte("persist"))
 
 	var err error
@@ -410,7 +419,7 @@ func TestBlockStoreTipNil(t *testing.T) {
 }
 
 func TestBlockStoreTipEmptyOK(t *testing.T) {
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	_, _, ok, err := store.Tip()
 	if err != nil {
 		t.Fatalf("tip: %v", err)
@@ -442,4 +451,187 @@ func testHeaderBytes(seed byte, nonce uint64) []byte {
 	}
 	binary.LittleEndian.PutUint64(header[108:116], nonce)
 	return header
+}
+
+// fresh datadir whose blockstore root does NOT exist yet.
+func freshDataDir(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// Parity matrix row 1: create with root and chainstate absent commits the tree
+// plus the EXACT empty version-1 marker, and the store opens after. Rust mirror:
+// `create_store_commits_exact_empty_marker`.
+func TestCreateBlockStoreCommitsExactEmptyMarker(t *testing.T) {
+	root := BlockStorePath(freshDataDir(t))
+	store := mustCreateBlockStore(t, root)
+	if got, err := store.CanonicalIndexSnapshot(); err != nil || len(got) != 0 {
+		t.Fatalf("canonical snapshot = %v, %v, want empty", got, err)
+	}
+	for _, sub := range []string{"blocks", "headers", "undo"} {
+		if info, err := os.Stat(filepath.Join(root, sub)); err != nil || !info.IsDir() {
+			t.Fatalf("%s: info=%v err=%v, want directory", sub, info, err)
+		}
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "index.json")) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if want := "{\n  \"canonical\": [],\n  \"version\": 1\n}\n"; string(raw) != want {
+		t.Fatalf("marker = %q, want %q", raw, want)
+	}
+	mustOpenBlockStore(t, root)
+}
+
+// Parity matrix row 2 + rejected case "create overwrites": an existing root of
+// any kind is refused, and a PARTIAL root (no marker yet, i.e. a crash between
+// mkdir and the commit) is adopted by neither constructor. Rust mirror:
+// `create_store_rejects_existing_and_partial_root`.
+func TestCreateBlockStoreRejectsExistingAndPartialRoot(t *testing.T) {
+	root := BlockStorePath(freshDataDir(t))
+	mustCreateBlockStore(t, root)
+	seeded := filepath.Join(root, "blocks", "marker.bin")
+	if err := os.WriteFile(seeded, []byte("pre-existing"), 0o600); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+	if _, err := CreateBlockStore(root); err == nil {
+		t.Fatalf("second create must fail")
+	}
+	if _, err := os.Stat(seeded); err != nil {
+		t.Fatalf("existing root must not be overwritten or reset: %v", err)
+	}
+
+	partial := BlockStorePath(freshDataDir(t))
+	if err := os.Mkdir(partial, 0o700); err != nil {
+		t.Fatalf("partial root: %v", err)
+	}
+	if _, err := CreateBlockStore(partial); err == nil {
+		t.Fatalf("no resume of a partial root")
+	}
+	if _, err := OpenBlockStore(partial); err == nil {
+		t.Fatalf("no adoption of a partial root")
+	}
+}
+
+// Parity matrix rows 6-8: strict open never repairs and never creates. Rust
+// mirror: `open_existing_rejects_uninitialized_tree_without_mutating`.
+func TestOpenBlockStoreRejectsUninitializedTree(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		break_ func(t *testing.T, root string)
+	}{
+		{"missing_root", func(t *testing.T, root string) { mustRemoveAll(t, root) }},
+		{"missing_subdir", func(t *testing.T, root string) { mustRemoveAll(t, filepath.Join(root, "undo")) }},
+		{"missing_blocks", func(t *testing.T, root string) { mustRemoveAll(t, filepath.Join(root, "blocks")) }},
+		{"missing_headers", func(t *testing.T, root string) { mustRemoveAll(t, filepath.Join(root, "headers")) }},
+		{"missing_marker", func(t *testing.T, root string) { mustRemoveAll(t, filepath.Join(root, "index.json")) }},
+		{"root_is_file", func(t *testing.T, root string) {
+			mustRemoveAll(t, root)
+			if err := os.WriteFile(root, []byte("x"), 0o600); err != nil {
+				t.Fatalf("root as file: %v", err)
+			}
+		}},
+		{"marker_is_directory", func(t *testing.T, root string) {
+			marker := filepath.Join(root, "index.json")
+			mustRemoveAll(t, marker)
+			if err := os.Mkdir(marker, 0o700); err != nil {
+				t.Fatalf("marker as dir: %v", err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := BlockStorePath(freshDataDir(t))
+			mustCreateBlockStore(t, root)
+			tc.break_(t, root)
+			if _, err := OpenBlockStore(root); err == nil {
+				t.Fatalf("strict open must reject")
+			}
+			switch tc.name {
+			case "missing_root":
+				if _, err := os.Stat(root); !os.IsNotExist(err) {
+					t.Fatalf("strict open must not mkdir: %v", err)
+				}
+			case "missing_marker":
+				if _, err := os.Stat(filepath.Join(root, "index.json")); !os.IsNotExist(err) {
+					t.Fatalf("strict open must not synthesize a marker: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func mustRemoveAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("remove %s: %v", path, err)
+	}
+}
+
+// index_marker_validity as an executing table. Rust mirror:
+// `open_existing_rejects_malformed_marker_rows` pins the same rows.
+func TestOpenBlockStoreRejectsMalformedMarker(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	rejected := []struct{ name, body string }{
+		{"empty", ""},
+		{"not_an_object", "[]"},
+		{"missing_version", `{"canonical":[]}`},
+		{"missing_canonical", `{"version":1}`},
+		{"canonical_null", `{"version":1,"canonical":null}`},
+		{"unknown_field", `{"version":1,"canonical":[],"chain_id":"x"}`},
+		{"duplicate_version", `{"version":1,"version":1,"canonical":[]}`},
+		{"duplicate_canonical", `{"version":1,"canonical":[],"canonical":[]}`},
+		{"wrong_version", `{"version":2,"canonical":[]}`},
+		{"version_wrong_type", `{"version":"1","canonical":[]}`},
+		{"version_non_integer", `{"version":1.0,"canonical":[]}`},
+		{"canonical_wrong_type", `{"version":1,"canonical":{}}`},
+		{"entry_uppercase", `{"version":1,"canonical":["` + strings.ToUpper(hash) + `"]}`},
+		{"entry_short", `{"version":1,"canonical":["ab"]}`},
+		{"entry_not_hex", `{"version":1,"canonical":["` + strings.Repeat("z", 64) + `"]}`},
+		{"entry_wrong_type", `{"version":1,"canonical":[1]}`},
+		{"trailing_value", `{"version":1,"canonical":[]} {"version":1}`},
+	}
+	root := BlockStorePath(freshDataDir(t))
+	mustCreateBlockStore(t, root)
+	marker := filepath.Join(root, "index.json")
+	for _, tc := range rejected {
+		if err := os.WriteFile(marker, []byte(tc.body), 0o600); err != nil {
+			t.Fatalf("%s: write marker: %v", tc.name, err)
+		}
+		if _, err := OpenBlockStore(root); err == nil {
+			t.Fatalf("marker row %s must be rejected", tc.name)
+		}
+	}
+	// Accepted rows: the empty marker, and a well-formed lowercase entry in the
+	// opposite field order (the Rust writer emits version first).
+	for _, tc := range []struct {
+		body string
+		want int
+	}{
+		{`{"version":1,"canonical":[]}`, 0},
+		{`{"canonical":["` + hash + `"],"version":1}`, 1},
+	} {
+		if err := os.WriteFile(marker, []byte(tc.body), 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		store, err := OpenBlockStore(root)
+		if err != nil {
+			t.Fatalf("%s must be accepted: %v", tc.body, err)
+		}
+		if got, err := store.CanonicalIndexSnapshot(); err != nil || len(got) != tc.want {
+			t.Fatalf("canonical len = %v (%v), want %d", got, err, tc.want)
+		}
+	}
+}
+
+// Rule 10 at the LOADER layer: a missing marker must error even though the tree
+// check above it already rejects — no implicit empty index anywhere. Rust mirror:
+// `open_existing_marker_loader_never_synthesizes_empty_index`.
+func TestLoadBlockStoreIndexNeverSynthesizesEmptyIndex(t *testing.T) {
+	root := BlockStorePath(t.TempDir())
+	mustCreateBlockStore(t, root)
+	marker := filepath.Join(root, "index.json")
+	mustRemoveAll(t, marker)
+	if _, err := loadBlockStoreIndex(marker); err == nil {
+		t.Fatalf("missing marker must not decode as an empty index")
+	}
 }

--- a/clients/go/node/chainstate_recovery.go
+++ b/clients/go/node/chainstate_recovery.go
@@ -51,6 +51,14 @@ func truncateIncompleteCanonicalSuffix(store *BlockStore) (bool, error) {
 	return scanAndTruncateCanonicalSuffix(store)
 }
 
+// errCanonicalIndexZeroCompletePrefix: the canonical index claims blocks but not
+// even height 0 has a complete header/block/undo set. Truncating to zero would
+// silently discard the operator's whole chain, so this is fatal. Raised AFTER the
+// scan's structural/IO/corruption errors (they keep precedence) and BEFORE
+// TruncateCanonical, any chainstate reset/replay/save, and any service start.
+// Cross-client literal — Rust mirror CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR.
+var errCanonicalIndexZeroCompletePrefix = errors.New("persisted canonical index has zero complete prefix")
+
 func scanAndTruncateCanonicalSuffix(store *BlockStore) (bool, error) {
 	canonical, err := store.CanonicalIndexSnapshot()
 	if err != nil {
@@ -59,6 +67,9 @@ func scanAndTruncateCanonicalSuffix(store *BlockStore) (bool, error) {
 	validCount, err := countCompleteCanonicalPrefix(store, canonical)
 	if err != nil {
 		return false, err
+	}
+	if len(canonical) > 0 && validCount == 0 {
+		return false, errCanonicalIndexZeroCompletePrefix
 	}
 	if validCount == uint64(len(canonical)) {
 		return false, nil

--- a/clients/go/node/chainstate_recovery_test.go
+++ b/clients/go/node/chainstate_recovery_test.go
@@ -84,9 +84,9 @@ func TestCloneChainState_NilAndDeepCopy(t *testing.T) {
 func TestReconcileChainStateWithBlockStoreReplaysMissingCanonicalBlocks(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -128,9 +128,9 @@ func TestReconcileChainStateWithBlockStoreReplaysMissingCanonicalBlocks(t *testi
 func TestReconcileChainStateWithBlockStoreResetsMismatchedSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -171,9 +171,9 @@ func TestReconcileChainStateWithBlockStore_InputValidationAndNoopPaths(t *testin
 	}
 
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	changed, err := ReconcileChainStateWithBlockStore(state, store, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir)))
 	if err != nil {
@@ -206,7 +206,7 @@ func TestTruncateIncompleteCanonicalSuffix_InputValidation(t *testing.T) {
 		t.Fatalf("expected nil blockstore error")
 	}
 
-	store := mustOpenBlockStore(t, BlockStorePath(t.TempDir()))
+	store := mustCreateBlockStore(t, BlockStorePath(t.TempDir()))
 	store.index.Canonical = []string{"zz"}
 	if _, err := truncateIncompleteCanonicalSuffix(store); err == nil {
 		t.Fatalf("expected malformed canonical hash error")
@@ -216,9 +216,9 @@ func TestTruncateIncompleteCanonicalSuffix_InputValidation(t *testing.T) {
 func TestReconcileChainStateWithBlockStore_NoopForCanonicalTipAndResetsAheadSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -258,9 +258,9 @@ func TestReconcileChainStateWithBlockStore_NoopForCanonicalTipAndResetsAheadSnap
 func TestReconcileChainStateWithBlockStore_TruncatesIncompleteCanonicalSuffix(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -319,9 +319,9 @@ func TestReconcileChainStateWithBlockStore_TruncatesIncompleteCanonicalSuffix(t 
 func TestReconcileChainStateWithBlockStore_PropagatesCorruptCanonicalArtifact(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -373,7 +373,7 @@ func TestReconcileChainStateWithBlockStore_PropagatesCorruptCanonicalArtifact(t 
 
 func TestTruncateIncompleteCanonicalSuffix_PropagatesIndexWriteFailure(t *testing.T) {
 	dir := t.TempDir()
-	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	store := mustCreateBlockStore(t, BlockStorePath(dir))
 
 	target := consensus.POW_LIMIT
 	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir))
@@ -417,9 +417,9 @@ func TestTruncateIncompleteCanonicalSuffix_PropagatesIndexWriteFailure(t *testin
 func TestReconcileChainStateWithBlockStore_ResetsDirtyTiplessSnapshotBeforeReplay(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -470,9 +470,9 @@ func TestReconcileChainStateWithBlockStore_ResetsDirtyTiplessSnapshotBeforeRepla
 func TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT
@@ -529,5 +529,86 @@ func TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap(t *te
 	want := "canonical artifact corruption during chainstate replay at height 1"
 	if !strings.Contains(err.Error(), want) {
 		t.Fatalf("expected error containing %q, got %v", want, err)
+	}
+}
+
+// storeAtGenesis returns a fresh store holding the canonical devnet genesis at
+// height 0, plus the live chainstate and the sync config used to build it.
+func storeAtGenesis(t *testing.T, dir string) (*BlockStore, *ChainState, SyncConfig) {
+	t.Helper()
+	store, err := CreateBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	target := consensus.POW_LIMIT
+	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir))
+	state := NewChainState()
+	engine, err := NewSyncEngine(state, store, cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	return store, state, cfg
+}
+
+// B2 rules 5-6 + parity matrix row 12: a canonical index that claims blocks but
+// has NO complete artifact set at height 0 is fatal. The guard fires before
+// TruncateCanonical, before any chainstate reset/save, with the exact
+// cross-client message. Rust mirror:
+// `zero_complete_canonical_prefix_is_fatal_before_any_mutation`.
+func TestReconcileZeroCompleteCanonicalPrefixIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	store, liveState, cfg := storeAtGenesis(t, dir)
+	markerPath := filepath.Join(BlockStorePath(dir), "index.json")
+	if err := os.Remove(filepath.Join(store.headersDir, hex.EncodeToString(devnetGenesisBlockHash[:])+".bin")); err != nil {
+		t.Fatalf("Remove(genesis header): %v", err)
+	}
+	indexBefore, err := os.ReadFile(markerPath) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	state := cloneChainState(liveState)
+	before := state.view()
+
+	_, err = ReconcileChainStateWithBlockStore(state, store, cfg)
+	if !errors.Is(err, errCanonicalIndexZeroCompletePrefix) {
+		t.Fatalf("reconcile err = %v, want errCanonicalIndexZeroCompletePrefix", err)
+	}
+	if got, want := err.Error(), "persisted canonical index has zero complete prefix"; got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+	indexAfter, err := os.ReadFile(markerPath) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if string(indexAfter) != string(indexBefore) {
+		t.Fatalf("guard must fire before TruncateCanonical(0): marker changed")
+	}
+	if got, err := store.CanonicalIndexSnapshot(); err != nil || len(got) != 1 {
+		t.Fatalf("canonical index = %v (%v), want length 1", got, err)
+	}
+	if after := state.view(); after != before {
+		t.Fatalf("chainstate mutated before the guard: %+v -> %+v", before, after)
+	}
+}
+
+// B2 rule 3: a structural/corruption error keeps its ORIGINAL error and wins
+// over the zero-prefix guard even though the complete prefix is also zero. Rust
+// mirror: `zero_complete_canonical_prefix_loses_to_artifact_error`.
+func TestReconcileZeroCompletePrefixLosesToArtifactError(t *testing.T) {
+	dir := t.TempDir()
+	store, liveState, cfg := storeAtGenesis(t, dir)
+	undo := filepath.Join(store.undoDir, hex.EncodeToString(devnetGenesisBlockHash[:])+".json")
+	if err := os.WriteFile(undo, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("corrupt undo: %v", err)
+	}
+	_, err := ReconcileChainStateWithBlockStore(cloneChainState(liveState), store, cfg)
+	if err == nil {
+		t.Fatalf("corrupt artifact must fail")
+	}
+	if errors.Is(err, errCanonicalIndexZeroCompletePrefix) {
+		t.Fatalf("structural error must win over the zero-prefix guard, got %v", err)
 	}
 }

--- a/clients/go/node/coverage_sub80_residual4_test.go
+++ b/clients/go/node/coverage_sub80_residual4_test.go
@@ -56,9 +56,9 @@ func TestCoverageResidual4_SyncRollbackAndPersistHelpers(t *testing.T) {
 
 func TestCoverageResidual4_SyncStoreErrorBranches(t *testing.T) {
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	if _, err := testParentTipTimestamp(store, 1, [32]byte{0xaa}); err == nil {
@@ -86,9 +86,9 @@ func TestCoverageResidual4_SyncStoreErrorBranches(t *testing.T) {
 
 func TestCoverageResidual4_SyncAdditionalErrorBranches(t *testing.T) {
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	st := NewChainState()

--- a/clients/go/node/devnet_test.go
+++ b/clients/go/node/devnet_test.go
@@ -500,7 +500,7 @@ func newDevnetNodeWithMineAddress(
 	}
 	chainStatePath := node.ChainStatePath(dir)
 	chainState := node.NewChainState()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore %s: %v", name, err)
 	}

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -4045,7 +4045,7 @@ func TestMempoolAddTxHeightOverflow(t *testing.T) {
 func TestMempoolAddTxBlockMTPError(t *testing.T) {
 	// Empty blockStore + non-zero height → prevTimestampsFromStore fails.
 	dir := t.TempDir()
-	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	store := mustCreateBlockStore(t, BlockStorePath(dir))
 	st := &ChainState{HasTip: true, Height: 50}
 	mp, err := NewMempool(st, store, devnetGenesisChainID)
 	if err != nil {
@@ -4126,7 +4126,7 @@ func TestMempoolSelectByFee(t *testing.T) {
 
 func TestMinerMineOneSelectsFromMempool(t *testing.T) {
 	dir := t.TempDir()
-	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	store := mustCreateBlockStore(t, BlockStorePath(dir))
 
 	var tipHash [32]byte
 	for height := uint64(0); height <= 100; height++ {

--- a/clients/go/node/miner_additional_test.go
+++ b/clients/go/node/miner_additional_test.go
@@ -14,7 +14,7 @@ func TestNewMinerSetsDefaultMaxTxPerBlockWhenNonPositive(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestNewMinerRejectsNilChainState(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
 
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestNewMinerRejectsNilBlockStore(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestMinerMineOneReturnsContextError(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestMinerMineOneRejectsNonCanonicalTxBytesInInput(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestMinerBuildContextAndAssembleBlockBytes(t *testing.T) {
 	chainState.HasTip = true
 	chainState.Height = 7
 	chainState.TipHash = [32]byte{0x44}
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -323,7 +323,6 @@ func TestCanonicalCoinbaseWeightMatchesLegacyWeight(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -536,7 +535,7 @@ func TestMinerBuildContextUtxoMapDoesNotAliasChainStateMap(t *testing.T) {
 		CreatedByCoinbase: true,
 	}
 
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/miner_da_anchor_policy_test.go
+++ b/clients/go/node/miner_da_anchor_policy_test.go
@@ -148,7 +148,7 @@ func TestMinerPolicyRejectsNonCoinbaseAnchorOutputs(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("save chainstate: %v", err)
 	}
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -187,7 +187,6 @@ func TestMinerPolicyRejectsNonCoinbaseAnchorOutputs(t *testing.T) {
 	if mb.TxCount != 1 {
 		t.Fatalf("tx_count=%d, want 1 (coinbase only; non-coinbase CORE_ANCHOR must be filtered)", mb.TxCount)
 	}
-
 }
 
 func TestMinerPolicyCapsDaTemplateBytes(t *testing.T) {
@@ -197,7 +196,7 @@ func TestMinerPolicyCapsDaTemplateBytes(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("save chainstate: %v", err)
 	}
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/miner_test.go
+++ b/clients/go/node/miner_test.go
@@ -17,7 +17,7 @@ func TestMinerMineOneFromEmptyState(t *testing.T) {
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("save chainstate: %v", err)
 	}
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestMinerMineNProducesTimestampProgression(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestMinerMineOneRejectsHeightOverflow(t *testing.T) {
 		t.Fatalf("save chainstate: %v", err)
 	}
 
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestNewMinerSetsDefaultTimestampSourceWhenNil(t *testing.T) {
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestUnixNowU64ReturnsZeroWhenUnixTimeNonPositive(t *testing.T) {
 
 func TestNewMinerRejectsNilSyncEngine(t *testing.T) {
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(t.TempDir()))
+	blockStore, err := CreateBlockStore(BlockStorePath(t.TempDir()))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestMinerMineOneHeightOnePaysConfiguredMineAddressAndTracksCoinbaseMetadata
 	chainStatePath := ChainStatePath(dir)
 
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -1229,7 +1229,7 @@ func TestProcessCompactTransactionsRejectsAcceptedBlockMissingAfterApply(t *test
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newCompactScriptedPeer(t)
-			otherStore, err := node.OpenBlockStore(node.BlockStorePath(t.TempDir()))
+			otherStore, err := node.CreateBlockStore(node.BlockStorePath(t.TempDir()))
 			requireNoCompactErr(t, err, "open alternate blockstore")
 			p.service.cfg.BlockStore = otherStore
 
@@ -1646,9 +1646,9 @@ func peerStockDevnetTargetSchedule(p *peer) bool {
 func retargetPeerEngine(t *testing.T, p *peer, network string, chainID [32]byte) {
 	t.Helper()
 	dir := t.TempDir()
-	store, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	store, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	cfg := node.DefaultSyncConfig(nil, chainID, node.ChainStatePath(dir))
 	cfg.Network = network

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -1310,9 +1310,9 @@ func TestBlockBytesIOError(t *testing.T) {
 	// a non-ErrNotExist error from GetBlockByHash. This exercises the error
 	// propagation path in blockBytes (line: return nil, false, err).
 	dir := t.TempDir()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	// Replace the blocks directory with a regular file.

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -1477,9 +1477,9 @@ func newPeerRuntimeTestPeer(t *testing.T) *peer {
 	t.Helper()
 	dir := t.TempDir()
 	chainState := node.NewChainState()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncEngine, err := node.NewSyncEngine(
 		chainState,

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -3,10 +3,12 @@ package p2p
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 )
 
 type testHarness struct {
+	dataDir     string
 	peerManager *node.PeerManager
 	chainState  *node.ChainState
 	blockStore  *node.BlockStore
@@ -885,9 +888,9 @@ func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeer
 	dir := t.TempDir()
 	chainStatePath := node.ChainStatePath(dir)
 	chainState := node.NewChainState()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	syncCfg := node.DefaultSyncConfig(&target, node.DevnetGenesisChainID(), chainStatePath)
@@ -897,6 +900,7 @@ func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeer
 	}
 
 	h := &testHarness{
+		dataDir:     dir,
 		peerManager: node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8)),
 		chainState:  chainState,
 		blockStore:  blockStore,
@@ -1361,5 +1365,43 @@ func TestIsConsensusApplyBlockError(t *testing.T) {
 	}
 	if !isConsensusApplyBlockError(&consensus.TxError{Code: consensus.TX_ERR_PARSE, Msg: "bad block"}) {
 		t.Fatalf("consensus TxError must be treated as consensus error")
+	}
+}
+
+// B1 parity matrix rows 14-16: the Go behavioral reference for block presence.
+// Absence is only reported when a healthy lookup proves it; a local store fault
+// is an error, never absence. Rust mirror: `has_block_local_store_rows`.
+func TestServiceHasBlockLocalStoreRows(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	tip, _, ok, err := h.blockStore.Tip()
+	if err != nil || !ok {
+		t.Fatalf("tip = %d ok=%v err=%v", tip, ok, err)
+	}
+	_, tipHash, _, err := h.blockStore.Tip()
+	if err != nil {
+		t.Fatalf("tip hash: %v", err)
+	}
+
+	// Row 14: readable header -> present.
+	if have, err := h.service.hasBlock(tipHash); err != nil || !have {
+		t.Fatalf("readable header: have=%v err=%v, want true/nil", have, err)
+	}
+	// Row 15: healthy missing header -> absent, NOT an error.
+	if have, err := h.service.hasBlock([32]byte{0xab}); err != nil || have {
+		t.Fatalf("missing header: have=%v err=%v, want false/nil", have, err)
+	}
+	// Row 16: the header path exists but cannot be read -> error, not absence.
+	var unreadable [32]byte
+	unreadable[0] = 0x5a
+	leaf := filepath.Join(node.BlockStorePath(h.dataDir), "headers", hex.EncodeToString(unreadable[:])+".bin")
+	if err := os.Mkdir(leaf, 0o700); err != nil {
+		t.Fatalf("header leaf as directory: %v", err)
+	}
+	have, err := h.service.hasBlock(unreadable)
+	if err == nil {
+		t.Fatalf("a failed header read must not read as absence (have=%v)", have)
+	}
+	if os.IsNotExist(err) {
+		t.Fatalf("read failure must not be classified as NotFound: %v", err)
 	}
 }

--- a/clients/go/node/runtime_perf_baseline_test.go
+++ b/clients/go/node/runtime_perf_baseline_test.go
@@ -347,9 +347,9 @@ func BenchmarkMinerBuildContext(b *testing.B) {
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
 	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
-	blockStore, err := OpenBlockStore(BlockStorePath(b.TempDir()))
+	blockStore, err := CreateBlockStore(BlockStorePath(b.TempDir()))
 	if err != nil {
-		b.Fatalf("OpenBlockStore: %v", err)
+		b.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncEngine, err := NewSyncEngine(state, blockStore, DefaultSyncConfig(nil, [32]byte{}, ""))
 	if err != nil {
@@ -483,9 +483,9 @@ func benchmarkRecoveryReplayFixture(tb testing.TB, blocks int) (*BlockStore, Syn
 	tb.Helper()
 	dir := tb.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		tb.Fatalf("OpenBlockStore: %v", err)
+		tb.Fatalf("CreateBlockStore: %v", err)
 	}
 
 	target := consensus.POW_LIMIT

--- a/clients/go/node/sync_genesis_identity_test.go
+++ b/clients/go/node/sync_genesis_identity_test.go
@@ -60,7 +60,7 @@ func isGenesisHashMismatchTxError(err error) bool {
 func newGenesisIdentityTestEngine(t *testing.T, chainID [32]byte) *SyncEngine {
 	t.Helper()
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestSyncEngineBootstrapCanonicalGenesisIfEmpty_NilChainState(t *testing.T) 
 func newAliasingTestPair(t *testing.T, chainID [32]byte) (*SyncEngine, *ChainState, *BlockStore) {
 	t.Helper()
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -339,12 +339,12 @@ func TestNewMiner_RejectsMismatchedChainState(t *testing.T) {
 // timestamp context from the miner's separate blockStore.
 func TestNewMiner_RejectsMismatchedBlockStore(t *testing.T) {
 	dir := t.TempDir()
-	storeA, err := OpenBlockStore(BlockStorePath(dir))
+	storeA, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore A: %v", err)
 	}
 	otherDir := t.TempDir()
-	storeB, err := OpenBlockStore(BlockStorePath(otherDir))
+	storeB, err := CreateBlockStore(BlockStorePath(otherDir))
 	if err != nil {
 		t.Fatalf("open blockstore B: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestNewMiner_RejectsMismatchedBlockStore(t *testing.T) {
 // corruption that the production code must handle.
 func TestMinerMineOne_PropagatesBootstrapError(t *testing.T) {
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -138,9 +138,9 @@ func TestDeepReorg10(t *testing.T) {
 		t.Fatalf("LastReorgDepth()=%d, want 10", depth)
 	}
 
-	referenceStore, err := OpenBlockStore(BlockStorePath(t.TempDir()))
+	referenceStore, err := CreateBlockStore(BlockStorePath(t.TempDir()))
 	if err != nil {
-		t.Fatalf("OpenBlockStore(reference): %v", err)
+		t.Fatalf("CreateBlockStore(reference): %v", err)
 	}
 	referenceState := NewChainState()
 	referenceEngine, err := NewSyncEngine(referenceState, referenceStore, DefaultSyncConfig(&target, devnetGenesisChainID, ""))
@@ -256,7 +256,7 @@ func requireDirectTipStateUnchanged(t *testing.T, engine *SyncEngine, store *Blo
 
 func TestApplyBlockWithReorgDerivesDirectTipMTPWhenCallerContextNil(t *testing.T) {
 	dir := t.TempDir()
-	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	store := mustCreateBlockStore(t, BlockStorePath(dir))
 	target := consensus.POW_LIMIT
 	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir)))
 	if err != nil {
@@ -541,9 +541,9 @@ func TestApplyBlockWithReorgRejectsSideBranchTimestampContextBeforeStore(t *test
 func TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, devnetGenesisChainID, chainStatePath))
@@ -745,9 +745,9 @@ func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 	newEmptyEngine := func(t *testing.T, chainID [32]byte) *SyncEngine {
 		t.Helper()
 		dir := t.TempDir()
-		store, err := OpenBlockStore(BlockStorePath(dir))
+		store, err := CreateBlockStore(BlockStorePath(dir))
 		if err != nil {
-			t.Fatalf("OpenBlockStore: %v", err)
+			t.Fatalf("CreateBlockStore: %v", err)
 		}
 		engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, chainID, ChainStatePath(dir)))
 		if err != nil {
@@ -1504,9 +1504,9 @@ func TestSyncReorgHelperCoveragePaths(t *testing.T) {
 		t.Fatalf("testBlockStoreCanonicalCount(genesis)=(%d,%v), want (1,nil)", got, err)
 	}
 	emptyDir := t.TempDir()
-	emptyStore, err := OpenBlockStore(BlockStorePath(emptyDir))
+	emptyStore, err := CreateBlockStore(BlockStorePath(emptyDir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore(empty): %v", err)
+		t.Fatalf("CreateBlockStore(empty): %v", err)
 	}
 	emptyEngine, err := NewSyncEngine(NewChainState(), emptyStore, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(emptyDir)))
 	if err != nil {
@@ -1709,7 +1709,7 @@ func TestSyncApplyHelperAdditionalBranches(t *testing.T) {
 		t.Fatalf("testBlockStoreCanonicalIndexSnapshot(nil)=(%v,%v), want (nil,nil)", got, err)
 	}
 
-	store := mustOpenBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 	store.index.Canonical = []string{"zz"}
 	if _, err := testBlockStoreCanonicalIndexSnapshot(store); err == nil {
 		t.Fatalf("expected invalid canonical snapshot error")
@@ -1821,9 +1821,9 @@ func reorgTestCoinbaseForWtxids(t *testing.T, height uint64, value uint64, addre
 func newReorgTestEngine(t *testing.T) (*SyncEngine, *BlockStore, [32]byte) {
 	t.Helper()
 	dir := t.TempDir()
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	target := consensus.POW_LIMIT
 	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir)))

--- a/clients/go/node/sync_stderr_test.go
+++ b/clients/go/node/sync_stderr_test.go
@@ -39,9 +39,9 @@ func TestRequeueDisconnectedNoErrorOnCoinbaseOnly(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := DefaultSyncConfig(nil, [32]byte{}, chainStatePath)
 	engine, err := NewSyncEngine(chainState, blockStore, syncCfg)
@@ -89,9 +89,9 @@ func TestRequeueDisconnectedSkipsUnparseableBlocks(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := DefaultSyncConfig(nil, [32]byte{}, chainStatePath)
 	engine, err := NewSyncEngine(chainState, blockStore, syncCfg)
@@ -120,9 +120,9 @@ func TestApplyBlockMempoolEvictStderrPlumbing(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := DefaultSyncConfig(nil, [32]byte{}, chainStatePath)
 	engine, err := NewSyncEngine(chainState, blockStore, syncCfg)
@@ -168,9 +168,9 @@ func TestRequeueDisconnectedLogsAddTxError(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
 	chainState := NewChainState()
-	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
-		t.Fatalf("OpenBlockStore: %v", err)
+		t.Fatalf("CreateBlockStore: %v", err)
 	}
 	syncCfg := DefaultSyncConfig(nil, devnetGenesisChainID, chainStatePath)
 	engine, err := NewSyncEngine(chainState, blockStore, syncCfg)

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -396,7 +396,7 @@ func TestSyncEngineIBDLogic(t *testing.T) {
 func TestSyncEngineApplyBlockPersistsChainstateAndStore(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestSyncEngineApplyBlockPersistsChainstateAndStore(t *testing.T) {
 func TestSyncEngineBlockApplyCountsCanonicalAcceptedRejected(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}
@@ -605,7 +605,7 @@ func TestChainStateDisconnectBlockRestoresSpentUTXOState(t *testing.T) {
 func TestSyncEngineDisconnectTipPersistsChainstateAndStore(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/sync_unix_test.go
+++ b/clients/go/node/sync_unix_test.go
@@ -25,7 +25,7 @@ func TestSyncEngineApplyBlockPutUndoFailureRollsBackCanonicalTip(t *testing.T) {
 
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
-	store, err := OpenBlockStore(BlockStorePath(dir))
+	store, err := CreateBlockStore(BlockStorePath(dir))
 	if err != nil {
 		t.Fatalf("open blockstore: %v", err)
 	}

--- a/clients/go/node/target_schedule_runtime_test.go
+++ b/clients/go/node/target_schedule_runtime_test.go
@@ -20,7 +20,7 @@ const boundarySpacingSeconds = consensus.TARGET_BLOCK_INTERVAL / 2
 func newStockDevnetEngine(t *testing.T, mutate func(*SyncConfig)) (*SyncEngine, *BlockStore, string) {
 	t.Helper()
 	dir := t.TempDir()
-	store := mustOpenBlockStore(t, BlockStorePath(dir))
+	store := mustCreateBlockStore(t, BlockStorePath(dir))
 	cfg := DefaultSyncConfig(nil, devnetGenesisChainID, ChainStatePath(dir))
 	if mutate != nil {
 		mutate(&cfg)

--- a/clients/go/node/target_schedule_test.go
+++ b/clients/go/node/target_schedule_test.go
@@ -81,7 +81,7 @@ func TestExpectedTargetForCandidateInputContract(t *testing.T) {
 	}
 	target := [32]byte{0x40}
 	raw, parent := scheduleHeader(t, [32]byte{}, target, 1_000_000, 1)
-	store := mustOpenBlockStore(t, t.TempDir())
+	store := mustCreateBlockStore(t, BlockStorePath(t.TempDir()))
 	if err := store.PutBlock(0, parent, raw, raw); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}

--- a/clients/rust/crates/rubin-node/benches/bench_support.rs
+++ b/clients/rust/crates/rubin-node/benches/bench_support.rs
@@ -249,7 +249,7 @@ pub fn signed_transfer_tx(
 pub fn fresh_sync_engine(prefix: &str) -> SyncFixture {
     let dir = unique_temp_dir(prefix);
     let chain_state_file = chain_state_path(&dir);
-    let block_store = BlockStore::open(block_store_path(&dir)).expect("open block store");
+    let block_store = BlockStore::create(block_store_path(&dir)).expect("create block store");
     let chain_state = ChainState::new();
     chain_state
         .save(&chain_state_file)

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -49,38 +49,102 @@ pub struct BlockStore {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BlockStoreIndexDisk {
     version: u32,
     canonical: Vec<String>,
 }
 
-impl BlockStore {
-    pub fn open<P: Into<PathBuf>>(root_path: P) -> Result<Self, String> {
-        let root_path = root_path.into();
-        if root_path.as_os_str().is_empty() {
+struct BlockStorePaths {
+    root: PathBuf,
+    index: PathBuf,
+    blocks: PathBuf,
+    headers: PathBuf,
+    undo: PathBuf,
+}
+
+impl BlockStorePaths {
+    fn new(root: PathBuf) -> Result<Self, String> {
+        if root.as_os_str().is_empty() {
             return Err("blockstore root is required".to_string());
         }
+        Ok(Self {
+            index: root.join("index.json"),
+            blocks: root.join("blocks"),
+            headers: root.join("headers"),
+            undo: root.join("undo"),
+            root,
+        })
+    }
 
-        let index_path = root_path.join("index.json");
-        let blocks_dir = root_path.join("blocks");
-        let headers_dir = root_path.join("headers");
-        let undo_dir = root_path.join("undo");
+    /// Check the resolved filesystem kind of every path the store needs.
+    /// `metadata`, not `symlink_metadata`: symlinks resolve normally on open.
+    fn require_initialized(&self) -> Result<(), String> {
+        for dir in [&self.root, &self.blocks, &self.headers, &self.undo] {
+            let meta = fs::metadata(dir)
+                .map_err(|e| format!("blockstore directory {}: {e}", dir.display()))?;
+            if !meta.is_dir() {
+                return Err(format!(
+                    "blockstore path is not a directory: {}",
+                    dir.display()
+                ));
+            }
+        }
+        let meta = fs::metadata(&self.index)
+            .map_err(|e| format!("blockstore index {}: {e}", self.index.display()))?;
+        if !meta.is_file() {
+            return Err(format!(
+                "blockstore index is not a regular file: {}",
+                self.index.display()
+            ));
+        }
+        Ok(())
+    }
+}
 
-        fs::create_dir_all(&blocks_dir)
-            .map_err(|e| format!("create blockstore blocks {}: {e}", blocks_dir.display()))?;
-        fs::create_dir_all(&headers_dir)
-            .map_err(|e| format!("create blockstore headers {}: {e}", headers_dir.display()))?;
-        fs::create_dir_all(&undo_dir)
-            .map_err(|e| format!("create blockstore undo {}: {e}", undo_dir.display()))?;
+impl BlockStore {
+    /// Initialize a fresh blockstore at `root_path`: the only constructor that
+    /// writes. The root is created exclusively (an existing root of any kind
+    /// fails; two racing creates cannot both win) and `index.json` is written
+    /// LAST as the creation commit marker, so a crash before it leaves a partial
+    /// root both constructors reject. Owns only `root_path`, never chainstate.
+    /// Go mirror: `CreateBlockStore` in `clients/go/node/blockstore.go`.
+    pub fn create<P: Into<PathBuf>>(root_path: P) -> Result<Self, String> {
+        let paths = BlockStorePaths::new(root_path.into())?;
+        fs::create_dir(&paths.root)
+            .map_err(|e| format!("create blockstore root {}: {e}", paths.root.display()))?;
+        for dir in [&paths.blocks, &paths.headers, &paths.undo] {
+            fs::create_dir(dir)
+                .map_err(|e| format!("create blockstore directory {}: {e}", dir.display()))?;
+        }
+        let index = BlockStoreIndexDisk {
+            version: BLOCK_STORE_INDEX_VERSION,
+            canonical: vec![],
+        };
+        save_blockstore_index(&paths.index, &index)?;
+        Self::from_parts(paths, index)
+    }
 
-        let index = load_blockstore_index(&index_path)?;
+    /// Open an already-initialized blockstore. Strict: no mkdir, no marker
+    /// synthesis, no fallback. A missing root/subdirectory/marker, a malformed
+    /// marker, or a resolved path of the wrong kind is an error, never a fresh
+    /// empty store. Symlinks resolve normally; no path-identity claim is made.
+    /// Go mirror: `OpenBlockStore` in `clients/go/node/blockstore.go`.
+    pub fn open<P: Into<PathBuf>>(root_path: P) -> Result<Self, String> {
+        let paths = BlockStorePaths::new(root_path.into())?;
+        paths.require_initialized()?;
+        let index = load_blockstore_index(&paths.index)?;
+        Self::from_parts(paths, index)
+    }
+
+    fn from_parts(paths: BlockStorePaths, index: BlockStoreIndexDisk) -> Result<Self, String> {
         let canonical_hash_by_height = build_canonical_hash_cache(&index.canonical)?;
         Ok(Self {
-            root_path,
-            index_path,
-            blocks_dir,
-            headers_dir,
-            undo_dir,
+            root_path: paths.root,
+            index_path: paths.index,
+            blocks_dir: paths.blocks,
+            headers_dir: paths.headers,
+            undo_dir: paths.undo,
             index,
             canonical_hash_by_height,
             #[cfg(test)]
@@ -818,16 +882,13 @@ fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
             ));
         }
     };
-    let raw = match read_file_from_dir(parent, name) {
-        Ok(raw) => raw,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(BlockStoreIndexDisk {
-                version: BLOCK_STORE_INDEX_VERSION,
-                canonical: vec![],
-            });
-        }
-        Err(e) => return Err(format!("read blockstore index {}: {e}", path.display())),
-    };
+    // A missing marker is an error, never an implicit empty index.
+    let raw = read_file_from_dir(parent, name)
+        .map_err(|e| format!("read blockstore index {}: {e}", path.display()))?;
+    // `deny_unknown_fields` plus serde's duplicate/missing-field errors,
+    // `from_slice`'s trailing-input rejection and the entry check below pin the
+    // exact marker schema: exactly one `version` and one `canonical` field, in
+    // either order. Go mirror: `decodeBlockStoreIndex` in the Go blockstore.
     let index: BlockStoreIndexDisk = serde_json::from_slice(&raw)
         .map_err(|e| format!("decode blockstore index {}: {e}", path.display()))?;
     if index.version != BLOCK_STORE_INDEX_VERSION {
@@ -836,15 +897,24 @@ fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
             index.version
         ));
     }
-    // Canonical hash validation is performed in `build_canonical_hash_cache`
-    // when callers (e.g. `BlockStore::open`, `reload_index_from_disk`) build
-    // the height->hash cache from this index. Validating here would re-decode
-    // every canonical entry on cold start (one decode in this loop, another
-    // inside `build_canonical_hash_cache`); the cache build is the
-    // single sanctioned `parse_hex32` site for canonical entries. Any caller
-    // that consumes `index.canonical` strings without going through that
-    // helper is expected to keep its own validation discipline.
+    // Cheap string-shape check (no decode): `parse_hex32` in
+    // `build_canonical_hash_cache` accepts uppercase, the marker does not.
+    for (i, hash_hex) in index.canonical.iter().enumerate() {
+        if !valid_canonical_hash_hex(hash_hex) {
+            return Err(format!(
+                "canonical[{i}]: not 64 lowercase hex characters: {hash_hex:?}"
+            ));
+        }
+    }
     Ok(index)
+}
+
+/// The marker's exact entry shape: 64 lowercase hex characters.
+fn valid_canonical_hash_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c))
 }
 
 fn save_blockstore_index(path: &Path, index: &BlockStoreIndexDisk) -> Result<(), String> {
@@ -1027,6 +1097,7 @@ fn write_file_if_absent(path: &Path, content: &[u8]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use crate::io_utils::unique_temp_path;
+    use std::path::{Path, PathBuf};
 
     use super::{block_store_path, write_file_if_absent, BlockStore, BLOCK_STORE_DIR_NAME};
 
@@ -1154,13 +1225,14 @@ mod tests {
     #[test]
     fn blockstore_open_and_reopen() {
         let dir = unique_temp_path("rubin-blockstore-test");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
         assert_eq!(
             root.file_name().and_then(|s| s.to_str()),
             Some(BLOCK_STORE_DIR_NAME)
         );
 
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
         assert!(store.tip().expect("tip").is_none());
         store
             .set_canonical_tip(0, [0x11; 32])
@@ -1181,8 +1253,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-store");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let store = BlockStore::open(&root).expect("open");
+        let store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1208,8 +1281,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-cw");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let hash = block_hash(&genesis[..BLOCK_HEADER_BYTES]).expect("hash");
@@ -1231,8 +1305,9 @@ mod tests {
         use crate::undo::{BlockUndo, TxUndo};
 
         let dir = unique_temp_path("rubin-blockstore-undo");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let store = BlockStore::open(&root).expect("open");
+        let store = BlockStore::create(&root).expect("create");
 
         let undo = BlockUndo {
             block_height: 7,
@@ -1251,8 +1326,9 @@ mod tests {
     #[test]
     fn blockstore_truncate_and_canonical_len() {
         let dir = unique_temp_path("rubin-blockstore-trunc");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         store.set_canonical_tip(0, [0x11; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x22; 32]).expect("set 1");
@@ -1280,8 +1356,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-commit-happy");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1317,8 +1394,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-commit-undo-fail");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1383,8 +1461,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-commit-undo-mismatch");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1435,8 +1514,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-replay-backfill");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1484,8 +1564,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-commit-gap");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1541,8 +1622,9 @@ mod tests {
         use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
         let dir = unique_temp_path("rubin-blockstore-same-hash-replay");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         let genesis = devnet_genesis_block_bytes();
         let header = &genesis[..BLOCK_HEADER_BYTES];
@@ -1619,8 +1701,9 @@ mod tests {
     #[test]
     fn canonical_hash_cache_coherent_after_append_and_truncate() {
         let dir = unique_temp_path("rubin-blockstore-e7-cache-append-trunc");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         // Append three entries via the production hot path.
         store.set_canonical_tip(0, [0xA0; 32]).expect("set 0");
@@ -1656,8 +1739,9 @@ mod tests {
         // must follow exactly: a stale entry at the replaced height
         // is the rejected case.
         let dir = unique_temp_path("rubin-blockstore-e7-cache-replace");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         store.set_canonical_tip(0, [0x10; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x11; 32]).expect("set 1");
@@ -1677,8 +1761,9 @@ mod tests {
     #[test]
     fn canonical_hash_cache_coherent_after_rewind_to_height() {
         let dir = unique_temp_path("rubin-blockstore-e7-cache-rewind");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         store.set_canonical_tip(0, [0x21; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x22; 32]).expect("set 1");
@@ -1696,8 +1781,9 @@ mod tests {
     #[test]
     fn canonical_hash_cache_coherent_after_rollback_canonical() {
         let dir = unique_temp_path("rubin-blockstore-e7-cache-rollback");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
+        let mut store = BlockStore::create(&root).expect("create");
 
         store.set_canonical_tip(0, [0x30; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x31; 32]).expect("set 1");
@@ -1727,10 +1813,11 @@ mod tests {
         // store, and `canonical_hash` must return the right hash with
         // zero hex parses on the read path.
         let dir = unique_temp_path("rubin-blockstore-e7-cache-cold-open");
+        std::fs::create_dir_all(&dir).expect("create test dir");
         let root = block_store_path(&dir);
         let entries: Vec<[u8; 32]> = (0..16u8).map(|i| [i; 32]).collect();
         {
-            let mut store = BlockStore::open(&root).expect("open");
+            let mut store = BlockStore::create(&root).expect("create");
             for (i, h) in entries.iter().enumerate() {
                 store.set_canonical_tip(i as u64, *h).expect("set");
             }
@@ -1747,5 +1834,221 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Fresh temp datadir whose blockstore root does NOT exist yet.
+    fn fresh_datadir(prefix: &str) -> PathBuf {
+        let dir = unique_temp_path(prefix);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    /// Parity matrix row 1: create with root and chainstate absent commits the
+    /// tree plus the EXACT empty version-1 marker, and the store opens after.
+    #[test]
+    fn create_store_commits_exact_empty_marker() {
+        let dir = fresh_datadir("rubin-bs-create-marker");
+        let root = block_store_path(&dir);
+        let store = BlockStore::create(&root).expect("create");
+        assert_eq!(store.canonical_len(), 0);
+        for sub in ["blocks", "headers", "undo"] {
+            assert!(root.join(sub).is_dir(), "{sub} must be a directory");
+        }
+        let raw = std::fs::read_to_string(root.join("index.json")).expect("marker");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("marker json");
+        assert_eq!(parsed, serde_json::json!({"version": 1, "canonical": []}));
+        BlockStore::open(&root).expect("strict open of a freshly created store");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Parity matrix row 2 + rejected case "create overwrites": an existing root
+    /// of any kind is refused, and a PARTIAL root (no marker yet, i.e. a crash
+    /// between mkdir and the commit) is adopted by neither constructor.
+    #[test]
+    fn create_store_rejects_existing_and_partial_root() {
+        let dir = fresh_datadir("rubin-bs-create-existing");
+        let root = block_store_path(&dir);
+        BlockStore::create(&root).expect("first create");
+        std::fs::write(root.join("blocks").join("marker.bin"), b"pre-existing")
+            .expect("seed artifact");
+        let err = BlockStore::create(&root).expect_err("second create must fail");
+        assert!(err.contains("create blockstore root"), "{err}");
+        assert!(
+            root.join("blocks").join("marker.bin").exists(),
+            "existing root must not be overwritten or reset"
+        );
+
+        let partial = block_store_path(fresh_datadir("rubin-bs-partial"));
+        std::fs::create_dir(&partial).expect("partial root");
+        assert!(
+            BlockStore::create(&partial).is_err(),
+            "no resume of a partial root"
+        );
+        assert!(
+            BlockStore::open(&partial).is_err(),
+            "no adoption of a partial root"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Parity matrix rows 6-8: strict open never repairs and never creates.
+    #[test]
+    fn open_existing_rejects_uninitialized_tree_without_mutating() {
+        type BreakFn = fn(&Path);
+        let cases: [(&str, BreakFn); 7] = [
+            ("missing_root", |root| {
+                std::fs::remove_dir_all(root).expect("drop root");
+            }),
+            ("missing_subdir", |root| {
+                std::fs::remove_dir_all(root.join("undo")).expect("drop undo");
+            }),
+            ("missing_blocks", |root| {
+                std::fs::remove_dir_all(root.join("blocks")).expect("drop blocks");
+            }),
+            ("missing_headers", |root| {
+                std::fs::remove_dir_all(root.join("headers")).expect("drop headers");
+            }),
+            ("missing_marker", |root| {
+                std::fs::remove_file(root.join("index.json")).expect("drop marker");
+            }),
+            ("root_is_file", |root| {
+                std::fs::remove_dir_all(root).expect("drop root");
+                std::fs::write(root, b"x").expect("root as file");
+            }),
+            ("marker_is_directory", |root| {
+                std::fs::remove_file(root.join("index.json")).expect("drop marker");
+                std::fs::create_dir(root.join("index.json")).expect("marker as dir");
+            }),
+        ];
+        for (name, break_it) in cases {
+            let dir = fresh_datadir("rubin-bs-strict-open");
+            let root = block_store_path(&dir);
+            BlockStore::create(&root).expect("create");
+            break_it(&root);
+            let err = BlockStore::open(&root).expect_err("row {name} must reject");
+            assert!(!err.is_empty(), "row {name}");
+            if name == "missing_root" {
+                assert!(!root.exists(), "row {name}: strict open must not mkdir");
+            } else if name == "missing_marker" {
+                assert!(
+                    !root.join("index.json").exists(),
+                    "row {name}: strict open must not synthesize a marker"
+                );
+            }
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    /// index_marker_validity as an executing table. Every row must reject; the
+    /// Go mirror `TestOpenBlockStoreRejectsMalformedMarker` pins the same rows.
+    #[test]
+    fn open_existing_rejects_malformed_marker_rows() {
+        let hash = "a".repeat(64);
+        let rows: Vec<(&str, String)> = vec![
+            ("empty", String::new()),
+            ("not_an_object", "[]".to_string()),
+            ("missing_version", r#"{"canonical":[]}"#.to_string()),
+            ("missing_canonical", r#"{"version":1}"#.to_string()),
+            (
+                "canonical_null",
+                r#"{"version":1,"canonical":null}"#.to_string(),
+            ),
+            (
+                "unknown_field",
+                r#"{"version":1,"canonical":[],"chain_id":"x"}"#.to_string(),
+            ),
+            (
+                "duplicate_version",
+                r#"{"version":1,"version":1,"canonical":[]}"#.to_string(),
+            ),
+            (
+                "duplicate_canonical",
+                r#"{"version":1,"canonical":[],"canonical":[]}"#.to_string(),
+            ),
+            (
+                "wrong_version",
+                r#"{"version":2,"canonical":[]}"#.to_string(),
+            ),
+            (
+                "version_wrong_type",
+                r#"{"version":"1","canonical":[]}"#.to_string(),
+            ),
+            (
+                "version_non_integer",
+                r#"{"version":1.0,"canonical":[]}"#.to_string(),
+            ),
+            (
+                "canonical_wrong_type",
+                r#"{"version":1,"canonical":{}}"#.to_string(),
+            ),
+            (
+                "entry_uppercase",
+                format!(r#"{{"version":1,"canonical":["{}"]}}"#, hash.to_uppercase()),
+            ),
+            (
+                "entry_short",
+                r#"{"version":1,"canonical":["ab"]}"#.to_string(),
+            ),
+            (
+                "entry_not_hex",
+                format!(r#"{{"version":1,"canonical":["{}"]}}"#, "z".repeat(64)),
+            ),
+            (
+                "entry_wrong_type",
+                r#"{"version":1,"canonical":[1]}"#.to_string(),
+            ),
+            (
+                "trailing_value",
+                r#"{"version":1,"canonical":[]} {"version":1}"#.to_string(),
+            ),
+        ];
+        let dir = fresh_datadir("rubin-bs-marker-rows");
+        let root = block_store_path(&dir);
+        BlockStore::create(&root).expect("create");
+        for (name, body) in rows {
+            std::fs::write(root.join("index.json"), body.as_bytes()).expect("write marker");
+            assert!(
+                BlockStore::open(&root).is_err(),
+                "marker row {name} must be rejected"
+            );
+        }
+        // The accepted rows: empty marker, and a well-formed lowercase entry.
+        std::fs::write(root.join("index.json"), br#"{"version":1,"canonical":[]}"#)
+            .expect("write marker");
+        assert_eq!(
+            BlockStore::open(&root)
+                .expect("empty marker accepted")
+                .canonical_len(),
+            0
+        );
+        std::fs::write(
+            root.join("index.json"),
+            format!(r#"{{"canonical":["{hash}"],"version":1}}"#).as_bytes(),
+        )
+        .expect("write marker");
+        assert_eq!(
+            BlockStore::open(&root)
+                .expect("field order is free")
+                .canonical_len(),
+            1
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Rule 10 at the LOADER layer: a missing marker must error even though the
+    /// tree check above it already rejects — no implicit empty index anywhere.
+    /// Go mirror: `TestLoadBlockStoreIndexNeverSynthesizesEmptyIndex`.
+    #[test]
+    fn open_existing_marker_loader_never_synthesizes_empty_index() {
+        let dir = fresh_datadir("rubin-bs-loader");
+        let root = block_store_path(&dir);
+        BlockStore::create(&root).expect("create");
+        let marker = root.join("index.json");
+        std::fs::remove_file(&marker).expect("drop marker");
+        assert!(
+            super::load_blockstore_index(&marker).is_err(),
+            "missing marker must not decode as an empty index"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -172,12 +172,24 @@ pub(crate) fn truncate_incomplete_canonical_suffix(store: &mut BlockStore) -> Re
         store.get_undo(block_hash)?;
         valid_count += 1;
     }
+    if canonical_len > 0 && valid_count == 0 {
+        return Err(CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR.to_string());
+    }
     if valid_count == canonical_len {
         return Ok(false);
     }
     store.truncate_canonical(valid_count)?;
     Ok(true)
 }
+
+/// The canonical index claims blocks but not even height 0 has a complete
+/// header/block/undo set. Truncating to zero would silently discard the
+/// operator's whole chain, so this is fatal. Raised AFTER the scan's
+/// structural/IO/corruption errors (they keep precedence) and BEFORE
+/// `truncate_canonical`, any chainstate reset/replay/save, and any service start.
+/// Cross-client literal — Go mirror `errCanonicalIndexZeroCompletePrefix`.
+pub(crate) const CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR: &str =
+    "persisted canonical index has zero complete prefix";
 
 /// Reconcile the persisted chainstate snapshot against the on-disk
 /// canonical chain in `store`. Returns `Ok(true)` if any repair was
@@ -449,14 +461,16 @@ mod tests {
     use rubin_consensus::{block_hash, parse_block_bytes};
     use std::fs;
 
+    use super::CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR;
+
     fn fresh_dir(prefix: &str) -> std::path::PathBuf {
         let dir = unique_temp_path(prefix);
         fs::create_dir_all(&dir).expect("create test dir");
         dir
     }
 
-    fn open_store_in(dir: &std::path::Path) -> BlockStore {
-        BlockStore::open(block_store_path(dir)).expect("open blockstore")
+    fn create_store_in(dir: &std::path::Path) -> BlockStore {
+        BlockStore::create(block_store_path(dir)).expect("create blockstore")
     }
 
     fn devnet_cfg() -> SyncConfig {
@@ -484,7 +498,7 @@ mod tests {
     #[test]
     fn reconcile_empty_store_empty_state_is_noop() {
         let dir = fresh_dir("rubin-recover-empty");
-        let mut store = open_store_in(&dir);
+        let mut store = create_store_in(&dir);
         let mut state = ChainState::new();
         let cfg = devnet_cfg();
         let changed =
@@ -496,7 +510,7 @@ mod tests {
     #[test]
     fn reconcile_empty_store_dirty_state_resets_to_empty() {
         let dir = fresh_dir("rubin-recover-dirty");
-        let mut store = open_store_in(&dir);
+        let mut store = create_store_in(&dir);
         let mut state = ChainState::new();
         state.has_tip = true;
         state.height = 7;
@@ -517,7 +531,7 @@ mod tests {
     #[test]
     fn reconcile_noop_when_state_matches_canonical_tip() {
         let dir = fresh_dir("rubin-recover-noop");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (_genesis_hash, mut store, mut state) = apply_genesis(store);
         let cfg = devnet_cfg();
         let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
@@ -529,7 +543,7 @@ mod tests {
     #[test]
     fn reconcile_resets_mismatched_snapshot_at_genesis() {
         let dir = fresh_dir("rubin-recover-mismatch");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, mut state) = apply_genesis(store);
         // Corrupt the snapshot's tip hash so canonical(height) != tip.
         state.tip_hash[0] ^= 0xff;
@@ -546,7 +560,7 @@ mod tests {
     #[test]
     fn reconcile_resets_ahead_snapshot() {
         let dir = fresh_dir("rubin-recover-ahead");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, mut state) = apply_genesis(store);
         // Snapshot claims a height the blockstore does not have.
         state.height = 5;
@@ -615,7 +629,7 @@ mod tests {
     fn reconcile_replays_forward_from_matching_lower_height() {
         use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
         let dir = fresh_dir("rubin-recover-fwd-replay");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let cfg = devnet_cfg();
         let mut engine =
             SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
@@ -693,7 +707,7 @@ mod tests {
     fn reconcile_propagates_corrupt_canonical_block_artifact() {
         use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
         let dir = fresh_dir("rubin-recover-corrupt-block");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let cfg = devnet_cfg();
         let mut engine =
             SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
@@ -755,7 +769,7 @@ mod tests {
     fn prev_timestamps_from_store_matches_sync_engine() {
         use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
         let dir = fresh_dir("rubin-recover-prev-ts-parity");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let cfg = devnet_cfg();
         let mut engine =
             SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
@@ -793,7 +807,7 @@ mod tests {
     #[test]
     fn reconcile_truncates_when_block_data_missing() {
         let dir = fresh_dir("rubin-recover-trunc-block");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, mut state) = apply_genesis(store);
         // Header + undo present, block_data missing → truncate at L101.
         let _fake = synth_partial_artifact_at_height_1(&dir, &mut store, "block_data");
@@ -812,7 +826,7 @@ mod tests {
     #[test]
     fn reconcile_truncates_when_undo_missing() {
         let dir = fresh_dir("rubin-recover-trunc-undo");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, mut state) = apply_genesis(store);
         // Header + block_data present, undo missing → truncate at L105.
         let _fake = synth_partial_artifact_at_height_1(&dir, &mut store, "undo");
@@ -831,7 +845,7 @@ mod tests {
     #[test]
     fn reconcile_resets_tipless_dirty_state_with_canonical_chain() {
         let dir = fresh_dir("rubin-recover-tipless");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, _) = apply_genesis(store);
         // Build a fresh dirty-but-tipless state: has_tip=false but
         // utxos non-empty (the "stale dirty snapshot" residue path).
@@ -871,7 +885,7 @@ mod tests {
     fn truncate_propagates_metadata_eacces_instead_of_silent_truncate() {
         use std::os::unix::fs::PermissionsExt;
         let dir = fresh_dir("rubin-recover-eacces");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (_genesis_hash, mut store, _state) = apply_genesis(store);
         // Promote canonical to a fake height-1 entry whose artifact
         // dir we will chmod 0o000 to force EACCES on metadata().
@@ -916,7 +930,7 @@ mod tests {
     #[test]
     fn reconcile_truncates_incomplete_canonical_suffix() {
         let dir = fresh_dir("rubin-recover-truncate");
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (genesis_hash, mut store, mut state) = apply_genesis(store);
         // Synthesise a canonical entry at height 1 whose artifacts are
         // missing. We use `BlockStore::set_canonical_tip` with a hash
@@ -1098,7 +1112,7 @@ mod tests {
     fn reconcile_then_explicit_save_persists_snapshot_independent_of_gate() {
         let dir = fresh_dir("rubin-recover-explicit-save");
         let chain_state_file = crate::chainstate::chain_state_path(&dir);
-        let store = open_store_in(&dir);
+        let store = create_store_in(&dir);
         let (_genesis_hash, mut store, mut state) = apply_genesis(store);
         // Force the gate to its "skip" branch by faking a large UTxO
         // set + off-interval height; reconcile + explicit save must
@@ -1191,7 +1205,7 @@ mod tests {
         fs::write(root.join("headers").join(format!("{h1}.bin")), [0x00]).expect("corrupt header");
         let before = durable_state(&root);
 
-        let mut fresh = open_store_in(&dir);
+        let mut fresh = BlockStore::open(block_store_path(&dir)).expect("reopen blockstore");
         let mut state = at_genesis;
         let err = reconcile_chain_state_with_block_store(&mut state, &mut fresh, &cfg).unwrap_err();
         assert_eq!(err, "target schedule history corrupt");
@@ -1213,5 +1227,66 @@ mod tests {
         let counts = ["blocks", "headers", "undo"]
             .map(|name| fs::read_dir(root.join(name)).expect("artifact dir").count());
         (index, counts)
+    }
+
+    /// B2 rules 5-6 + parity matrix row 12: a canonical index that claims blocks
+    /// but has NO complete artifact set at height 0 is fatal. The guard must be
+    /// raised before truncate_canonical, before any chainstate reset/save, and
+    /// with the exact cross-client message. Go mirror:
+    /// `TestReconcileZeroCompleteCanonicalPrefixIsFatal`.
+    #[test]
+    fn zero_complete_canonical_prefix_is_fatal_before_any_mutation() {
+        let dir = fresh_dir("rubin-recover-zero-prefix");
+        let store = create_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        let root = block_store_path(&dir);
+        let leaf = format!("{}.bin", hex::encode(genesis_hash));
+        fs::remove_file(root.join("headers").join(&leaf)).expect("drop height-0 header");
+        let index_before = fs::read(root.join("index.json")).expect("index before");
+        let state_before = (state.height, state.tip_hash, state.has_tip);
+
+        let err = reconcile_chain_state_with_block_store(&mut state, &mut store, &devnet_cfg())
+            .expect_err("zero complete prefix must be fatal");
+        assert_eq!(err, CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR);
+        assert_eq!(err, "persisted canonical index has zero complete prefix");
+        assert_eq!(
+            fs::read(root.join("index.json")).expect("index after"),
+            index_before,
+            "guard must fire before TruncateCanonical(0)"
+        );
+        assert_eq!(
+            store.canonical_len(),
+            1,
+            "canonical index kept in memory too"
+        );
+        assert_eq!(
+            (state.height, state.tip_hash, state.has_tip),
+            state_before,
+            "no chainstate reset before the guard"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// B2 rule 3 + parity matrix precedence: a structural/corruption error keeps
+    /// its ORIGINAL error and wins over the zero-prefix guard, even though the
+    /// complete prefix is also zero. Go mirror:
+    /// `TestReconcileZeroCompletePrefixLosesToArtifactError`.
+    #[test]
+    fn zero_complete_canonical_prefix_loses_to_artifact_error() {
+        let dir = fresh_dir("rubin-recover-zero-prefix-precedence");
+        let store = create_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        let root = block_store_path(&dir);
+        let leaf = format!("{}.json", hex::encode(genesis_hash));
+        // Height 0 is present but its undo record does not parse: complete
+        // prefix is still zero, yet the parse error must be what surfaces.
+        fs::write(root.join("undo").join(&leaf), b"not json").expect("corrupt undo");
+        let err = reconcile_chain_state_with_block_store(&mut state, &mut store, &devnet_cfg())
+            .expect_err("corrupt artifact must fail");
+        assert_ne!(
+            err, CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR,
+            "structural error must win over the zero-prefix guard"
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/da_txgen.rs
+++ b/clients/rust/crates/rubin-node/src/da_txgen.rs
@@ -22,6 +22,7 @@
 //! wallet/key generation. The key material is devnet-only and ephemeral.
 
 use std::fs;
+use std::io;
 use std::path::Path;
 
 use rubin_consensus::constants::{
@@ -340,12 +341,34 @@ pub fn build_signed_da_set(
 /// signed DA set spending the matured coinbases. The keypair never leaves this
 /// process. Leaves a persisted devnet datadir (chainstate + blockstore) for
 /// downstream relay wiring (RUB-443).
+/// Create-mode rule 5 applied to this generator, BEFORE any datadir mutation.
+/// `mine_and_generate` commits a blockstore and then keeps working, so any later
+/// failure (bad chainstate tip, insufficient coinbase maturity, ...) used to
+/// leave an initialized root behind and every retry died on "root already
+/// exists". Refusing up front keeps a failed run retryable. `symlink_metadata`,
+/// not `metadata`, so a dangling symlink counts as present; the blockstore-root
+/// error wins when both paths exist.
+fn require_absent_for_generate(data_dir: &Path) -> Result<(), String> {
+    for (label, path) in [
+        ("blockstore root", block_store_path(data_dir)),
+        ("chainstate", chain_state_path(data_dir)),
+    ] {
+        match fs::symlink_metadata(&path) {
+            Ok(_) => return Err(format!("{label} already exists: {}", path.display())),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(format!("stat {label} {}: {err}", path.display())),
+        }
+    }
+    Ok(())
+}
+
 pub fn mine_and_generate(data_dir: &Path, mine_blocks: u64) -> Result<SignedDaSet, String> {
     let genesis = load_genesis_config(None, "devnet")?;
     let chain_id = genesis.chain_id;
     let keypair = Mldsa87Keypair::generate().map_err(|err| err.to_string())?;
     let mine_covenant_data = p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes());
 
+    require_absent_for_generate(data_dir)?;
     fs::create_dir_all(data_dir)
         .map_err(|err| format!("datadir create failed ({}): {err}", data_dir.display()))?;
     let chain_state_file = chain_state_path(data_dir);
@@ -504,5 +527,35 @@ mod tests {
 
     fn genesis_chain_id() -> [u8; 32] {
         crate::genesis::devnet_genesis_chain_id()
+    }
+
+    /// A failed generate must never poison the datadir. With a chainstate present
+    /// and no store (the shape a crashed/rejected run leaves behind), the
+    /// precondition refuses BEFORE any mutation: no blockstore is created, and a
+    /// SECOND call returns the identical refusal rather than "File exists".
+    /// The refusal precedes every read, so the chainstate bytes are irrelevant.
+    #[test]
+    fn mine_and_generate_refuses_existing_state_without_mutating_datadir() {
+        let dir = TempDir::new();
+        fs::create_dir_all(&dir.path).expect("mkdir datadir");
+        fs::write(chain_state_path(&dir.path), b"{}").expect("seed chainstate");
+
+        let first = mine_and_generate(&dir.path, DA_RELAY_BASE_HEIGHT)
+            .expect_err("an existing chainstate must refuse the run");
+        assert!(first.contains("chainstate already exists"), "{first}");
+        assert!(
+            !block_store_path(&dir.path).exists(),
+            "refusal must not create a blockstore root"
+        );
+
+        let second = mine_and_generate(&dir.path, DA_RELAY_BASE_HEIGHT)
+            .expect_err("the refusal must be idempotent");
+        assert_eq!(first, second, "retry must not degrade into a create error");
+
+        // The blockstore-root error wins when both paths exist.
+        fs::create_dir_all(block_store_path(&dir.path)).expect("mkdir root");
+        let both = mine_and_generate(&dir.path, DA_RELAY_BASE_HEIGHT)
+            .expect_err("an existing root must refuse the run");
+        assert!(both.contains("blockstore root already exists"), "{both}");
     }
 }

--- a/clients/rust/crates/rubin-node/src/da_txgen.rs
+++ b/clients/rust/crates/rubin-node/src/da_txgen.rs
@@ -350,7 +350,7 @@ pub fn mine_and_generate(data_dir: &Path, mine_blocks: u64) -> Result<SignedDaSe
         .map_err(|err| format!("datadir create failed ({}): {err}", data_dir.display()))?;
     let chain_state_file = chain_state_path(data_dir);
     let chain_state = load_chain_state(&chain_state_file)?;
-    let block_store = BlockStore::open(block_store_path(data_dir))?;
+    let block_store = BlockStore::create(block_store_path(data_dir))?;
 
     let mut sync_cfg = default_sync_config(None, chain_id, Some(chain_state_file.clone()));
     sync_cfg.suite_context = genesis.suite_context.clone();

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2884,7 +2884,7 @@ mod tests {
     fn build_state(with_genesis: bool) -> (super::DevnetRPCState, PathBuf) {
         let dir = unique_temp_path("rubin-devnet-rpc");
         fs::create_dir_all(&dir).expect("mkdir");
-        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let block_store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(block_store.clone()),
@@ -2910,7 +2910,7 @@ mod tests {
     fn build_state_with_live_mining(with_genesis: bool) -> (super::DevnetRPCState, PathBuf) {
         let dir = unique_temp_path("rubin-devnet-rpc-live");
         fs::create_dir_all(&dir).expect("mkdir");
-        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let block_store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(block_store.clone()),
@@ -5783,7 +5783,7 @@ mod tests {
     fn concurrent_connections_are_handled() {
         let dir = unique_temp_path("rubin-concurrent-rpc");
         fs::create_dir_all(&dir).expect("mkdir");
-        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let block_store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(block_store.clone()),
@@ -5831,7 +5831,7 @@ mod tests {
     fn excess_connections_are_dropped_at_capacity() {
         let dir = unique_temp_path("rubin-capacity-rpc");
         fs::create_dir_all(&dir).expect("mkdir");
-        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let block_store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(block_store.clone()),

--- a/clients/rust/crates/rubin-node/src/interop/mod.rs
+++ b/clients/rust/crates/rubin-node/src/interop/mod.rs
@@ -233,8 +233,9 @@ pub fn run_action(session: &mut PeerSession, action: &Action) -> io::Result<()> 
         }
         Action::SyncBlocks => {
             let mut data_dir = unique_interop_temp_dir();
+            fs::create_dir_all(&data_dir)?;
             let block_store =
-                BlockStore::open(block_store_path(&data_dir)).map_err(io::Error::other)?;
+                BlockStore::create(block_store_path(&data_dir)).map_err(io::Error::other)?;
             let chain_state_path = chain_state_path(&data_dir);
             let mut cfg = default_sync_config(
                 Some(POW_LIMIT),
@@ -713,7 +714,8 @@ mod tests {
                 let block = devnet_genesis_block_bytes();
                 let block_hash_bytes =
                     block_hash(&block[..BLOCK_HEADER_BYTES]).map_err(|err| err.to_string())?;
-                let mut store = BlockStore::open(block_store_path(&server_dir))?;
+                std::fs::create_dir_all(&server_dir).map_err(|err| err.to_string())?;
+                let mut store = BlockStore::create(block_store_path(&server_dir))?;
                 store.put_block(0, block_hash_bytes, &block[..BLOCK_HEADER_BYTES], &block)?;
 
                 let mut cfg = default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), None);

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -43,6 +43,7 @@ struct CliConfig {
     legacy_suite_ids: Vec<u8>,
     legacy_exposure_include_outpoints: bool,
     dry_run: bool,
+    create_store: bool,
 }
 
 #[derive(Serialize)]
@@ -139,6 +140,55 @@ fn load_legacy_exposure_scan_chain_state(
     Ok(chain_state)
 }
 
+/// Select the explicit create path or the strict open-existing path. In create
+/// mode the CLI owns the preconditions: the blockstore root must be absent (its
+/// error wins) and the chainstate must be absent, both checked before the datadir
+/// or any store artifact is created.
+fn create_or_open_block_store(
+    cfg: &CliConfig,
+    chain_state_file: &Path,
+    stderr: &mut dyn Write,
+) -> Result<BlockStore, i32> {
+    let root_path = block_store_path(&cfg.data_dir);
+    if !cfg.create_store {
+        return BlockStore::open(root_path).map_err(|err| {
+            let _ = writeln!(stderr, "blockstore open failed: {err}");
+            2
+        });
+    }
+    for (label, path) in [
+        ("blockstore root", root_path.as_path()),
+        ("chainstate", chain_state_file),
+    ] {
+        if let Err(err) = require_absent_path(label, path) {
+            let _ = writeln!(stderr, "blockstore create failed: {err}");
+            return Err(2);
+        }
+    }
+    if let Err(err) = fs::create_dir_all(&cfg.data_dir) {
+        let _ = writeln!(
+            stderr,
+            "datadir create failed ({}): {err}",
+            cfg.data_dir.display()
+        );
+        return Err(2);
+    }
+    BlockStore::create(root_path).map_err(|err| {
+        let _ = writeln!(stderr, "blockstore create failed: {err}");
+        2
+    })
+}
+
+/// Reject any existing filesystem entry at `path`. `symlink_metadata`, not
+/// `metadata`, so a dangling symlink counts as present rather than as not-found.
+fn require_absent_path(label: &str, path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Err(format!("{label} already exists: {}", path.display())),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("stat {label} {}: {err}", path.display())),
+    }
+}
+
 fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     if args.iter().any(|arg| arg == "-h" || arg == "--help") {
         usage(stdout);
@@ -157,6 +207,18 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         return 2;
     }
 
+    // --create-store is a storage-mutating mode; --dry-run and
+    // --legacy-exposure-scan are read-only modes. Reject the combination here,
+    // after the existing config/legacy-suite validation and before genesis
+    // loading, the legacy scan's chainstate read, and every filesystem write,
+    // so the process exits 2 on an untouched filesystem.
+    if cfg.create_store && (cfg.dry_run || cfg.legacy_exposure_scan) {
+        let _ = writeln!(
+            stderr,
+            "--create-store cannot be combined with --dry-run or --legacy-exposure-scan"
+        );
+        return 2;
+    }
     let chain_state_file = chain_state_path(&cfg.data_dir);
     if cfg.legacy_exposure_scan {
         let chain_state = match load_legacy_exposure_scan_chain_state(&chain_state_file, stderr) {
@@ -186,14 +248,24 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             return 2;
         }
     };
-    if let Err(err) = fs::create_dir_all(&cfg.data_dir) {
-        let _ = writeln!(
-            stderr,
-            "datadir create failed ({}): {err}",
-            cfg.data_dir.display()
-        );
+    // Identity guards run BEFORE the storage lifecycle so a misconfigured
+    // network rejects on an untouched filesystem, mirroring the Go ordering in
+    // `clients/go/cmd/rubin-node/main.go` (guard, then createOrOpenBlockStore).
+    // The guard reads only `network`. `SyncEngine::new` re-runs it on the final
+    // SyncConfig for embedded callers — that inner call is not a duplicate.
+    let mut guard_cfg = default_sync_config(None, genesis_cfg.chain_id, None);
+    guard_cfg.network = cfg.network.clone();
+    if let Err(err) = validate_mainnet_genesis_guard(&guard_cfg) {
+        let _ = writeln!(stderr, "mainnet genesis guard failed: {err}");
         return 2;
     }
+    // Storage lifecycle runs BEFORE the chainstate load: an uninitialized or
+    // half-initialized store must reject before anything reads or writes
+    // chainstate. Ordinary startup performs no mkdir at all.
+    let mut block_store = match create_or_open_block_store(&cfg, &chain_state_file, stderr) {
+        Ok(block_store) => block_store,
+        Err(code) => return code,
+    };
     let mut chain_state = match load_chain_state(&chain_state_file) {
         Ok(chain_state) => chain_state,
         Err(err) => {
@@ -207,35 +279,11 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     };
     let chain_id = genesis_cfg.chain_id;
 
-    let mut block_store = match BlockStore::open(block_store_path(&cfg.data_dir)) {
-        Ok(block_store) => block_store,
-        Err(err) => {
-            let _ = writeln!(stderr, "blockstore open failed: {err}");
-            return 2;
-        }
-    };
-
     let mut sync_cfg = default_sync_config(None, chain_id, Some(chain_state_file.clone()));
     sync_cfg.network = cfg.network.clone();
     sync_cfg.suite_context = genesis_cfg.suite_context.clone();
     sync_cfg.parallel_validation_mode = cfg.pv_mode.clone();
     sync_cfg.pv_shadow_max_samples = cfg.pv_shadow_max;
-
-    // Mainnet target / genesis guard runs BEFORE reconcile so a
-    // misconfigured `--network mainnet` startup is rejected before
-    // any reconcile-driven state mutation: reconcile may rewrite
-    // chainstate via truncate / replay, and we must not touch persisted
-    // state when the network config itself is invalid. `SyncEngine::new`
-    // runs the same guard internally as defence-in-depth: it re-validates
-    // the final `SyncConfig` actually passed to the engine, catching any
-    // mutation between this early call and engine construction. For
-    // callers that construct `SyncEngine` directly (tests, embedded uses)
-    // it is the ONLY guard. Do not remove the inner call as a perceived
-    // duplicate. Devnet / test networks no-op.
-    if let Err(err) = validate_mainnet_genesis_guard(&sync_cfg) {
-        let _ = writeln!(stderr, "mainnet genesis guard failed: {err}");
-        return 2;
-    }
 
     // Startup reconcile (E.2): repair any chainstate ↔ blockstore
     // mismatch left by a crash (incomplete canonical suffix, stale
@@ -794,6 +842,7 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         legacy_suite_ids: Vec::new(),
         legacy_exposure_include_outpoints: false,
         dry_run: false,
+        create_store: false,
     };
     let mut peer_tokens = Vec::new();
 
@@ -909,6 +958,9 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
             "--dry-run" => {
                 cfg.dry_run = true;
             }
+            "--create-store" => {
+                cfg.create_store = true;
+            }
             unknown => {
                 return Err(format!("unknown flag: {unknown}"));
             }
@@ -932,7 +984,7 @@ fn default_data_dir() -> PathBuf {
 fn usage(stdout: &mut dyn Write) {
     let _ = writeln!(
         stdout,
-        "usage: rubin-node [--network <name>] [--datadir <path>] [--genesis-file <path>] [--bind <host:port>] [--peer <host:port>]... [--peers <csv>] [--max-peers <n>] [--rpc-bind <host:port>] [--mine-address <hex>] [--mine-blocks <n>] [--mine-exit] [--pv-mode <off|shadow|on>] [--pv-shadow-max <n>] [--legacy-exposure-scan] [--legacy-suite-id <id>]... [--legacy-exposure-include-outpoints] [--dry-run]"
+        "usage: rubin-node [--network <name>] [--datadir <path>] [--genesis-file <path>] [--bind <host:port>] [--peer <host:port>]... [--peers <csv>] [--max-peers <n>] [--rpc-bind <host:port>] [--mine-address <hex>] [--mine-blocks <n>] [--mine-exit] [--pv-mode <off|shadow|on>] [--pv-shadow-max <n>] [--legacy-exposure-scan] [--legacy-suite-id <id>]... [--legacy-exposure-include-outpoints] [--dry-run] [--create-store]"
     );
 }
 
@@ -1984,6 +2036,7 @@ mod tests {
     #[test]
     fn dry_run_defaults_to_devnet_chain_id() {
         let dir = unique_temp_dir("rubin-node-bin-default");
+        seed_block_store(&dir);
         let args = vec![
             "--dry-run".to_string(),
             "--datadir".to_string(),
@@ -2008,6 +2061,7 @@ mod tests {
     fn dry_run_loads_chain_id_from_genesis_file() {
         let dir = unique_temp_dir("rubin-node-bin-genesis");
         fs::create_dir_all(&dir).expect("mkdir");
+        seed_block_store(&dir);
         let genesis_file = dir.join("genesis.json");
         fs::write(
             &genesis_file,
@@ -2383,6 +2437,7 @@ mod tests {
     #[test]
     fn dry_run_emits_rpc_bind_when_present() {
         let dir = unique_temp_dir("rubin-node-bin-rpc-bind");
+        seed_block_store(&dir);
         let args = vec![
             "--dry-run".to_string(),
             "--datadir".to_string(),
@@ -2404,6 +2459,7 @@ mod tests {
     #[test]
     fn dry_run_emits_p2p_runtime_fields() {
         let dir = unique_temp_dir("rubin-node-bin-p2p-runtime");
+        seed_block_store(&dir);
         let args = vec![
             "--dry-run".to_string(),
             "--datadir".to_string(),
@@ -2431,6 +2487,7 @@ mod tests {
     #[test]
     fn dry_run_emits_pv_fields() {
         let dir = unique_temp_dir("rubin-node-bin-pv");
+        seed_block_store(&dir);
         let args = vec![
             "--dry-run".to_string(),
             "--datadir".to_string(),
@@ -2470,6 +2527,7 @@ mod tests {
     #[test]
     fn dry_run_emits_sync_and_peer_slots_banners_after_json_in_order() {
         let dir = unique_temp_dir("rubin-node-bin-banners");
+        seed_block_store(&dir);
         let args = vec![
             "--dry-run".to_string(),
             "--datadir".to_string(),
@@ -3067,6 +3125,7 @@ mod tests {
     fn mine_exit_mines_requested_blocks_and_returns_zero() {
         let dir = unique_temp_dir("rubin-node-bin-mine-exit");
         let args = vec![
+            "--create-store".to_string(),
             "--datadir".to_string(),
             dir.display().to_string(),
             "--mine-blocks".to_string(),
@@ -3151,5 +3210,214 @@ mod tests {
     fn validate_addr_accepts_valid_hostname() {
         assert!(super::validate_addr_inner("test", "node-1.example.com:8333", false).is_ok());
         assert!(super::validate_addr_inner("test", "a.b.c:19111", false).is_ok());
+    }
+
+    use rubin_node::{block_store_path, chain_state_path, BlockStore};
+
+    /// Initialize a store the way an operator would with --create-store, for
+    /// tests whose subject is a later startup step. Go mirror: `seedBlockStore`
+    /// in `clients/go/cmd/rubin-node/main_test.go`.
+    fn seed_block_store(data_dir: &std::path::Path) {
+        fs::create_dir_all(data_dir).expect("mkdir datadir");
+        BlockStore::create(block_store_path(data_dir)).expect("create block store");
+    }
+
+    fn cli(args: &[&str]) -> (i32, String) {
+        let owned: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+        let (mut out, mut err) = (Vec::new(), Vec::new());
+        let code = run(&owned, &mut out, &mut err);
+        (code, String::from_utf8_lossy(&err).to_string())
+    }
+
+    /// create_open_state_machine rule 2 + parity row 4: --create-store is
+    /// incompatible with the read-only modes and rejects before any filesystem
+    /// access. Go mirror: `TestRunCreateStoreRejectsFlagCombinationsBeforeStorage`.
+    #[test]
+    fn create_store_rejects_flag_combinations_before_any_storage_access() {
+        for extra in [
+            vec!["--dry-run"],
+            vec!["--legacy-exposure-scan", "--legacy-suite-id", "1"],
+        ] {
+            let dir = unique_temp_dir("rubin-node-create-flags");
+            let d = dir.display().to_string();
+            let mut args = vec!["--datadir", d.as_str(), "--create-store"];
+            args.extend(extra.iter().copied());
+            let (code, err) = cli(&args);
+            assert_eq!(code, 2, "{extra:?}");
+            assert!(
+                err.contains(
+                    "--create-store cannot be combined with --dry-run or --legacy-exposure-scan"
+                ),
+                "{extra:?}: {err}"
+            );
+            assert!(
+                !dir.exists(),
+                "{extra:?}: no filesystem entry may be created"
+            );
+        }
+    }
+
+    /// Parity rows 1-3 + rejected cases: create commits the tree, refuses an
+    /// existing root (whose error wins over chainstate), refuses an existing
+    /// chainstate without touching the root. Go mirror:
+    /// `TestRunCreateStoreCreatesTreeAndRejectsExisting`.
+    #[test]
+    fn create_store_creates_tree_and_rejects_existing_root_or_chainstate() {
+        fn mk(d: &str) -> Vec<&str> {
+            vec![
+                "--datadir",
+                d,
+                "--create-store",
+                "--mine-blocks",
+                "1",
+                "--mine-exit",
+            ]
+        }
+
+        let dir = unique_temp_dir("rubin-node-create-tree");
+        let d = dir.display().to_string();
+        let (code, err) = cli(&mk(&d));
+        assert_eq!(code, 0, "{err}");
+        let root = block_store_path(&dir);
+        for sub in ["blocks", "headers", "undo"] {
+            assert!(root.join(sub).is_dir());
+        }
+        assert!(root.join("index.json").is_file());
+
+        // Re-create: root exists -> refused, existing store untouched.
+        let marker_before = fs::read(root.join("index.json")).expect("marker");
+        let (code, err) = cli(&mk(&d));
+        assert_eq!(code, 2);
+        assert!(err.contains("blockstore root already exists"), "{err}");
+        assert_eq!(
+            fs::read(root.join("index.json")).expect("marker"),
+            marker_before
+        );
+
+        // Chainstate present, root absent -> refused BEFORE the root is created.
+        let cs = unique_temp_dir("rubin-node-create-chainstate");
+        fs::create_dir_all(&cs).expect("mkdir");
+        fs::write(chain_state_path(&cs), b"{}").expect("seed chainstate");
+        let (code, err) = cli(&mk(&cs.display().to_string()));
+        assert_eq!(code, 2);
+        assert!(err.contains("chainstate already exists"), "{err}");
+        assert!(!block_store_path(&cs).exists(), "root must not be created");
+
+        // Both present -> the blockstore-root error wins.
+        let both = unique_temp_dir("rubin-node-create-both");
+        fs::create_dir_all(block_store_path(&both)).expect("mkdir root");
+        fs::write(chain_state_path(&both), b"{}").expect("seed chainstate");
+        let (code, err) = cli(&mk(&both.display().to_string()));
+        assert_eq!(code, 2);
+        assert!(err.contains("blockstore root already exists"), "{err}");
+
+        // hostile: a DANGLING symlink at either path is present (lstat), not absent.
+        #[cfg(unix)]
+        for target in ["blockstore root", "chainstate"] {
+            let d = unique_temp_dir("rubin-node-create-dangling");
+            fs::create_dir_all(&d).expect("mkdir");
+            let link = if target == "chainstate" {
+                chain_state_path(&d)
+            } else {
+                block_store_path(&d)
+            };
+            std::os::unix::fs::symlink(d.join("nowhere"), &link).expect("dangling symlink");
+            let (code, err) = cli(&mk(&d.display().to_string()));
+            assert_eq!(code, 2, "dangling {target}: {err}");
+            assert!(err.contains(&format!("{target} already exists")), "{err}");
+            let _ = fs::remove_dir_all(&d);
+        }
+
+        for x in [&dir, &cs, &both] {
+            let _ = fs::remove_dir_all(x);
+        }
+    }
+
+    /// Parity rows 5-9: ordinary startup strictly opens. A missing store errors
+    /// with NO mkdir; the legacy scan without --create-store keeps its
+    /// chainstate-only flow; after an explicit create the same startup succeeds.
+    /// Go mirror: `TestRunOpenExistingStartupDoesNotSynthesizeStore`.
+    #[test]
+    fn open_existing_startup_never_synthesizes_a_store() {
+        let dir = unique_temp_dir("rubin-node-open-existing");
+        let d = dir.display().to_string();
+
+        let (code, err) = cli(&["--datadir", &d, "--dry-run"]);
+        assert_eq!(code, 2);
+        assert!(err.contains("blockstore open failed"), "{err}");
+        assert!(
+            !dir.exists(),
+            "ordinary startup must not create the datadir"
+        );
+
+        let (code, err) = cli(&[
+            "--datadir",
+            &d,
+            "--legacy-exposure-scan",
+            "--legacy-suite-id",
+            "1",
+        ]);
+        assert_eq!(code, 2);
+        assert!(
+            err.contains("legacy exposure scan requires an existing chainstate"),
+            "{err}"
+        );
+        assert!(!dir.exists(), "legacy scan must not create a store");
+
+        let (code, err) = cli(&[
+            "--datadir",
+            &d,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ]);
+        assert_eq!(code, 0, "{err}");
+        let (code, err) = cli(&["--datadir", &d, "--dry-run"]);
+        assert_eq!(code, 0, "{err}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// FIX-1 / state machine rule 4: identity guards precede the storage
+    /// lifecycle, so a misconfigured network rejects on an untouched
+    /// filesystem in BOTH modes. Go mirror:
+    /// `TestRunMainnetFailsBeforeReconcilingChainState` ordering.
+    #[test]
+    fn create_store_mainnet_guard_rejects_before_storage() {
+        let genesis = unique_temp_dir("rubin-node-mainnet-guard-genesis");
+        fs::create_dir_all(&genesis).expect("mkdir");
+        let genesis_file = genesis.join("genesis.json");
+        fs::write(&genesis_file, "{\"chain_id_hex\":\"0x1111111111111111111111111111111111111111111111111111111111111111\"}")
+            .expect("write genesis");
+        let gf = genesis_file.display().to_string();
+
+        for create in [true, false] {
+            let dir = unique_temp_dir("rubin-node-mainnet-guard");
+            let d = dir.display().to_string();
+            let mut args = vec![
+                "--network",
+                "mainnet",
+                "--genesis-file",
+                &gf,
+                "--datadir",
+                &d,
+            ];
+            if create {
+                args.extend(["--create-store", "--mine-blocks", "1", "--mine-exit"]);
+            } else {
+                args.push("--dry-run");
+            }
+            let (code, err) = cli(&args);
+            assert_eq!(code, 2, "create={create}: {err}");
+            assert!(
+                err.contains("mainnet genesis guard failed"),
+                "create={create}: the guard must win over any storage error: {err}"
+            );
+            assert!(
+                !dir.exists(),
+                "create={create}: filesystem must stay untouched"
+            );
+        }
+        let _ = fs::remove_dir_all(&genesis);
     }
 }

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -901,7 +901,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("mkdir");
         let chain_state_file = chain_state_path(&dir);
-        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let block_store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let chain_state = ChainState::new();
         chain_state.save(&chain_state_file).expect("save");
         let sync = SyncEngine::new(

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1554,9 +1554,8 @@ impl PeerSession {
             // the parent-not-found class even after the precheck passed — the
             // precheck tests the CANDIDATE's prev hash while derivation asks
             // for the prepared canonical tip, i.e. different hashes and
-            // different files, and `has_block` is a `Path::exists()` probe that
-            // conflates "missing" with a metadata error. A partially truncated
-            // or damaged store therefore disagrees with no concurrency at all.
+            // different files. A partially truncated or damaged store therefore
+            // disagrees with no concurrency at all.
             // The precheck is an optimization and must not harden the outcome:
             // route to the SAME orphan retention Go reaches from this position
             // (`handlers_block.go` `retainRelayedOrphanIfValid`), instead of
@@ -3994,7 +3993,7 @@ mod tests {
         fs::create_dir_all(&root).expect("create temp dir");
         let blockstore_dir = root.join("blockstore");
         let chainstate_path = root.join("chainstate.json");
-        let block_store = BlockStore::open(&blockstore_dir).expect("open blockstore");
+        let block_store = BlockStore::create(&blockstore_dir).expect("create blockstore");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(block_store),
@@ -7540,5 +7539,153 @@ mod tests {
         assert!(err.to_string().contains("pow invalid"), "{err}");
         assert_eq!(session.state().ban_score, 100);
         fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// B1 rules 7-8: ONE local store fault, all six named live P2P consumers.
+    /// Each must propagate the error instead of converting it into absence,
+    /// with ban score and orphan population unchanged — no absence-driven
+    /// request/response, orphan retention, compact fallback, or peer fault.
+    /// Go reference: `p2p.Service.hasBlock` callers in `clients/go/node/p2p`.
+    #[test]
+    fn has_block_local_store_error_propagates_through_p2p_consumers() {
+        use crate::sync::{next_candidate_block_for_test, stock_devnet_engine_for_test};
+
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-b1-consumers", |_| {});
+        let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        let hash = block_hash(&block[..BLOCK_HEADER_BYTES]).expect("candidate hash");
+        let root = crate::blockstore::block_store_path(&dir);
+        // Header leaf is a directory: the probe succeeds, the read fails. This is
+        // exactly the class `Path::exists` would silently report as "absent".
+        fs::create_dir(
+            root.join("headers")
+                .join(format!("{}.bin", hex::encode(hash))),
+        )
+        .expect("header leaf as directory");
+        assert!(
+            engine.has_block(hash).is_err(),
+            "fixture must fault the store"
+        );
+
+        let inv = encode_inventory_vectors(&[InventoryVector {
+            kind: MSG_BLOCK,
+            hash,
+        }])
+        .expect("encode inv");
+
+        // 1. handle_cmpctblock — no compact fallback on a local fault.
+        let (mut session, _c1) = test_peer_session();
+        session
+            .handle_cmpctblock(&compact_payload_for_block(&block), &mut engine, None)
+            .expect_err("cmpctblock must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+        assert_eq!(session.orphans.len(), 0);
+
+        // 2. handle_getblocktxn — announced, so the probe is reached.
+        let (mut session, _c2) = test_peer_session();
+        session.compact_announced.push(hash);
+        session
+            .handle_getblocktxn(
+                &encode_getblocktxn_payload(GetBlockTxnPayload {
+                    block_hash: hash,
+                    indexes: vec![0],
+                })
+                .expect("encode getblocktxn"),
+                &engine,
+            )
+            .expect_err("getblocktxn must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+
+        // 3. handle_inv — no absence-driven getdata request.
+        let (mut session, _c3) = test_peer_session();
+        session
+            .handle_inv(&inv, &engine, None)
+            .expect_err("inv must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+
+        // 4. collect_getdata_responses — no absence-driven skip/serve.
+        let (mut session, _c4) = test_peer_session();
+        session
+            .collect_getdata_responses(&inv, &engine, None)
+            .expect_err("getdata must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+
+        // 5. handle_block_with_acceptance — fault on the block's OWN probe:
+        //    no apply, no orphan, no ban.
+        let (mut session, _c5) = test_peer_session();
+        session
+            .handle_block_with_acceptance(&block, &mut engine, None)
+            .expect_err("relayed block must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+        assert_eq!(session.orphans.len(), 0);
+        assert_eq!(engine.chain_state.height, 0, "nothing became canonical");
+
+        // 6. retain_or_resolve_orphan — reached only with a healthy own-probe and
+        //    a faulty PARENT probe. It adds to the orphan pool BEFORE its own
+        //    probe, so the pool grows by exactly one and the error still wins:
+        //    no resolve, no apply, no ban.
+        let child = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 2);
+        let child_hash = block_hash(&child[..BLOCK_HEADER_BYTES]).expect("child hash");
+        let (mut session, _c6) = test_peer_session();
+        session
+            .retain_or_resolve_orphan(child_hash, hash, &child, &mut engine, None)
+            .expect_err("orphan resolve must propagate the local store error");
+        assert_eq!(session.state().ban_score, 0);
+        assert_eq!(session.orphans.len(), 1);
+        assert_eq!(engine.chain_state.height, 0);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The retain_or_resolve_orphan ordering is unreachable with a faulty parent:
+    /// handle_block_with_acceptance probes the SAME parent hash first, so the
+    /// orphan insertion inside retain_or_resolve_orphan is never executed on a
+    /// local store fault. Pins the ordering rather than arguing it.
+    #[test]
+    fn has_block_local_store_parent_fault_never_reaches_orphan_insertion() {
+        use crate::sync::{next_candidate_block_for_test, stock_devnet_engine_for_test};
+
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-b1-orphan-order", |_| {});
+        let parent = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        let parent_hash = block_hash(&parent[..BLOCK_HEADER_BYTES]).expect("parent hash");
+        engine
+            .apply_block_with_reorg(&parent, None)
+            .expect("apply parent");
+        let child = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        let child_hash = block_hash(&child[..BLOCK_HEADER_BYTES]).expect("child hash");
+        let root = crate::blockstore::block_store_path(&dir);
+
+        // Fault the PARENT header read; the child itself is genuinely absent.
+        let leaf = format!("{}.bin", hex::encode(parent_hash));
+        let saved = fs::read(root.join("headers").join(&leaf)).expect("save parent header");
+        fs::remove_file(root.join("headers").join(&leaf)).expect("drop parent header");
+        fs::create_dir(root.join("headers").join(&leaf)).expect("parent leaf as directory");
+        assert_eq!(
+            engine.has_block(child_hash),
+            Ok(false),
+            "child is healthily absent"
+        );
+        assert!(
+            engine.has_block(parent_hash).is_err(),
+            "parent probe faults"
+        );
+
+        let (mut session, _client) = test_peer_session();
+        session
+            .handle_block_with_acceptance(&child, &mut engine, None)
+            .expect_err("parent fault must propagate");
+        assert_eq!(
+            session.orphans.len(),
+            0,
+            "the parent fault must reject BEFORE any orphan insertion"
+        );
+        assert_eq!(
+            session.state().ban_score,
+            0,
+            "a local fault is not a peer fault"
+        );
+
+        fs::remove_dir(root.join("headers").join(&leaf)).expect("undo fixture");
+        fs::write(root.join("headers").join(&leaf), &saved).expect("restore parent header");
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1469,7 +1469,8 @@ mod tests {
 
     fn test_engine(prefix: &str) -> (Arc<Mutex<SyncEngine>>, std::path::PathBuf) {
         let dir = unique_temp_dir(prefix);
-        let store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         let cfg = default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), None);
         let engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("sync engine");
         (Arc::new(Mutex::new(engine)), dir)

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -819,11 +819,26 @@ impl SyncEngine {
         block_store.get_block_by_hash(block_hash_bytes)
     }
 
+    /// Live P2P block-presence decision. Absence is reported only when a healthy
+    /// lookup proves it: the fallible `try_has_block` probe separates NotFound
+    /// (`Ok(false)`) from every other local failure (`Err`), and a positive probe
+    /// is confirmed by a real `get_header_by_hash` read whose failure is also
+    /// `Err`. `Path::exists` and the boolean `BlockStore::has_block` conflate a
+    /// local fault with absence and must not decide this. No parse or consensus
+    /// check is added — a successful byte read is the criterion, matching Go
+    /// `p2p.Service.hasBlock` (`clients/go/node/p2p/service_sync.go`).
+    ///
+    /// Stable-path only: if the header disappears between probe and read, the
+    /// read error propagates as `Err`, not absence.
     pub fn has_block(&self, block_hash_bytes: [u8; 32]) -> Result<bool, String> {
         let Some(block_store) = self.block_store.as_ref() else {
             return Ok(false);
         };
-        Ok(block_store.has_block(block_hash_bytes))
+        if !block_store.try_has_block(block_hash_bytes)? {
+            return Ok(false);
+        }
+        block_store.get_header_by_hash(block_hash_bytes)?;
+        Ok(true)
     }
 
     pub fn is_in_ibd(&self, now_unix: u64) -> bool {
@@ -1406,7 +1421,9 @@ pub(crate) fn stock_devnet_engine_for_test(
     mutate: impl FnOnce(&mut SyncConfig),
 ) -> (SyncEngine, std::path::PathBuf) {
     let dir = crate::io_utils::unique_temp_path(prefix);
-    let store = BlockStore::open(crate::blockstore::block_store_path(&dir)).expect("open store");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let store =
+        BlockStore::create(crate::blockstore::block_store_path(&dir)).expect("create store");
     let mut cfg = default_sync_config(None, devnet_genesis_chain_id(), None);
     mutate(&mut cfg);
     let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("engine");
@@ -1636,7 +1653,8 @@ mod tests {
         let dir = unique_temp_path("rubin-node-sync-persist");
         let chain_state_file = chain_state_path(&dir);
         let block_store_root = block_store_path(&dir);
-        let store = BlockStore::open(block_store_root).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_root).expect("create blockstore");
 
         let st = ChainState::new();
         let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_file.clone()));
@@ -1685,7 +1703,8 @@ mod tests {
     fn sync_engine_apply_block_no_chainstate_path_skips_save_path() {
         let dir = unique_temp_path("rubin-node-sync-no-chainstate-path");
         let block_store_root = block_store_path(&dir);
-        let store = BlockStore::open(block_store_root).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_root).expect("create blockstore");
 
         let st = ChainState::new();
         let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], None /* chain_state_path */);
@@ -1753,7 +1772,8 @@ mod tests {
         let dir = unique_temp_path("rubin-node-sync-pv-shared-suite-context");
         let chain_state_file = chain_state_path(&dir);
         let block_store_root = block_store_path(&dir);
-        let store = BlockStore::open(block_store_root).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_root).expect("create blockstore");
 
         let rotation = Arc::new(CountingRotationProvider {
             spend_calls: AtomicUsize::new(0),
@@ -1915,7 +1935,8 @@ mod tests {
     fn sync_engine_hydrates_tip_timestamp_from_persisted_tip_header() {
         let dir = unique_temp_path("rubin-node-sync-tip-timestamp");
         let block_store_root = block_store_path(&dir);
-        let mut store = BlockStore::open(block_store_root).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let mut store = BlockStore::create(block_store_root).expect("create blockstore");
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2577,5 +2598,60 @@ mod tests {
             .expect("boundary");
         assert_eq!(ok.summary.block_height, WINDOW_SIZE);
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// B1 rules 1-6 + parity matrix rows 14-16/18: the presence decision. Rows
+    /// are the same shapes the Go mirror `TestServiceHasBlockLocalStoreRows`
+    /// asserts against `p2p.Service.hasBlock`, the behavioral reference.
+    #[test]
+    fn has_block_local_store_rows() {
+        // Row 18: no configured blockstore stays Ok(false).
+        let engine_no_store = SyncEngine::new(
+            ChainState::new(),
+            None,
+            default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), None),
+        )
+        .expect("engine");
+        assert_eq!(engine_no_store.has_block([0x11; 32]), Ok(false));
+
+        let (engine, dir) = stock_devnet_engine_for_test("rubin-b1-rows", |_| {});
+        let root = crate::blockstore::block_store_path(&dir);
+
+        // Row 14: readable header -> present.
+        assert_eq!(engine.has_block(engine.chain_state.tip_hash), Ok(true));
+        // Row 15: healthy missing header -> absent (NOT an error).
+        assert_eq!(engine.has_block([0xab; 32]), Ok(false));
+
+        // Row 16a: probe says present, the header read fails -> Err, not absent.
+        let unreadable = [0x5a; 32];
+        std::fs::create_dir(
+            root.join("headers")
+                .join(format!("{}.bin", hex::encode(unreadable))),
+        )
+        .expect("header leaf as directory");
+        let err = engine
+            .has_block(unreadable)
+            .expect_err("a failed header read must not read as absence");
+        assert!(err.contains("read header"), "{err}");
+
+        // Row 16b: the probe itself fails (parent directory unreadable) -> Err.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let headers = root.join("headers");
+            let restore = std::fs::metadata(&headers)
+                .expect("headers meta")
+                .permissions();
+            std::fs::set_permissions(&headers, std::fs::Permissions::from_mode(0o000))
+                .expect("seal headers");
+            let probe = engine.has_block([0xcd; 32]);
+            std::fs::set_permissions(&headers, restore).expect("restore headers");
+            // Running as root defeats the permission bit; only assert when it bit.
+            if probe != Ok(false) {
+                let err = probe.expect_err("probe failure must not read as absence");
+                assert!(err.contains("stat"), "{err}");
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -207,7 +207,8 @@ mod tests {
 
     fn engine_with_store(suffix: &str) -> (SyncEngine, std::path::PathBuf) {
         let dir = unique_temp_path(suffix);
-        let store = BlockStore::open(block_store_path(&dir)).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("create blockstore");
         let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_path(&dir)));
         let engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("new sync");
         (engine, dir)

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -964,7 +964,8 @@ mod tests {
 
     fn engine_with_store(suffix: &str) -> (SyncEngine, std::path::PathBuf) {
         let dir = unique_temp_path(suffix);
-        let store = BlockStore::open(block_store_path(&dir)).expect("open blockstore");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("create blockstore");
         let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_path(&dir)));
         let engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("new sync");
         (engine, dir)

--- a/clients/rust/crates/rubin-node/src/target_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/target_schedule.rs
@@ -365,7 +365,7 @@ mod tests {
             std::process::id(),
             NEXT_DIR.fetch_add(1, Ordering::Relaxed)
         ));
-        let mut store = BlockStore::open(&path).expect("open blockstore");
+        let mut store = BlockStore::create(&path).expect("create blockstore");
         let raw = header([0u8; 32], [0x70; 32], 1, 1);
         let parent = block_hash(&raw).expect("parent hash");
         store

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -2268,10 +2268,10 @@ mod tests {
         ))
     }
 
-    fn open_block_store(prefix: &str) -> (BlockStore, PathBuf) {
+    fn create_block_store(prefix: &str) -> (BlockStore, PathBuf) {
         let dir = unique_temp_dir(prefix);
         fs::create_dir_all(&dir).expect("mkdir");
-        let store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let store = BlockStore::create(block_store_path(&dir)).expect("blockstore");
         (store, dir)
     }
 
@@ -2794,7 +2794,7 @@ mod tests {
     fn next_block_mtp_handles_missing_store_context() {
         assert_eq!(next_block_mtp(None, 0).expect("mtp"), 0);
 
-        let (store, dir) = open_block_store("rubin-txpool-mtp");
+        let (store, dir) = create_block_store("rubin-txpool-mtp");
         assert_eq!(next_block_mtp(Some(&store), 0).expect("mtp"), 0);
         let err = next_block_mtp(Some(&store), 1).unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
@@ -2804,7 +2804,7 @@ mod tests {
 
     #[test]
     fn next_block_mtp_reads_timestamp_context_from_store() {
-        let (store, dir) = open_block_store("rubin-txpool-mtp-success");
+        let (store, dir) = create_block_store("rubin-txpool-mtp-success");
         let mut engine = SyncEngine::new(
             ChainState::new(),
             Some(store.clone()),
@@ -4065,7 +4065,7 @@ mod tests {
         state.has_tip = true;
         state.height = 0;
 
-        let (store, dir) = open_block_store("rubin-txpool-admit-mtp");
+        let (store, dir) = create_block_store("rubin-txpool-admit-mtp");
         let err = TxPool::new()
             .admit(&raw, &state, Some(&store), devnet_genesis_chain_id())
             .unwrap_err();
@@ -4121,7 +4121,7 @@ mod tests {
         state.has_tip = true;
         state.height = 0;
 
-        let (mut store, dir) = open_block_store("rubin-txpool-admit-header-read");
+        let (mut store, dir) = create_block_store("rubin-txpool-admit-header-read");
         store
             .set_canonical_tip(0, [0x42; 32])
             .expect("set canonical tip");

--- a/conformance/devnetcv/devnetcv.go
+++ b/conformance/devnetcv/devnetcv.go
@@ -282,7 +282,7 @@ func newDevnetEnv() (*devnetEnv, error) {
 	target := consensus.POW_LIMIT
 	chainID := node.DevnetGenesisChainID()
 	chainState := node.NewChainState()
-	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	blockStore, err := node.CreateBlockStore(node.BlockStorePath(dir))
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/devnet-core-htlc-evidence.sh
+++ b/scripts/devnet-core-htlc-evidence.sh
@@ -117,7 +117,7 @@ func main() {
  if *datadir == "" || !v.ExpectOK || v.ExpectErr != "" || v.TxHex == "" || len(v.Utxos) == 0 { die("CORE_HTLC fixture contract mismatch") }
  if v.ChainIDHex != *chainID { die(fmt.Sprintf("chain_id_hex actual=%s expected=%s", v.ChainIDHex, *chainID)) }; runtimeChainID:=node.DevnetGenesisChainID(); if got:=hex.EncodeToString(runtimeChainID[:]); got != *chainID { die(fmt.Sprintf("runtime devnet chain_id actual=%s expected=%s", got, *chainID)) }
  if _, err := hex.DecodeString(v.TxHex); err != nil { die(fmt.Sprintf("invalid tx_hex: %v", err)) }
- st := node.NewChainState(); store, err := node.OpenBlockStore(node.BlockStorePath(*datadir)); if err != nil { die(err) }
+ st := node.NewChainState(); store, err := node.CreateBlockStore(node.BlockStorePath(*datadir)); if err != nil { die(err) }
  engine, err := node.NewSyncEngine(st, store, node.DefaultSyncConfig(nil, runtimeChainID, node.ChainStatePath(*datadir))); if err != nil { die(err) }
  if _, err := engine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil { die(err) }
  for _, u := range v.Utxos { txidBytes, err := hex.DecodeString(u.Txid); if err != nil || len(txidBytes) != 32 { die("invalid fixture txid") }; cov, err := hex.DecodeString(u.CovenantData); if err != nil { die(fmt.Sprintf("invalid fixture covenant_data: %v", err)) }; var txid [32]byte; copy(txid[:], txidBytes); st.Utxos[consensus.Outpoint{Txid: txid, Vout: u.Vout}] = consensus.UtxoEntry{Value: u.Value, CovenantType: u.CovenantType, CovenantData: cov, CreationHeight: u.CreationHeight, CreatedByCoinbase: u.CreatedByCoinbase} }

--- a/scripts/devnet-core-multisig-evidence.sh
+++ b/scripts/devnet-core-multisig-evidence.sh
@@ -386,7 +386,7 @@ func main() {
 	}
 
 	st := node.NewChainState()
-	store, err := node.OpenBlockStore(node.BlockStorePath(*datadir))
+	store, err := node.CreateBlockStore(node.BlockStorePath(*datadir))
 	if err != nil {
 		die(err)
 	}

--- a/scripts/devnet-core-vault-evidence.sh
+++ b/scripts/devnet-core-vault-evidence.sh
@@ -122,7 +122,7 @@ func main() {
  if *datadir == "" || !v.ExpectOK || v.ExpectErr != "" || v.TxHex == "" || len(v.Utxos) == 0 { die("CORE_VAULT fixture contract mismatch") }
  if v.ChainIDHex != *chainID { die(fmt.Sprintf("chain_id_hex actual=%s expected=%s", v.ChainIDHex, *chainID)) }
  if _, err := hex.DecodeString(v.TxHex); err != nil { die(fmt.Sprintf("invalid tx_hex: %v", err)) }
- st := node.NewChainState(); store, err := node.OpenBlockStore(node.BlockStorePath(*datadir)); if err != nil { die(err) }
+ st := node.NewChainState(); store, err := node.CreateBlockStore(node.BlockStorePath(*datadir)); if err != nil { die(err) }
  engine, err := node.NewSyncEngine(st, store, node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), node.ChainStatePath(*datadir))); if err != nil { die(err) }
  if _, err := engine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil { die(err) }
  for _, u := range v.Utxos { txidBytes, err := hex.DecodeString(u.Txid); if err != nil || len(txidBytes) != 32 { die("invalid fixture txid") }; cov, err := hex.DecodeString(u.CovenantData); if err != nil { die(fmt.Sprintf("invalid fixture covenant_data: %v", err)) }; var txid [32]byte; copy(txid[:], txidBytes); st.Utxos[consensus.Outpoint{Txid: txid, Vout: u.Vout}] = consensus.UtxoEntry{Value: u.Value, CovenantType: u.CovenantType, CovenantData: cov, CreationHeight: u.CreationHeight, CreatedByCoinbase: u.CreatedByCoinbase} }

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -342,7 +342,7 @@ pid_listens_on() {
 start_partition_go_node() {
   local log_file="partition-node-go.log" args
   GO_PARTITION_PID="" GO_PARTITION_RPC="" GO_PARTITION_P2P="" GO_PARTITION_STARTED=""
-  args=(--network devnet --datadir "${RUBIN_PROCESS_ARTIFACT_ROOT}/partition-node-go" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
+  args=(--network devnet --create-store --datadir "${RUBIN_PROCESS_ARTIFACT_ROOT}/partition-node-go" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
   [[ -z "${PARTITION_GO_MINE_ADDRESS_HEX:-}" ]] || args+=(--mine-address "${PARTITION_GO_MINE_ADDRESS_HEX}")
   rubin_process_start "${log_file}" "${NODE_BIN}" "${args[@]}" || return 1
   GO_PARTITION_PID="${RUBIN_PROCESS_LAST_PID}"
@@ -355,7 +355,7 @@ start_partition_go_node() {
 start_partition_rust_node() {
   local log_file="partition-node-rust.log" peer_addr="$1" args
   RUST_PARTITION_PID="" RUST_PARTITION_RPC="" RUST_PARTITION_P2P="" RUST_PARTITION_STARTED=""
-  args=(--network devnet --datadir "${RUBIN_PROCESS_ARTIFACT_ROOT}/partition-node-rust" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${peer_addr}")
+  args=(--network devnet --create-store --datadir "${RUBIN_PROCESS_ARTIFACT_ROOT}/partition-node-rust" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${peer_addr}")
   [[ -z "${PARTITION_RUST_MINE_ADDRESS_HEX:-}" ]] || args+=(--mine-address "${PARTITION_RUST_MINE_ADDRESS_HEX}")
   rubin_process_start "${log_file}" "${RUST_NODE_BIN}" "${args[@]}" || return 1
   RUST_PARTITION_PID="${RUBIN_PROCESS_LAST_PID}"
@@ -1254,7 +1254,7 @@ MINE_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1
 TO_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["to_address_hex"])' "${KEYGEN_JSON}")"
 mkdir -p "${A_DIR}" "${B_DIR}" "${C_DIR}"
 echo "Mining mature Go chain to height ${BASE_HEIGHT}"
-"${NODE_BIN}" --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_MINE_BLOCKS}" --mine-exit >"${MINE_LOG}" 2>&1
+"${NODE_BIN}" --create-store --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_MINE_BLOCKS}" --mine-exit >"${MINE_LOG}" 2>&1
 cp -R "${A_DIR}/." "${B_DIR}/"
 cp -R "${A_DIR}/." "${C_DIR}/"
 echo "Starting three Go rubin-node processes"

--- a/scripts/devnet-go-compact-relay.sh
+++ b/scripts/devnet-go-compact-relay.sh
@@ -130,10 +130,10 @@ PY
 start_node() {
   local label="$1" log_file="$2" datadir="$3" peers="${4:-}"
   if [[ -z "${peers}" ]]; then
-    rubin_process_start "${log_file}" "${NODE_BIN}" --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
+    rubin_process_start "${log_file}" "${NODE_BIN}" --create-store --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
       || { printf 'failed to start %s log_file=%s\n' "${label}" "${log_file}" >&2; return 1; }
   else
-    rubin_process_start "${log_file}" "${NODE_BIN}" --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${peers}" \
+    rubin_process_start "${log_file}" "${NODE_BIN}" --create-store --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${peers}" \
       || { printf 'failed to start %s log_file=%s\n' "${label}" "${log_file}" >&2; return 1; }
   fi
   STARTED_PID="${RUBIN_PROCESS_LAST_PID}"

--- a/scripts/devnet-go-da-relay.sh
+++ b/scripts/devnet-go-da-relay.sh
@@ -332,7 +332,7 @@ RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "$
 MINE_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["mine_address_hex"])' "${KEYGEN_JSON}")"
 mkdir -p "${A_DIR}" "${B_DIR}"
 echo "Mining mature Go chain to height ${BASE_HEIGHT}"
-"${NODE_BIN}" --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_HEIGHT}" --mine-exit >"${MINE_LOG}" 2>&1
+"${NODE_BIN}" --create-store --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_HEIGHT}" --mine-exit >"${MINE_LOG}" 2>&1
 write_da_txgen
 RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${DATXGEN_GO}" "${A_DIR}" "${FROM_KEY_FILE}" >"${DA_TX_JSON}"
 cleanup_from_key_file

--- a/scripts/devnet-go-two-node-full-block.sh
+++ b/scripts/devnet-go-two-node-full-block.sh
@@ -691,7 +691,7 @@ TO_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])
 
 mkdir -p "${A_DIR}" "${B_DIR}"
 echo "Mining mature Go chain to height ${BASE_HEIGHT}"
-"${NODE_BIN}" --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_HEIGHT}" --mine-exit >"${MINE_LOG}" 2>&1
+"${NODE_BIN}" --create-store --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_HEIGHT}" --mine-exit >"${MINE_LOG}" 2>&1
 cp -R "${A_DIR}/." "${B_DIR}/"
 assert_distinct_datadirs
 

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -538,7 +538,8 @@ if partition_mode:
     proof_for_argv = data.get("proof")
     req(isinstance(proof_for_argv, dict) and ep(proof_for_argv.get("partition_proxy_endpoint")), "partition proxy endpoint is malformed")
     rust_expected_peer = proof_for_argv["partition_proxy_endpoint"]
-req(report_node_argv_eq(nodes_by_impl["go"], "node-go", []) and report_node_argv_eq(nodes_by_impl["rust"], "node-rust", ["--peer", rust_expected_peer]), "node command_argv does not match exact launched argv")
+create_flag = [] if (tx_mode or restart_mode or partition_mode) else ["--create-store"]
+req(report_node_argv_eq(nodes_by_impl["go"], "node-go", create_flag) and report_node_argv_eq(nodes_by_impl["rust"], "node-rust", ["--peer", rust_expected_peer] + create_flag), "node command_argv does not match exact launched argv")
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
 req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
 req(len({nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")}) == 4, "node rpc/p2p endpoints are not pairwise distinct")
@@ -789,6 +790,10 @@ source "${HELPER}"
 rubin_process_init mixed-client-mesh
 GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"; RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
 GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
+# A datadir is initialized once, by whoever constructs it first: the prepare_*
+# mine, or the first node start in plain mode. Every later start/restart, and
+# the Rust datadir once it is a byte-copy of the Go one, is a reopen.
+GO_STORE_READY=0; RUST_STORE_READY=0
 GO_LOG="node-go.log"; RUST_LOG="node-rust.log"; RUST_RESTART_LOG="node-rust-restart.log"; PARTITION_PROXY_LOG="partition-proxy.log"; REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 RUST_PRE_RESTART_TIP_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-pre-restart-tip.json"; GO_RESTART_MINE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-restart-mine-next.json"; GO_RESTART_TARGET_TIP_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-restart-target-tip.json"; RUST_CATCH_UP_TIP_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-catch-up-tip.json"
@@ -1275,8 +1280,10 @@ with open(sys.argv[1], "w", encoding="utf-8") as f:
 PY
   rm -f -- "${KEYGEN_GO}" || { cleanup_tx_from_key_file || true; TX_REASON=go_submit_keygen_cleanup_failed; return 1; }
   echo "Mining mature chainstate for mixed-client evidence" >&2
-  bounded_mesh "${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --mine-address "${mine_address}" --mine-blocks 101 --mine-exit >"$(_rubin_process_resolve_log "${MINE_LOG}")" 2>&1 || { status=$?; cleanup_tx_from_key_file || true; [[ ${status} -eq 142 ]] && TX_REASON=go_submit_mine_timeout || TX_REASON=go_submit_mine_failed; return 1; }
+  bounded_mesh "${GO_NODE_BIN}" --network devnet --create-store --datadir "${GO_DIR}" --mine-address "${mine_address}" --mine-blocks 101 --mine-exit >"$(_rubin_process_resolve_log "${MINE_LOG}")" 2>&1 || { status=$?; cleanup_tx_from_key_file || true; [[ ${status} -eq 142 ]] && TX_REASON=go_submit_mine_timeout || TX_REASON=go_submit_mine_failed; return 1; }
+  GO_STORE_READY=1
   cp -R -- "${GO_DIR}/." "${RUST_DIR}/" || { cleanup_tx_from_key_file || true; TX_REASON=go_submit_chainstate_copy_failed; return 1; }
+  RUST_STORE_READY=1
 }
 prepare_restart_chainstate() {
   TX_REASON=""
@@ -2586,6 +2593,7 @@ start_rust_node_with_log() {
   local rust_log="$1"
   local peer_addr="${RUST_BOOTSTRAP_PEER_ADDR:-${GO_P2P_ADDR}}"
   local -a argv=("${RUST_NODE_BIN}" --network devnet --datadir "${RUST_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${peer_addr}")
+  (( RUST_STORE_READY )) || { argv+=(--create-store); RUST_STORE_READY=1; }
   START_REASON=""
   RUST_CMD="$(argv_cmd "${argv[@]}")"; RUST_ARGV_JSON="$(argv_json "${argv[@]}")"
   rubin_process_start "${rust_log}" "${argv[@]}" || { START_REASON=rust_launch_failed; return 1; }; RUST_PID="${RUBIN_PROCESS_LAST_PID}"
@@ -2657,6 +2665,7 @@ run_rust_restart_scenario() {
 }
 start_go_node() {
   local -a argv=("${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
+  (( GO_STORE_READY )) || { argv+=(--create-store); GO_STORE_READY=1; }
   START_REASON=""
   GO_CMD="$(argv_cmd "${argv[@]}")"; GO_ARGV_JSON="$(argv_json "${argv[@]}")"
   rubin_process_start "${GO_LOG}" "${argv[@]}" || { START_REASON=go_launch_failed; return 1; }; GO_PID="${RUBIN_PROCESS_LAST_PID}"

--- a/scripts/devnet-rpc-parity-smoke.sh
+++ b/scripts/devnet-rpc-parity-smoke.sh
@@ -248,7 +248,7 @@ PY
 mkdir -p "${GO_DATA_DIR}" "${RUST_DATA_DIR}"
 
 echo "Mining mature chainstate with Go node"
-"${GO_NODE_BIN}" --datadir "${GO_DATA_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks 101 --mine-exit >"${MINE_LOG}" 2>&1
+"${GO_NODE_BIN}" --create-store --datadir "${GO_DATA_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks 101 --mine-exit >"${MINE_LOG}" 2>&1
 cp -R "${GO_DATA_DIR}/." "${RUST_DATA_DIR}/"
 
 echo "Starting Go RPC node at ${GO_RPC_ADDR}"

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -398,7 +398,7 @@ NODE_PID=""
 # on a single helper failure — the calling `if` block decides next steps.
 attempt_helper_launch() {
   rubin_process_start "${LOG_FILE}" "${NODE_BIN}" \
-    --network devnet --datadir "${DATA_DIR}" \
+    --network devnet --create-store --datadir "${DATA_DIR}" \
     --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
     || { LAUNCH_FAILURE_REASON="rubin_process_start did not register a Rust helper/advisory process"; return 1; }
   NODE_PID="${RUBIN_PROCESS_LAST_PID:-}"

--- a/scripts/devnet-rust-compact-relay.sh
+++ b/scripts/devnet-rust-compact-relay.sh
@@ -275,7 +275,7 @@ PY
 }
 start_node() {
   local label="$1" log="$2" datadir="$3" peers="${4:-}"
-  local cmd=("${NODE_BIN}" --network devnet --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
+  local cmd=("${NODE_BIN}" --network devnet --create-store --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
   STARTED_PID=""; STARTED_RPC=""; STARTED_P2P=""
   [[ -z "${peers}" ]] || cmd+=(--peers "${peers}")
   rubin_process_start "${log}" "${cmd[@]}" || { echo "failed to start ${label}" >&2; return 1; }

--- a/scripts/devnet-smoke.sh
+++ b/scripts/devnet-smoke.sh
@@ -225,7 +225,7 @@ NODE_A_PORT="$((29110 + ($$ % 1000)))"
 NODE_A_ADDR="127.0.0.1:${NODE_A_PORT}"
 
 echo "Starting node A at ${NODE_A_ADDR}"
-start_node "${NODE_A_LOG}" --datadir "${NODE_A_DIR}" --bind "${NODE_A_ADDR}" --rpc-bind "${NODE_A_RPC_ADDR}" --mine-blocks 10
+start_node "${NODE_A_LOG}" --create-store --datadir "${NODE_A_DIR}" --bind "${NODE_A_ADDR}" --rpc-bind "${NODE_A_RPC_ADDR}" --mine-blocks 10
 NODE_A_PID="${LAST_PID}"
 wait_for_log "${NODE_A_LOG}" "rpc: listening=" 30 "${NODE_A_PID}"
 NODE_A_RPC_ADDR="$(extract_rpc_addr "${NODE_A_LOG}")"
@@ -245,10 +245,10 @@ if [[ "${NODE_A_HAS_TIP}" != "true" ]]; then
 fi
 
 echo "Starting node B"
-start_node "${NODE_B_LOG}" --datadir "${NODE_B_DIR}" --bind "127.0.0.1:0" --rpc-bind "${NODE_B_RPC_ADDR}" --peers "${NODE_A_ADDR}"
+start_node "${NODE_B_LOG}" --create-store --datadir "${NODE_B_DIR}" --bind "127.0.0.1:0" --rpc-bind "${NODE_B_RPC_ADDR}" --peers "${NODE_A_ADDR}"
 NODE_B_PID="${LAST_PID}"
 echo "Starting node C"
-start_node "${NODE_C_LOG}" --datadir "${NODE_C_DIR}" --bind "127.0.0.1:0" --rpc-bind "${NODE_C_RPC_ADDR}" --peers "${NODE_A_ADDR}"
+start_node "${NODE_C_LOG}" --create-store --datadir "${NODE_C_DIR}" --bind "127.0.0.1:0" --rpc-bind "${NODE_C_RPC_ADDR}" --peers "${NODE_A_ADDR}"
 NODE_C_PID="${LAST_PID}"
 
 wait_for_log "${NODE_B_LOG}" "rpc: listening=" 30 "${NODE_B_PID}"


### PR DESCRIPTION
## Issue
- Linear: RUB-1053

Refs: Q-STORAGE-INTEGRITY-LIFECYCLE-01

## Summary
A node no longer conjures a block store out of whatever the datadir happens to contain. `CreateBlockStore` / `BlockStore::create` are the only constructors that build a store and are reachable only through the new `--create-store` flag; `OpenBlockStore` / `BlockStore::open` became strict open-existing operations that never mkdir, never synthesize a marker, and never fall back. `index.json` with `version=1` and an empty canonical array, written last, is the sole creation commit marker, and both clients accept and reject the same marker shapes: exactly two fields, lowercase 64-hex entries, nothing unknown or duplicated.

Create refuses an existing blockstore root or chainstate of any filesystem kind, dangling symlinks included, before it creates anything, and the root error wins when both exist. Flag combinations incompatible with `--create-store` exit 2 before any filesystem access, and the genesis identity guards run before storage mutation in both clients, so a misconfigured mainnet start leaves the disk untouched instead of committing a store it then rejects.

Startup recovery stops erasing what it cannot see. A persisted canonical index that is non-empty while its complete artifact prefix computes to zero is no longer a crash tail to truncate away: it returns a named fatal error before `TruncateCanonical(0)`, before any chainstate reset or save, and before a single service is exposed. Structural, I/O and corruption errors keep their existing precedence over the new guard.

Rust block presence now matches Go's: the fallible probe decides absence only on `NotFound`, and presence is confirmed by an actual header read, so a local store fault propagates as an error through the relayed-block, compact, orphan, inventory and getdata paths instead of being reported as a missing block that would retain an orphan or score a peer.

Every constructor call site in the tree is classified as fresh or reopen rather than renamed in bulk, and the devnet orchestration scripts declare `--create-store` on the runs that genuinely start from nothing.

## Invariant
Across startup and live P2P, Go and Rust classify a block as absent only when a strictly opened initialized store exists and the lookup proves healthy absence; missing initialization, local probe/read failure, or a non-empty canonical index with zero complete artifact prefix fails before destructive recovery or absence-driven downstream disposition.

## Scope
- Changed files: 53
- Surfaces: clients/go, clients/rust, conformance, scripts
- Non-scope: no pre-devnet local-store compatibility, migration, import/export, legacy recovery, operator repair command, new marker/schema/version or identity field, automatic deletion of partial create state, runtime filesystem-replacement protection, consensus, wire, peer-scoring, canonical specification, formal, activation, or conformance-schema change
- Consensus rules unchanged: YES — no consensus path is touched in either client; accept/reject outcomes, public error codes and their ordering are untouched, and the new errors are node-private startup/local-store classes
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `go test -race -timeout=20m -shuffle=on -count=1 ./...` — PASS; `go test ./... -count=1` — PASS (9 packages); `go test ./cmd/rubin-node ./node ./node/p2p -run "CreateStore|OpenBlockStore|ZeroCompleteCanonicalPrefix|HasBlock.*LocalStore|LocalStore.*HasBlock" -count=1` — PASS; `go vet ./...` — PASS; `cargo nextest run --workspace --all-targets` — PASS; `cargo test --workspace --doc` — PASS; `cargo test --workspace -- --test-threads=1` — PASS (2064); `cargo test -p rubin-node create_store|open_existing|zero_complete_canonical_prefix|has_block_local_store` — PASS (5/5/2/3); `cargo fmt --check` — PASS; `cargo clippy -p rubin-node --all-targets -- -D warnings` — PASS; `cd conformance && go test ./... -count=1 && go vet ./...` — PASS; `scripts/devnet-smoke.sh` — PASS; `scripts/devnet-rpc-parity-smoke.sh` — PASS; `scripts/devnet-go-da-relay.sh` — PASS; `scripts/devnet-rust-binary-soak.sh` — PASS; `scripts/devnet-mixed-client-mesh.sh` (plain and `--go-submit-rust-accept`) — PASS; `git diff --check` — PASS
- Explicit skips: `scripts/devnet-mixed-client-mesh.sh --partition-heal-reorg` fails with `NO_DATA: partition_go_metrics_missing_or_zero`, reproduced byte-identically on a pristine baseline tree, so it is pre-existing and not attributable to this change; the three `devnet-core-*-evidence.sh` scripts are owned by RUB-1054 and were not run here.

## Follow-ups / Waivers
- RUB-1057 bounds local store file reads in both clients (the marker parse is currently unbounded) — independent of this slice.
- RUB-1058 repays the repository-wide gofumpt debt; the two files this slice touched were cleaned here, the other nine are outside its allowlist.
- The startup-amnesia composite recorded in RUB-1052 (both mains create the datadir before loading chainstate) is unchanged by this slice and remains a recorded residual.
