### PR TITLE
RUB-1058: repay the gofumpt debt across clients/go in one deliberate pass

### DIFF
--- a/clients/go/consensus/da_verify_parallel.go
+++ b/clients/go/consensus/da_verify_parallel.go
@@ -35,7 +35,6 @@ func VerifyDAChunkHashesParallel(ctx context.Context, tasks []DAChunkHashTask, w
 			return struct{}{}, nil
 		},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,6 @@ func VerifyDAPayloadCommitsParallel(ctx context.Context, tasks []DAPayloadCommit
 			return struct{}{}, nil
 		},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/clients/go/consensus/sig_verify_queued_test.go
+++ b/clients/go/consensus/sig_verify_queued_test.go
@@ -374,7 +374,7 @@ func TestValidateThresholdSigSpendQ_RollbackOnLateThresholdErrors(t *testing.T) 
 		},
 		{
 			name:       "key_binding_mismatch",
-			keys:       [][32]byte{keyID1, [32]byte{0xEE}},
+			keys:       [][32]byte{keyID1, {0xEE}},
 			second:     WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp2.PubkeyBytes(), Signature: sig2},
 			wantErr:    TX_ERR_SIG_INVALID,
 			wantErrMsg: "key binding mismatch",

--- a/clients/go/consensus/utxo_basic_additional_test.go
+++ b/clients/go/consensus/utxo_basic_additional_test.go
@@ -42,7 +42,6 @@ func TestCheckSpendCovenant_SupportedTypes(t *testing.T) {
 	if err := checkSpendCovenant(COV_TYPE_HTLC, htlcData); err != nil {
 		t.Fatalf("CORE_HTLC: %v", err)
 	}
-
 }
 
 func TestCheckSpendCovenant_Errors(t *testing.T) {

--- a/clients/go/consensus/wire_read_test.go
+++ b/clients/go/consensus/wire_read_test.go
@@ -9,7 +9,6 @@ func TestReadBytes_RejectsInvalidOffsets(t *testing.T) {
 	buf := []byte{0x01, 0x02, 0x03}
 
 	for _, off := range []int{-1, len(buf) + 1, int(^uint(0) >> 1)} {
-
 		t.Run("off", func(t *testing.T) {
 			_, err := readBytes(buf, &off, 1)
 			if err == nil {

--- a/clients/go/node/chainstate_io.go
+++ b/clients/go/node/chainstate_io.go
@@ -95,6 +95,7 @@ func chainStateFromDisk(disk chainStateDisk) (*ChainState, error) {
 		Utxos:            utxos,
 	}, nil
 }
+
 func ChainStatePath(dataDir string) string {
 	return filepath.Join(dataDir, chainStateFileName)
 }

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -179,6 +179,7 @@ func TestMinerCompleteDASetProviderValidity(t *testing.T) {
 		t.Fatalf("selected batches=%d, want capped provider DA batches", len(selected)/3)
 	}
 }
+
 func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
 	fixture := newMinerProviderTestFixture(t)
 	base := fixture.completeDASet(t, [32]byte{0x83}, []byte("chunk-0"), []byte("chunk-1"))

--- a/clients/go/node/p2p/service_listener_test.go
+++ b/clients/go/node/p2p/service_listener_test.go
@@ -30,7 +30,6 @@ func TestNextAcceptErrorBackoff(t *testing.T) {
 		{"overshoot clamps to cap", 10 * time.Second, acceptErrorBackoffCap},
 	}
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			got := nextAcceptErrorBackoff(tc.current)
 			if got != tc.want {

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -10,8 +10,10 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-const productionRotationScheduleVersion = 1
-const productionRotationScheduleErrStem = "production_rotation_schedule"
+const (
+	productionRotationScheduleVersion = 1
+	productionRotationScheduleErrStem = "production_rotation_schedule"
+)
 
 // Derived runtime copy of conformance/fixtures/protocol/production_rotation_schedule_v1.json.
 // Go embed cannot read a parent-path artifact directly, so tests keep this JSON-equivalent

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -205,7 +205,6 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 	}
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 				"version": 1,
@@ -280,7 +279,6 @@ func TestLoadCompiledProductionRotationScheduleRejectsNonFiniteSunsetHeightOnPro
 	}
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			sunsetField := ""
 			if tc.sunsetField != "" {


### PR DESCRIPTION
## Issue
- Linear: RUB-1058

Refs: Q-GO-GOFUMPT-DEBT-REPAY-01

## Summary
Nine files under clients/go were never gofumpt-clean, invisible to the diff-scoped formatting gate until a slice touched one and inherited an unrelated red cell — RUB-1053 hit this twice. This applies `gofumpt 0.11.0` verbatim to exactly the measured nine-file set and nothing else: 17 changed lines, no hand edit riding along, and re-running the tool on the result is a byte-level no-op.

Semantics preservation is proven, not asserted. Seven of the nine differ from base only in whitespace, with bit-identical compiler token streams (go/scanner comparison, automatic-semicolon positions included). The two non-whitespace hunks are the tool's known rewrite classes, each additionally executed side by side against its base form: the elided redundant composite-literal element type yields a DeepEqual-identical value of the identical type, and the grouped consecutive const declarations keep explicit expressions so no implicit-repetition or iota semantics can engage.

## Invariant
Every Go file under clients/go is gofumpt-clean at the pinned tool version, the change is proven semantics-preserving rather than asserted, and no behavior, test outcome, or generated artifact differs before and after.

## Scope
- Changed files: 9
- Surfaces: clients/go (formatting only)
- Non-scope: no gate-scoping change, no CI wiring of gofumpt, no tool version bump, no behavior or test-expectation change, no reformatting of anything the tool does not flag
- Consensus rules unchanged: YES
- Consensus-path note: four touched files sit under clients/go/consensus/ but carry formatting-only hunks; three of the four have bit-identical token streams to base and the fourth differs only by an elided redundant literal element type, proven value- and type-identical by execution
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `go build ./... && go vet ./...` — PASS; `go test ./... -count=1` — PASS (9 packages, before/after package results identical); `go test -race -shuffle=on -count=1 ./...` — PASS; `cd conformance && go test ./... -count=1 && go vet ./...` — PASS; `gofumpt -l .` — empty; `gofmt -l . && goimports -l .` — empty; `git diff --check` — PASS

## Follow-ups / Waivers
- None. The two files RUB-1053 already cleaned are excluded (re-measured at this baseline); conformance/ was measured clean.

### Parity exemption justification
Go-only formatting slice with zero behavioral delta, so no Rust mirror exists to write. Four touched files sit under the parity-gate trigger path (clients/go/consensus/): three have bit-identical compiler token streams to their base versions — the compiler cannot distinguish them — and the fourth (sig_verify_queued_test.go) differs only by removing a redundant composite-literal element type inside one test table, executed side by side against the base form with DeepEqual-identical value and identical type. No consensus behavior, error code, serialization, or test expectation changes; the conformance suite and both formatting-sensitive gates pass on the result.
