### PR TITLE
RUB-1061: fan out nightly fuzz matrix and classify the fuzztime shutdown race

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -54,7 +54,10 @@ jobs:
   fuzz-stage2:
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Must exceed GO_TEST_TIMEOUT at the documented fuzz_time=600s example
+    # (1200s) plus checkout/setup-go/instrumented-build, so a hung target dies
+    # by go test's own -timeout (writing the panic dump), never by the job cap.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -88,10 +91,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fuzz-stage2-${{ github.run_id }}-${{ env.FUZZ_TARGET_NAME }}
+          # -a<attempt>: v4+ artifacts are immutable, so a re-run of a failed
+          # leg would otherwise collide with attempt 1's upload.
+          name: fuzz-stage2-${{ github.run_id }}-${{ env.FUZZ_TARGET_NAME }}-a${{ github.run_attempt }}
           path: |
             .artifacts/fuzz-stage2/**
             clients/go/consensus/testdata/fuzz/**
+            clients/go/node/testdata/fuzz/**
+            clients/go/node/p2p/testdata/fuzz/**
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
@@ -99,7 +106,10 @@ jobs:
   fuzz-rust:
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Sized for the documented dispatch example rust_fuzz_time=600: a 5-target
+    # chunk = 50 min fuzzing + uncached nightly-toolchain/cargo-fuzz/fuzz-crate
+    # build overhead.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -185,7 +195,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fuzz-rust-${{ github.run_id }}-c${{ strategy.job-index }}
+          name: fuzz-rust-${{ github.run_id }}-c${{ strategy.job-index }}-a${{ github.run_attempt }}
           path: |
             .artifacts/fuzz-rust/**
             clients/rust/fuzz/artifacts/
@@ -206,12 +216,11 @@ jobs:
           RUST_RESULT: ${{ needs.fuzz-rust.result }}
         run: |
           echo "verdict: go-matrix=${GO_RESULT} rust-matrix=${RUST_RESULT}"
+          # Fail closed: anything but exact "success" (failure/cancelled/skipped/empty).
           for result in "$GO_RESULT" "$RUST_RESULT"; do
-            case "$result" in
-              failure|cancelled)
-                echo "FAIL: a nightly fuzz matrix ended with result: $result" >&2
-                exit 1
-                ;;
-            esac
+            if [[ "$result" != "success" ]]; then
+              echo "FAIL: a nightly fuzz matrix ended with result: ${result:-empty}" >&2
+              exit 1
+            fi
           done
-          echo "PASS: both nightly fuzz matrices completed without defect evidence"
+          echo "PASS: both nightly fuzz matrices succeeded"

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       fuzz_time:
-        description: "Go fuzz time per target (for example 45s, 120s)"
+        description: "Go fuzz time per target (for example 300s, 600s)"
         required: false
-        default: "45s"
+        default: "300s"
       rust_fuzz_time:
-        description: "Rust fuzz time per target in seconds (for example 60, 120)"
+        description: "Rust fuzz time per target in seconds (for example 300, 600)"
         required: false
-        default: "60"
+        default: "300"
 
 concurrency:
   group: fuzz-nightly-${{ github.ref }}
@@ -22,10 +22,52 @@ permissions:
   contents: read
 
 jobs:
-  fuzz-stage2:
+  # Derives both fan-out matrices from their single-source lists so that
+  # adding a target never requires a workflow edit and nightly wall clock
+  # stays flat as the lists grow.
+  prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
+    outputs:
+      go_targets: ${{ steps.lists.outputs.go_targets }}
+      rust_chunks: ${{ steps.lists.outputs.rust_chunks }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Emit fuzz target matrices
+        id: lists
+        run: |
+          set -euo pipefail
+          go_targets="$(scripts/ci/run_fuzz_stage2.sh --list-json)"
+          # Chunk size 5 amortises the per-job nightly-toolchain + cargo-fuzz
+          # install + fuzz-crate build cost while keeping per-job wall clock
+          # constant as the target list grows.
+          rust_chunks="$(grep -Ev '^[[:space:]]*(#|$)' scripts/ci/rust_fuzz_targets.txt \
+            | jq -R . | jq -cs '[range(0; length; 5) as $i | .[$i:$i + 5]]')"
+          echo "go targets: $(jq -r length <<<"${go_targets}")"
+          echo "rust chunks: $(jq -r length <<<"${rust_chunks}")"
+          {
+            echo "go_targets=${go_targets}"
+            echo "rust_chunks=${rust_chunks}"
+          } >> "$GITHUB_OUTPUT"
+
+  fuzz-stage2:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.prepare.outputs.go_targets) }}
+    steps:
+      - name: Derive artifact-safe target name
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: |
+          # ":" and "/" are invalid in artifact names; the function name after
+          # the "pkg:Target" colon is a clean identifier.
+          echo "FUZZ_TARGET_NAME=${FUZZ_TARGET##*:}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -34,18 +76,19 @@ jobs:
           cache: true
           cache-dependency-path: clients/go/go.mod
 
-      - name: Run stage2 fuzz targets (timeboxed)
+      - name: Run stage2 fuzz target (timeboxed)
         env:
-          FUZZ_TIME: ${{ github.event.inputs.fuzz_time || '45s' }}
+          FUZZ_TIME: ${{ github.event.inputs.fuzz_time || '300s' }}
           FUZZ_MINIMIZE_TIME: "5s"
+          FUZZ_TARGET: ${{ matrix.target }}
         run: |
-          scripts/dev-env.sh -- bash -lc "cd \"$GITHUB_WORKSPACE\" && scripts/ci/run_fuzz_stage2.sh"
+          scripts/dev-env.sh -- bash -lc "cd \"$GITHUB_WORKSPACE\" && scripts/ci/run_fuzz_stage2.sh --target \"$FUZZ_TARGET\""
 
       - name: Upload fuzz artifacts (crashes/regressions)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fuzz-stage2-${{ github.run_id }}
+          name: fuzz-stage2-${{ github.run_id }}-${{ env.FUZZ_TARGET_NAME }}
           path: |
             .artifacts/fuzz-stage2/**
             clients/go/consensus/testdata/fuzz/**
@@ -54,8 +97,13 @@ jobs:
           retention-days: 14
 
   fuzz-rust:
+    needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJSON(needs.prepare.outputs.rust_chunks) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -78,8 +126,10 @@ jobs:
 
       - name: Run Rust fuzz targets (timeboxed)
         env:
-          RUST_FUZZ_TIME: ${{ github.event.inputs.rust_fuzz_time || '60' }}
+          RUST_FUZZ_TIME: ${{ github.event.inputs.rust_fuzz_time || '300' }}
+          CHUNK_TARGETS: ${{ toJSON(matrix.chunk) }}
         run: |
+          set -euo pipefail
           quote_env_value() {
             local value="$1"
             printf "'"
@@ -96,7 +146,13 @@ jobs:
           RUST_ARTIFACTS_DIR="$GITHUB_WORKSPACE/.artifacts/fuzz-rust"
           mkdir -p "$RUST_ARTIFACTS_DIR"
           cd clients/rust
-          TARGETS=(merkle_determinism retarget_no_panic biguint_roundtrip sighash parse_tx parse_block_bytes compactsize validate_block_basic pow_check compact_shortid parse_htlc parse_vault parse_multisig fork_work block_subsidy covenant_genesis p2p_wire_message p2p_version_payload sig_verify_openssl sig_cache_structural connect_block_inmem da_chunk_hash_verify tx_dep_graph da_payload_commit_verify tx_relay_announce tx_relay_receive)
+          # The chunk arrives from the prepare job matrix as a JSON array of
+          # target names taken from scripts/ci/rust_fuzz_targets.txt.
+          mapfile -t TARGETS < <(jq -r '.[]' <<<"$CHUNK_TARGETS")
+          if [[ "${#TARGETS[@]}" -eq 0 ]]; then
+            echo "FAIL: empty target chunk" >&2
+            exit 2
+          fi
           {
             write_env_field "commit_sha" "${GITHUB_SHA}"
             write_env_field "workflow_run_id" "${GITHUB_RUN_ID}"
@@ -129,10 +185,33 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fuzz-rust-${{ github.run_id }}
+          name: fuzz-rust-${{ github.run_id }}-c${{ strategy.job-index }}
           path: |
             .artifacts/fuzz-rust/**
             clients/rust/fuzz/artifacts/
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
+
+  # Single aggregate verdict so a nightly run stays answerable as one result.
+  verdict:
+    needs: [fuzz-stage2, fuzz-rust]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate nightly fuzz verdict
+        env:
+          GO_RESULT: ${{ needs.fuzz-stage2.result }}
+          RUST_RESULT: ${{ needs.fuzz-rust.result }}
+        run: |
+          echo "verdict: go-matrix=${GO_RESULT} rust-matrix=${RUST_RESULT}"
+          for result in "$GO_RESULT" "$RUST_RESULT"; do
+            case "$result" in
+              failure|cancelled)
+                echo "FAIL: a nightly fuzz matrix ended with result: $result" >&2
+                exit 1
+                ;;
+            esac
+          done
+          echo "PASS: both nightly fuzz matrices completed without defect evidence"

--- a/scripts/ci/classify_go_fuzz_exit.sh
+++ b/scripts/ci/classify_go_fuzz_exit.sh
@@ -3,10 +3,9 @@
 # fuzztime-expiry shutdown race (exit 0) or defect evidence (exit 1).
 #
 # Benign signature (verified in go1.26.5, src/internal/fuzz/fuzz.go:129): the
-# fuzz coordinator can observe the fuzztime deadline via the parent done
-# channel before its own context reports it, so the suppression guard
-# `err == fuzzCtx.Err()` misses and a bare "context deadline exceeded" fails
-# the run even though the full fuzz budget was spent and no defect was found.
+# coordinator can observe the fuzztime deadline before its own context reports
+# it, so the `err == fuzzCtx.Err()` suppression guard misses and a bare
+# "context deadline exceeded" fails a run that spent its full budget cleanly.
 #
 # Usage:
 #   classify_go_fuzz_exit.sh <target> <fuzztime_seconds> <log_file> \
@@ -15,8 +14,7 @@
 # <corpus_before_list> is a file holding the sorted `find <corpus_dir> -type f`
 # output taken before the run (may be empty); <corpus_dir> may not exist.
 #
-# Exit codes: 0 = benign shutdown race (PASS-with-warning),
-#             1 = not benign (FAIL), 2 = usage/malformed-argument error.
+# Exit: 0 = benign race (PASS-with-warning), 1 = not benign (FAIL), 2 = usage.
 set -euo pipefail
 
 fail_usage() {
@@ -46,19 +44,31 @@ not_benign() {
   exit 1
 }
 
-# Conjunct 1: exactly one FAIL block, whose failure text is exactly the bare
-# "context deadline exceeded" line. Any other failure text (panic, assertion,
-# hang diagnostics) or a second FAIL block is defect evidence, not the race.
+# Conjunct 1: exactly one FAIL block, closed on both sides: the '^--- FAIL: '
+# count over ANY target closes the foreign-FAIL-block channel, and requiring
+# the bare deadline line followed immediately by the package-level "FAIL"
+# verdict line closes the trailing-diagnostic channel.
+any_fail_count="$(grep -Ec -- '^--- FAIL: ' "${log_file}" || true)"
+if [[ "${any_fail_count}" -ne 1 ]]; then
+  not_benign "expected exactly one FAIL block in the log, found ${any_fail_count}"
+fi
 fail_regex="^--- FAIL: ${target} \(([0-9]+(\.[0-9]+)?)s\)\$"
 fail_count="$(grep -Ec -- "${fail_regex}" "${log_file}" || true)"
 if [[ "${fail_count}" -ne 1 ]]; then
   not_benign "expected exactly one benign-shaped FAIL line, found ${fail_count}"
 fi
 fail_line_no="$(grep -En -- "${fail_regex}" "${log_file}" | cut -d: -f1)"
+# A NUL byte switches grep -En to "Binary file ... matches" with no line
+# number; classify instead of aborting on the sed call below via set -e.
+[[ "${fail_line_no}" =~ ^[0-9]+$ ]] || not_benign "FAIL line number not derivable (binary or malformed log)"
 fail_line="$(sed -n "${fail_line_no}p" "${log_file}")"
 next_line="$(sed -n "$((fail_line_no + 1))p" "${log_file}")"
 if [[ "${next_line}" != "    context deadline exceeded" ]]; then
   not_benign "failure text after the FAIL line is not the bare deadline"
+fi
+verdict_line="$(sed -n "$((fail_line_no + 2))p" "${log_file}")"
+if [[ "${verdict_line}" != "FAIL" ]]; then
+  not_benign "trailing diagnostic between the deadline and the package FAIL verdict"
 fi
 
 # Conjunct 2: the run must have consumed at least the full fuzztime budget.
@@ -70,15 +80,19 @@ if ! awk -v d="${duration}" -v budget="${fuzz_seconds}" 'BEGIN { exit !(d + 0 >=
   not_benign "deadline hit at ${duration}s, below the ${fuzz_seconds}s budget"
 fi
 
-# Conjunct 3: no crash/instability marker anywhere in the log. Each marker is
-# a distinct defect-evidence channel: a written failing input (reproducible
-# crash), a hung/terminated worker (abnormal termination), a worker
-# communication error, or an internal fuzz-engine failure.
+# Conjunct 3: no crash/instability marker anywhere in the log. Each closes a
+# distinct defect-evidence channel: written failing input (reproducible crash),
+# hung/terminated worker, worker communication error, internal fuzz-engine
+# failure, "panic:" (a cleanup/TestMain panic produces no other marker), and
+# "fatal error:" (runtime aborts like concurrent map writes print fatal
+# error:, not panic:, and can follow the package FAIL verdict).
 for marker in \
   "Failing input written" \
   "fuzzing process hung or terminated" \
   "communicating with fuzzing process" \
-  "internal failure"; do
+  "internal failure" \
+  "panic:" \
+  "fatal error:"; do
   if grep -Fq -- "${marker}" "${log_file}"; then
     not_benign "defect-evidence marker present: ${marker}"
   fi

--- a/scripts/ci/classify_go_fuzz_exit.sh
+++ b/scripts/ci/classify_go_fuzz_exit.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Classify a non-zero `go test -fuzz` exit as either the benign upstream
+# fuzztime-expiry shutdown race (exit 0) or defect evidence (exit 1).
+#
+# Benign signature (verified in go1.26.5, src/internal/fuzz/fuzz.go:129): the
+# fuzz coordinator can observe the fuzztime deadline via the parent done
+# channel before its own context reports it, so the suppression guard
+# `err == fuzzCtx.Err()` misses and a bare "context deadline exceeded" fails
+# the run even though the full fuzz budget was spent and no defect was found.
+#
+# Usage:
+#   classify_go_fuzz_exit.sh <target> <fuzztime_seconds> <log_file> \
+#       <corpus_before_list> <corpus_dir>
+#
+# <corpus_before_list> is a file holding the sorted `find <corpus_dir> -type f`
+# output taken before the run (may be empty); <corpus_dir> may not exist.
+#
+# Exit codes: 0 = benign shutdown race (PASS-with-warning),
+#             1 = not benign (FAIL), 2 = usage/malformed-argument error.
+set -euo pipefail
+
+fail_usage() {
+  echo "FAIL: $*" >&2
+  exit 2
+}
+
+if (($# != 5)); then
+  fail_usage "expected 5 arguments: <target> <fuzztime_seconds> <log_file> <corpus_before_list> <corpus_dir>"
+fi
+
+target="$1"
+fuzz_seconds="$2"
+log_file="$3"
+corpus_before_list="$4"
+corpus_dir="$5"
+
+# Target feeds a grep pattern below; restricting it to a Go identifier keeps
+# hostile input out of the regex.
+[[ "${target}" =~ ^[A-Za-z0-9_]+$ ]] || fail_usage "target must be a Go identifier: ${target}"
+[[ "${fuzz_seconds}" =~ ^[0-9]+$ ]] || fail_usage "fuzztime_seconds must match ^[0-9]+\$: ${fuzz_seconds}"
+[[ -f "${log_file}" && -r "${log_file}" ]] || fail_usage "log file not readable: ${log_file}"
+[[ -f "${corpus_before_list}" && -r "${corpus_before_list}" ]] || fail_usage "corpus before-list not readable: ${corpus_before_list}"
+
+not_benign() {
+  echo "NOT_BENIGN ${target}: $*" >&2
+  exit 1
+}
+
+# Conjunct 1: exactly one FAIL block, whose failure text is exactly the bare
+# "context deadline exceeded" line. Any other failure text (panic, assertion,
+# hang diagnostics) or a second FAIL block is defect evidence, not the race.
+fail_regex="^--- FAIL: ${target} \(([0-9]+(\.[0-9]+)?)s\)\$"
+fail_count="$(grep -Ec -- "${fail_regex}" "${log_file}" || true)"
+if [[ "${fail_count}" -ne 1 ]]; then
+  not_benign "expected exactly one benign-shaped FAIL line, found ${fail_count}"
+fi
+fail_line_no="$(grep -En -- "${fail_regex}" "${log_file}" | cut -d: -f1)"
+fail_line="$(sed -n "${fail_line_no}p" "${log_file}")"
+next_line="$(sed -n "$((fail_line_no + 1))p" "${log_file}")"
+if [[ "${next_line}" != "    context deadline exceeded" ]]; then
+  not_benign "failure text after the FAIL line is not the bare deadline"
+fi
+
+# Conjunct 2: the run must have consumed at least the full fuzztime budget.
+# A deadline below budget means something else cancelled the run early and the
+# fuzz coverage was NOT delivered — that is red, not the shutdown race.
+duration="${fail_line#*"("}"
+duration="${duration%"s)"}"
+if ! awk -v d="${duration}" -v budget="${fuzz_seconds}" 'BEGIN { exit !(d + 0 >= budget + 0) }'; then
+  not_benign "deadline hit at ${duration}s, below the ${fuzz_seconds}s budget"
+fi
+
+# Conjunct 3: no crash/instability marker anywhere in the log. Each marker is
+# a distinct defect-evidence channel: a written failing input (reproducible
+# crash), a hung/terminated worker (abnormal termination), a worker
+# communication error, or an internal fuzz-engine failure.
+for marker in \
+  "Failing input written" \
+  "fuzzing process hung or terminated" \
+  "communicating with fuzzing process" \
+  "internal failure"; do
+  if grep -Fq -- "${marker}" "${log_file}"; then
+    not_benign "defect-evidence marker present: ${marker}"
+  fi
+done
+
+# Conjunct 4: no new file under the target's corpus dir. `go test` writes any
+# discovered crasher into testdata/fuzz/<Target>/ before exiting, so an
+# unchanged sorted file list proves no crash input was recorded.
+corpus_after="$(mktemp)"
+trap 'rm -f "${corpus_after}"' EXIT
+if [[ -d "${corpus_dir}" ]]; then
+  find "${corpus_dir}" -type f | sort > "${corpus_after}"
+fi
+if ! diff -q -- "${corpus_before_list}" "${corpus_after}" >/dev/null; then
+  not_benign "corpus file list changed under ${corpus_dir}"
+fi
+
+echo "BENIGN_FUZZTIME_SHUTDOWN_RACE ${target}: full ${fuzz_seconds}s budget spent, no defect evidence"
+exit 0

--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -47,11 +47,16 @@ TARGETS=(
 
 usage() {
   cat <<USAGE
-Usage: scripts/ci/run_fuzz_stage2.sh
+Usage: scripts/ci/run_fuzz_stage2.sh [--list-json | --target <pkg:Target>]
 
 Runs the bounded Go stage2 fuzz target list and writes reproducibility metadata
 under .artifacts/fuzz-stage2/. The script does not commit, push, regenerate
 tracked fixtures, or open issues.
+
+Modes:
+  (no args)          run every target in the list (local use)
+  --list-json        print the target list as a compact JSON array and exit
+  --target <spec>    run exactly one listed "pkg:Target" spec (CI matrix use)
 
 Environment:
   FUZZ_TIME=${FUZZ_TIME}
@@ -62,16 +67,77 @@ Artifact metadata includes:
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  usage
-  exit 0
+# TARGETS entries are trusted in-file literals ("pkg:Target", no quotes or
+# backslashes), so plain string concatenation yields valid JSON.
+list_json() {
+  local out="["
+  local first=1
+  local spec
+  for spec in "${TARGETS[@]}"; do
+    if ((first)); then first=0; else out+=","; fi
+    out+="\"${spec}\""
+  done
+  printf '%s]\n' "${out}"
+}
+
+MODE="all"
+TARGET_SPEC=""
+case "${1:-}" in
+  --help|-h)
+    usage
+    exit 0
+    ;;
+  --list-json)
+    if (($# > 1)); then
+      echo "FAIL: --list-json takes no extra arguments" >&2
+      exit 2
+    fi
+    list_json
+    exit 0
+    ;;
+  --target)
+    if (($# != 2)); then
+      echo "FAIL: --target requires exactly one pkg:Target spec" >&2
+      usage >&2
+      exit 2
+    fi
+    MODE="single"
+    TARGET_SPEC="$2"
+    ;;
+  "")
+    MODE="all"
+    ;;
+  *)
+    echo "FAIL: unexpected arguments: $*" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "${MODE}" == "single" ]]; then
+  target_known=0
+  for spec in "${TARGETS[@]}"; do
+    if [[ "${spec}" == "${TARGET_SPEC}" ]]; then
+      target_known=1
+      break
+    fi
+  done
+  if [[ "${target_known}" -ne 1 ]]; then
+    echo "FAIL: unknown target spec: ${TARGET_SPEC}" >&2
+    exit 2
+  fi
 fi
 
-if (($# > 0)); then
-  echo "FAIL: unexpected arguments: $*" >&2
-  usage >&2
+if [[ ! "${FUZZ_TIME}" =~ ^[0-9]+s$ ]]; then
+  echo "FAIL: FUZZ_TIME must match ^[0-9]+s\$ (got: ${FUZZ_TIME})" >&2
   exit 2
 fi
+fuzz_seconds="${FUZZ_TIME%s}"
+# The +600s margin covers baseline-coverage gathering, minimisation
+# (FUZZ_MINIMIZE_TIME), coordinator shutdown, and runner starvation; without an
+# explicit -timeout the default 10m go test timeout would become the binding
+# kill once fuzztime reaches minutes.
+GO_TEST_TIMEOUT="$((fuzz_seconds + 600))s"
 
 COMMIT_SHA="${GITHUB_SHA:-$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || printf '%s' unknown)}"
 
@@ -155,9 +221,36 @@ write_target_metadata() {
     write_env_field "corpus_path" "${corpus_path}"
     write_env_field "artifacts_path" "${artifacts_path}"
     write_env_field "seed_path" "${corpus_path}"
-    write_env_field "command" "cd clients/go && go test -run=^$ -fuzz=\"${target}\" -fuzztime=\"${FUZZ_TIME}\" -fuzzminimizetime=\"${FUZZ_MINIMIZE_TIME}\" \"${pkg}\""
+    write_env_field "go_test_timeout" "${GO_TEST_TIMEOUT}"
+    write_env_field "command" "cd clients/go && go test -run=^$ -fuzz=\"${target}\" -fuzztime=\"${FUZZ_TIME}\" -fuzzminimizetime=\"${FUZZ_MINIMIZE_TIME}\" -timeout=\"${GO_TEST_TIMEOUT}\" \"${pkg}\""
     write_env_field "log_path" ".artifacts/fuzz-stage2/${target}.log"
   } > "${metadata_file}"
+}
+
+run_one_target() {
+  local pkg="$1"
+  local target="$2"
+  local log_file="${ARTIFACTS_DIR}/${target}.log"
+  local corpus_dir="${GO_DIR}/${pkg#./}/testdata/fuzz/${target}"
+  local corpus_before="${ARTIFACTS_DIR}/${target}.corpus-before.txt"
+  # Snapshot the corpus file list before the run: the benign-exit classifier
+  # treats "no new file here" as proof no crasher was written.
+  if [[ -d "${corpus_dir}" ]]; then
+    find "${corpus_dir}" -type f | sort > "${corpus_before}"
+  else
+    : > "${corpus_before}"
+  fi
+  write_target_metadata "${pkg}" "${target}"
+  echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
+  if go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" -timeout="${GO_TEST_TIMEOUT}" "${pkg}" >"${log_file}" 2>&1; then
+    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  elif "${ROOT_DIR}/scripts/ci/classify_go_fuzz_exit.sh" "${target}" "${fuzz_seconds}" "${log_file}" "${corpus_before}" "${corpus_dir}"; then
+    echo "PASS_AFTER_BENIGN_DEADLINE ${target} (upstream fuzztime shutdown race; full budget spent, no defect evidence)" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  else
+    STATUS=1
+    echo "FAIL ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  fi
 }
 
 trap collect_artifacts EXIT
@@ -168,25 +261,19 @@ write_run_metadata
   echo "commit sha: ${COMMIT_SHA}"
   echo "fuzz time per target: ${FUZZ_TIME}"
   echo "fuzz minimize time: ${FUZZ_MINIMIZE_TIME}"
+  echo "go test timeout: ${GO_TEST_TIMEOUT}"
   echo "metadata: ${ARTIFACTS_DIR}/run-metadata.env"
 } > "${ARTIFACTS_DIR}/summary.log"
 
 cd "${GO_DIR}"
 
-for spec in "${TARGETS[@]}"; do
-  pkg="${spec%%:*}"
-  target="${spec##*:}"
-  log_file="${ARTIFACTS_DIR}/${target}.log"
-  write_target_metadata "${pkg}" "${target}"
-  echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
-  echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
-  if ! go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" "${pkg}" >"${log_file}" 2>&1; then
-    STATUS=1
-    echo "FAIL ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
-  else
-    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
-  fi
-done
+if [[ "${MODE}" == "single" ]]; then
+  run_one_target "${TARGET_SPEC%%:*}" "${TARGET_SPEC##*:}"
+else
+  for spec in "${TARGETS[@]}"; do
+    run_one_target "${spec%%:*}" "${spec##*:}"
+  done
+fi
 
 echo "fuzz stage2 finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${ARTIFACTS_DIR}/summary.log"
 exit "${STATUS}"

--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -82,37 +82,37 @@ list_json() {
 
 MODE="all"
 TARGET_SPEC=""
-case "${1:-}" in
-  --help|-h)
-    usage
-    exit 0
-    ;;
-  --list-json)
-    if (($# > 1)); then
-      echo "FAIL: --list-json takes no extra arguments" >&2
-      exit 2
-    fi
-    list_json
-    exit 0
-    ;;
-  --target)
-    if (($# != 2)); then
-      echo "FAIL: --target requires exactly one pkg:Target spec" >&2
+# Full-loop mode only on truly empty argv: an empty-string first arg is rejected.
+if (($# > 0)); then
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --list-json)
+      if (($# > 1)); then
+        echo "FAIL: --list-json takes no extra arguments" >&2
+        exit 2
+      fi
+      list_json
+      exit 0
+      ;;
+    --target)
+      if (($# != 2)); then
+        echo "FAIL: --target requires exactly one pkg:Target spec" >&2
+        usage >&2
+        exit 2
+      fi
+      MODE="single"
+      TARGET_SPEC="$2"
+      ;;
+    *)
+      echo "FAIL: unexpected arguments: $*" >&2
       usage >&2
       exit 2
-    fi
-    MODE="single"
-    TARGET_SPEC="$2"
-    ;;
-  "")
-    MODE="all"
-    ;;
-  *)
-    echo "FAIL: unexpected arguments: $*" >&2
-    usage >&2
-    exit 2
-    ;;
-esac
+      ;;
+  esac
+fi
 
 if [[ "${MODE}" == "single" ]]; then
   target_known=0
@@ -128,11 +128,13 @@ if [[ "${MODE}" == "single" ]]; then
   fi
 fi
 
-if [[ ! "${FUZZ_TIME}" =~ ^[0-9]+s$ ]]; then
-  echo "FAIL: FUZZ_TIME must match ^[0-9]+s\$ (got: ${FUZZ_TIME})" >&2
+# {1,6} bounds the value so the +600 arithmetic below can never wrap int64.
+if [[ ! "${FUZZ_TIME}" =~ ^[0-9]{1,6}s$ ]]; then
+  echo "FAIL: FUZZ_TIME must match ^[0-9]{1,6}s\$ (got: ${FUZZ_TIME})" >&2
   exit 2
 fi
-fuzz_seconds="${FUZZ_TIME%s}"
+# 10# forces base-10: zero-padded input (e.g. 08s) is valid per the stated format but would otherwise be parsed as octal.
+fuzz_seconds="$((10#${FUZZ_TIME%s}))"
 # The +600s margin covers baseline-coverage gathering, minimisation
 # (FUZZ_MINIMIZE_TIME), coordinator shutdown, and runner starvation; without an
 # explicit -timeout the default 10m go test timeout would become the binding
@@ -244,7 +246,15 @@ run_one_target() {
   echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
   echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
   if go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" -timeout="${GO_TEST_TIMEOUT}" "${pkg}" >"${log_file}" 2>&1; then
-    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    # `go test -fuzz=<pattern>` matching no fuzz test exits 0, so a renamed or
+    # deleted target left in TARGETS would otherwise report a silent green
+    # PASS with zero coverage.
+    if grep -Eq -- '^fuzz: elapsed:' "${log_file}"; then
+      echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    else
+      STATUS=1
+      echo "FAIL ${target} (no fuzzing executed — target missing from package?)" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    fi
   elif "${ROOT_DIR}/scripts/ci/classify_go_fuzz_exit.sh" "${target}" "${fuzz_seconds}" "${log_file}" "${corpus_before}" "${corpus_dir}"; then
     echo "PASS_AFTER_BENIGN_DEADLINE ${target} (upstream fuzztime shutdown race; full budget spent, no defect evidence)" | tee -a "${ARTIFACTS_DIR}/summary.log"
   else

--- a/scripts/ci/rust_fuzz_targets.txt
+++ b/scripts/ci/rust_fuzz_targets.txt
@@ -1,0 +1,30 @@
+# Single-source nightly Rust fuzz target list, consumed by the prepare job of
+# .github/workflows/fuzz-nightly.yml (chunked into the fuzz-rust matrix).
+# Adding a target here requires no workflow edit: the matrix derives from this
+# file. Readers must skip blank lines and lines starting with '#'.
+merkle_determinism
+retarget_no_panic
+biguint_roundtrip
+sighash
+parse_tx
+parse_block_bytes
+compactsize
+validate_block_basic
+pow_check
+compact_shortid
+parse_htlc
+parse_vault
+parse_multisig
+fork_work
+block_subsidy
+covenant_genesis
+p2p_wire_message
+p2p_version_payload
+sig_verify_openssl
+sig_cache_structural
+connect_block_inmem
+da_chunk_hash_verify
+tx_dep_graph
+da_payload_commit_verify
+tx_relay_announce
+tx_relay_receive

--- a/scripts/ci/test_classify_go_fuzz_exit.sh
+++ b/scripts/ci/test_classify_go_fuzz_exit.sh
@@ -77,20 +77,22 @@ cat > "${CRASH_LOG}" <<'EOF'
 fuzz: elapsed: 45s, execs: 324315 (13337/sec), new interesting: 15 (total: 17)
 --- FAIL: FuzzX (46.02s)
     context deadline exceeded
-Failing input written to testdata/fuzz/FuzzX/abc
 FAIL
+Failing input written to testdata/fuzz/FuzzX/abc
 exit status 1
 EOF
 run_case crash_with_input 1 \
   FuzzX 45 "${CRASH_LOG}" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
 
-# Case 3: a hung/terminated worker is abnormal termination (conjunct 3).
+# Case 3: a hung/terminated worker is abnormal termination — rejected by its
+# marker (conjunct 3) even when the FAIL block itself is benign-shaped.
 HUNG_LOG="${WORKDIR}/hung.log"
 cat > "${HUNG_LOG}" <<'EOF'
 fuzz: elapsed: 3s, execs: 18013 (6004/sec), new interesting: 3 (total: 5)
 --- FAIL: FuzzX (52.00s)
-    fuzzing process hung or terminated unexpectedly: exit status 2
+    context deadline exceeded
 FAIL
+fuzzing process hung or terminated unexpectedly: exit status 2
 exit status 1
 EOF
 run_case hung_or_terminated 1 \
@@ -124,6 +126,45 @@ run_case duration_below_budget 1 \
 # Case 7: malformed fuzztime argument fails closed with the usage code.
 run_case malformed_fuzztime 2 \
   FuzzDAChunkHashVerify 45s "${BENIGN_LOG}" "${EMPTY_LIST}" "${EMPTY_CORPUS_DIR}"
+
+# Case 8: a diagnostic between the deadline and the package "FAIL" verdict.
+cat > "${WORKDIR}/trailing.log" <<'EOF'
+--- FAIL: FuzzX (46.02s)
+    context deadline exceeded
+    cleanup: assertion failed
+EOF
+run_case trailing_diagnostic_after_deadline 1 \
+  FuzzX 45 "${WORKDIR}/trailing.log" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 9: a panic after an otherwise benign-shaped block (conjunct 3).
+cat > "${WORKDIR}/panic.log" <<'EOF'
+--- FAIL: FuzzX (46.02s)
+    context deadline exceeded
+FAIL
+panic: runtime error: index out of range
+EOF
+run_case panic_after_benign_block 1 \
+  FuzzX 45 "${WORKDIR}/panic.log" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 10: a second FAIL block for another target elsewhere in the log.
+cat > "${WORKDIR}/second.log" <<'EOF'
+--- FAIL: FuzzX (46.02s)
+    context deadline exceeded
+FAIL
+--- FAIL: FuzzY (1.00s)
+EOF
+run_case second_fail_block 1 \
+  FuzzX 45 "${WORKDIR}/second.log" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 11: a Go runtime abort after an otherwise benign-shaped block.
+cat > "${WORKDIR}/fatal.log" <<'EOF'
+--- FAIL: FuzzX (46.02s)
+    context deadline exceeded
+FAIL
+fatal error: concurrent map writes
+EOF
+run_case fatal_error_after_verdict 1 \
+  FuzzX 45 "${WORKDIR}/fatal.log" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
 
 echo "classifier corpus: ${PASS_COUNT}/${TOTAL} PASS"
 if [[ "${FAILED}" -ne 0 ]]; then

--- a/scripts/ci/test_classify_go_fuzz_exit.sh
+++ b/scripts/ci/test_classify_go_fuzz_exit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Executing corpus for scripts/ci/classify_go_fuzz_exit.sh. Runs locally in
+# seconds, no network. Each case pins the classifier's exact exit code; any
+# mismatch fails the suite.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLASSIFIER="${ROOT_DIR}/scripts/ci/classify_go_fuzz_exit.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+TOTAL=0
+PASS_COUNT=0
+FAILED=0
+
+run_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local actual=0
+  TOTAL=$((TOTAL + 1))
+  if "${CLASSIFIER}" "$@" >/dev/null 2>&1; then
+    actual=0
+  else
+    actual=$?
+  fi
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "PASS ${name} (exit ${actual})"
+  else
+    FAILED=1
+    echo "FAIL ${name}: expected exit ${expected}, got ${actual}" >&2
+  fi
+}
+
+EMPTY_LIST="${WORKDIR}/empty-before.txt"
+: > "${EMPTY_LIST}"
+
+# Case 1: the verbatim benign log recorded from nightly run 30422282156
+# (2026-07-29): full 45s budget spent, bare deadline, no crasher written.
+BENIGN_LOG="${WORKDIR}/benign.log"
+cat > "${BENIGN_LOG}" <<'EOF'
+fuzz: elapsed: 0s, gathering baseline coverage: 0/2 completed
+fuzz: elapsed: 0s, gathering baseline coverage: 2/2 completed, now fuzzing with 4 workers
+fuzz: elapsed: 3s, execs: 18013 (6004/sec), new interesting: 3 (total: 5)
+fuzz: elapsed: 6s, execs: 23121 (1701/sec), new interesting: 6 (total: 8)
+fuzz: elapsed: 9s, execs: 23365 (81/sec), new interesting: 7 (total: 9)
+fuzz: elapsed: 12s, execs: 24852 (496/sec), new interesting: 8 (total: 10)
+fuzz: elapsed: 15s, execs: 24852 (0/sec), new interesting: 8 (total: 10)
+fuzz: elapsed: 18s, execs: 28855 (1336/sec), new interesting: 9 (total: 11)
+fuzz: elapsed: 21s, execs: 32203 (1116/sec), new interesting: 11 (total: 13)
+fuzz: elapsed: 24s, execs: 60590 (9463/sec), new interesting: 12 (total: 14)
+fuzz: elapsed: 27s, execs: 81347 (6919/sec), new interesting: 13 (total: 15)
+fuzz: elapsed: 30s, execs: 128948 (15867/sec), new interesting: 13 (total: 15)
+fuzz: elapsed: 33s, execs: 187312 (19455/sec), new interesting: 13 (total: 15)
+fuzz: elapsed: 36s, execs: 238166 (16950/sec), new interesting: 13 (total: 15)
+fuzz: elapsed: 39s, execs: 272865 (11564/sec), new interesting: 14 (total: 16)
+fuzz: elapsed: 42s, execs: 284302 (3813/sec), new interesting: 14 (total: 16)
+fuzz: elapsed: 45s, execs: 324315 (13337/sec), new interesting: 15 (total: 17)
+fuzz: elapsed: 46s, execs: 324315 (0/sec), new interesting: 15 (total: 17)
+--- FAIL: FuzzDAChunkHashVerify (46.02s)
+    context deadline exceeded
+FAIL
+exit status 1
+FAIL	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus	46.024s
+EOF
+EMPTY_CORPUS_DIR="${WORKDIR}/corpus-empty/FuzzDAChunkHashVerify"
+mkdir -p "${EMPTY_CORPUS_DIR}"
+run_case benign_real_log 0 \
+  FuzzDAChunkHashVerify 45 "${BENIGN_LOG}" "${EMPTY_LIST}" "${EMPTY_CORPUS_DIR}"
+
+# Case 2: a written failing input is a reproducible crash (conjunct 3), even
+# when the FAIL block itself is benign-shaped and the budget was spent.
+CRASH_LOG="${WORKDIR}/crash.log"
+cat > "${CRASH_LOG}" <<'EOF'
+fuzz: elapsed: 45s, execs: 324315 (13337/sec), new interesting: 15 (total: 17)
+--- FAIL: FuzzX (46.02s)
+    context deadline exceeded
+Failing input written to testdata/fuzz/FuzzX/abc
+FAIL
+exit status 1
+EOF
+run_case crash_with_input 1 \
+  FuzzX 45 "${CRASH_LOG}" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 3: a hung/terminated worker is abnormal termination (conjunct 3).
+HUNG_LOG="${WORKDIR}/hung.log"
+cat > "${HUNG_LOG}" <<'EOF'
+fuzz: elapsed: 3s, execs: 18013 (6004/sec), new interesting: 3 (total: 5)
+--- FAIL: FuzzX (52.00s)
+    fuzzing process hung or terminated unexpectedly: exit status 2
+FAIL
+exit status 1
+EOF
+run_case hung_or_terminated 1 \
+  FuzzX 45 "${HUNG_LOG}" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 4: any failure text other than the bare deadline is defect evidence
+# (conjunct 1).
+OTHER_LOG="${WORKDIR}/other.log"
+cat > "${OTHER_LOG}" <<'EOF'
+fuzz: elapsed: 45s, execs: 324315 (13337/sec), new interesting: 15 (total: 17)
+--- FAIL: FuzzX (46.02s)
+    fuzz_test.go:33: round-trip mismatch
+FAIL
+exit status 1
+EOF
+run_case non_benign_text 1 \
+  FuzzX 45 "${OTHER_LOG}" "${EMPTY_LIST}" "${WORKDIR}/no-such-corpus"
+
+# Case 5: benign-looking text plus a new corpus file stays FAIL (conjunct 4).
+GROWN_CORPUS_DIR="${WORKDIR}/corpus-grown/FuzzDAChunkHashVerify"
+mkdir -p "${GROWN_CORPUS_DIR}"
+printf 'go test fuzz v1\n[]byte("x")\n' > "${GROWN_CORPUS_DIR}/deadbeef"
+run_case benign_text_plus_new_corpus_file 1 \
+  FuzzDAChunkHashVerify 45 "${BENIGN_LOG}" "${EMPTY_LIST}" "${GROWN_CORPUS_DIR}"
+
+# Case 6: a deadline below the budget means fuzz coverage was not delivered
+# (conjunct 2): the same 46.02s log checked against a 60s budget.
+run_case duration_below_budget 1 \
+  FuzzDAChunkHashVerify 60 "${BENIGN_LOG}" "${EMPTY_LIST}" "${EMPTY_CORPUS_DIR}"
+
+# Case 7: malformed fuzztime argument fails closed with the usage code.
+run_case malformed_fuzztime 2 \
+  FuzzDAChunkHashVerify 45s "${BENIGN_LOG}" "${EMPTY_LIST}" "${EMPTY_CORPUS_DIR}"
+
+echo "classifier corpus: ${PASS_COUNT}/${TOTAL} PASS"
+if [[ "${FAILED}" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1061
- GitHub Issue mirror (non-authoritative): #1061

Refs: Q-CI-FUZZ-NIGHTLY-BUDGET-01

## Summary
The nightly fuzz workflow fans out into per-target Go jobs and chunked Rust jobs, both matrices derived at run time from single-source lists (the runner script's TARGETS array via a new `--list-json` mode; a new `scripts/ci/rust_fuzz_targets.txt`), so nightly wall clock no longer scales with target count and adding a target needs no workflow edit. The per-target budget rises from 45s/60s to a deliberate 300s default, and the Go runner now passes an explicit `go test -timeout` of fuzztime+600s so the default 10-minute test timeout can never become the binding kill at minutes-scale budgets.

A non-zero `go test -fuzz` exit is now red only on defect evidence. The 2026-07-29 nightly went red on FuzzDAChunkHashVerify with a bare `context deadline exceeded` at 46.02s after the full 45s budget was spent and zero crash inputs — an upstream race in the go1.26.5 fuzz coordinator shutdown (the parent done channel closes before child-context cancellation propagates, so the suppression guard at internal/fuzz/fuzz.go:129 misses). A new standalone classifier reports that signature PASS_AFTER_BENIGN_DEADLINE, visible in the summary, only when all four conjuncts hold: exactly one benign-shaped FAIL block with the bare deadline line, duration at or above the budget, none of the four crash/instability markers, and an unchanged corpus file list under the target's testdata/fuzz directory. Anything else stays FAIL. An executing seven-case corpus pins every classifier branch, seeded with the verbatim red-nightly log.

## Invariant
Every fuzz target gets a per-target time budget that is a deliberate choice rather than a consequence of how many targets exist, and a nightly run reports red only on defect evidence — never because a target ran out of wall clock and never from the fuzztime-expiry shutdown race.

## Scope
- Changed files: 5
- Surfaces: tooling
- Non-scope: no fuzz target body or assertion, no target added or removed (11 unwired Rust fuzz_targets files remain a recorded follow-up), no corpus seeding or crash-promotion policy, no other workflow, no Go toolchain change, no client source, no retry loop
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `scripts/ci/test_classify_go_fuzz_exit.sh` — PASS (classifier corpus: 7/7, including the verbatim 2026-07-29 red-nightly log as the benign seed); `FUZZ_TIME=5s FUZZ_MINIMIZE_TIME=1s scripts/dev-env.sh -- scripts/ci/run_fuzz_stage2.sh --target "./consensus:FuzzDAChunkHashVerify"` — PASS (metadata records go_test_timeout=605s); `scripts/ci/run_fuzz_stage2.sh --list-json | jq length` — 32; `scripts/ci/run_fuzz_stage2.sh --target bogus` — exit 2; rust chunking expression over rust_fuzz_targets.txt — 6 chunks, 26 names; `actionlint .github/workflows/fuzz-nightly.yml` — PASS; `shellcheck` on all three scripts — PASS; `bash -n` on all three scripts — PASS; `git diff --check` — PASS
- `workflow_dispatch` run of the modified workflow on this PR head (fuzz_time=15s, rust_fuzz_time=15): https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30446044900 — PASS, 40/40 jobs green (prepare + 32 per-target Go jobs + 6 Rust chunk jobs + verdict), 38 artifacts uploaded, wall clock 3m25s; the Rust chunk logs show each target genuinely fuzzing (`Done 321409 runs in 16 second(s)`), and FuzzDAChunkHashVerify reports PASS through the new single-target path.

## Follow-ups / Waivers
- 11 Rust fuzz targets exist under clients/rust/fuzz/fuzz_targets/ but are not wired into the nightly list (measured 2026-07-29); wiring them is a separately owned decision recorded in RUB-1061's system_boundary, not part of this slice.
