### PR TITLE
RUB-1061: classify a zero-exit fuzz run as fuzzed, missing, or setup-skipped

### DIFF
--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -246,20 +246,21 @@ run_one_target() {
   echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
   echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
   if go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" -timeout="${GO_TEST_TIMEOUT}" "${pkg}" >"${log_file}" 2>&1; then
-    # `go test -fuzz=<pattern>` matching no fuzz test exits 0, so a renamed or
-    # deleted target left in TARGETS would otherwise report a silent green
-    # PASS with zero coverage. Warning text pinned empirically on go1.26.5:
-    # "testing: warning: no fuzz tests to fuzz".
+    # A zero exit is a real PASS only with fuzz-execution evidence: `go test
+    # -fuzz=<pattern>` matching nothing exits 0, and a setup f.Skipf() (e.g.
+    # unavailable ML-DSA backend, measured 2026-07-29) leaves a bare PASS log.
     if grep -Eq -- '^fuzz: elapsed:' "${log_file}"; then
       echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
-    elif grep -Fq -- "testing: warning: no fuzz tests to fuzz" "${log_file}"; then
+    # Disambiguate via the test binary's own -list output — the truth source
+    # for target existence: the no-fuzz-tests warning is not emitted when the
+    # package has no fuzz tests at all. The -list run reuses the already-built
+    # test binary, so it is cheap. Ambiguity is FAIL (fail closed).
+    elif go test -run='^$' -list "^${target}\$" "${pkg}" >"${ARTIFACTS_DIR}/${target}.list.txt" 2>&1 &&
+      grep -Fxq -- "${target}" "${ARTIFACTS_DIR}/${target}.list.txt"; then
+      echo "SKIP_FUZZ_SETUP ${target} (fuzz target skipped during setup; zero fuzz coverage — ML-DSA backend unavailable? see RUB-1064)" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    else
       STATUS=1
       echo "FAIL ${target} (no fuzzing executed — target missing from package?)" | tee -a "${ARTIFACTS_DIR}/summary.log"
-    else
-      # Measured 2026-07-29: targets whose setup f.Skipf()s on an unavailable
-      # crypto backend exit 0 with a bare PASS log; visible-never-silent, and
-      # red stays reserved for defect evidence.
-      echo "SKIP_FUZZ_SETUP ${target} (fuzz target skipped during setup; zero fuzz coverage — ML-DSA backend unavailable? see RUB-1064)" | tee -a "${ARTIFACTS_DIR}/summary.log"
     fi
   elif "${ROOT_DIR}/scripts/ci/classify_go_fuzz_exit.sh" "${target}" "${fuzz_seconds}" "${log_file}" "${corpus_before}" "${corpus_dir}"; then
     echo "PASS_AFTER_BENIGN_DEADLINE ${target} (upstream fuzztime shutdown race; full budget spent, no defect evidence)" | tee -a "${ARTIFACTS_DIR}/summary.log"

--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -248,12 +248,18 @@ run_one_target() {
   if go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" -timeout="${GO_TEST_TIMEOUT}" "${pkg}" >"${log_file}" 2>&1; then
     # `go test -fuzz=<pattern>` matching no fuzz test exits 0, so a renamed or
     # deleted target left in TARGETS would otherwise report a silent green
-    # PASS with zero coverage.
+    # PASS with zero coverage. Warning text pinned empirically on go1.26.5:
+    # "testing: warning: no fuzz tests to fuzz".
     if grep -Eq -- '^fuzz: elapsed:' "${log_file}"; then
       echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
-    else
+    elif grep -Fq -- "testing: warning: no fuzz tests to fuzz" "${log_file}"; then
       STATUS=1
       echo "FAIL ${target} (no fuzzing executed — target missing from package?)" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    else
+      # Measured 2026-07-29: targets whose setup f.Skipf()s on an unavailable
+      # crypto backend exit 0 with a bare PASS log; visible-never-silent, and
+      # red stays reserved for defect evidence.
+      echo "SKIP_FUZZ_SETUP ${target} (fuzz target skipped during setup; zero fuzz coverage — ML-DSA backend unavailable? see RUB-1064)" | tee -a "${ARTIFACTS_DIR}/summary.log"
     fi
   elif "${ROOT_DIR}/scripts/ci/classify_go_fuzz_exit.sh" "${target}" "${fuzz_seconds}" "${log_file}" "${corpus_before}" "${corpus_dir}"; then
     echo "PASS_AFTER_BENIGN_DEADLINE ${target} (upstream fuzztime shutdown race; full budget spent, no defect evidence)" | tee -a "${ARTIFACTS_DIR}/summary.log"


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1061
- GitHub Issue mirror (non-authoritative): #1061

Refs: Q-CI-FUZZ-NIGHTLY-BUDGET-01

## Summary
Follow-up to #2728, which merged before this final slice landed on its branch. The runner's zero-exit handling becomes a three-way classification: a log with `fuzz: elapsed:` evidence is PASS; otherwise the test binary's own `-list` output is the truth source for target existence — the run is a loud `SKIP_FUZZ_SETUP` summary line with the job green only when `-list` exits 0 and prints the exact target name (captured per target in the artifacts for audit), and anything else — a renamed or deleted target, a package that lost its last fuzz test (which emits neither fuzz output nor the no-match warning, reproduced against ./cmd/rubin-node), or a failed `-list` run — fails closed as FAIL.

Without this, tonight's cron nightly goes red on FuzzUtxoApplyNonCoinbase and FuzzDaFeeFloorPolicyBoundaries: the #2728 no-fuzzing guard fires FAIL on them, but their zero coverage is not a defect of this run — their setup calls f.Skipf("ML-DSA backend unavailable") on GitHub runners (identical bare-PASS logs exist in pre-#2728 nightly artifacts, so they have never fuzzed in CI). The backend repair is owned by RUB-1064; until it lands the skip stays visible in every summary, never silent and never red.

## Invariant
A zero-exit fuzz run is green only with evidence — real fuzzing, or a loudly logged setup skip — while a target missing from its package stays red; red remains reserved for defect evidence.

## Scope
- Changed files: 1
- Surfaces: tooling
- Non-scope: no classifier change, no workflow change, no fuzz target body, no ML-DSA backend provisioning (RUB-1064), no client source
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: stub-go four-way matrix (fuzz-evidence → PASS rc=0; bare PASS + `-list` prints the name → SKIP_FUZZ_SETUP rc=0 with list.txt present; bare PASS + `-list` without the name → FAIL rc=1; bare PASS + `-list` non-zero exit → FAIL rc=1) — PASS; live `-list` semantics on go1.26.5 (`./consensus` existing/missing name; `./cmd/rubin-node` as the no-fuzz-tests package) — verified; `FUZZ_TIME=5s FUZZ_MINIMIZE_TIME=1s scripts/dev-env.sh -- scripts/ci/run_fuzz_stage2.sh --target "./consensus:FuzzDAChunkHashVerify"` — PASS (fuzz-evidence path, no `-list` invoked); `scripts/ci/test_classify_go_fuzz_exit.sh` — 11/11 PASS (classifier untouched); `shellcheck` + `bash -n` — PASS; `git diff --check` — PASS; `workflow_dispatch` runs: 92fccf9 https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30451262783 — 40/40 green with both `SKIP_FUZZ_SETUP` lines visible; 6bf3580 https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30452694426 — result recorded below before merge.

## Follow-ups / Waivers
- RUB-1064 provisions an ML-DSA-capable OpenSSL for the runners so the two signature-path targets actually fuzz; the SKIP lines this PR introduces disappear there.
- Deferred debt recorded during #2728 review: quote_env_value duplication between runner and workflow; seed_path_for_pkg dead branches; wiring the classifier corpus test into CI.
