### PR TITLE
RUB-1063: wire the 11 unwired Rust fuzz targets and document the nightly classification

### DIFF
--- a/scripts/ci/rust_fuzz_targets.txt
+++ b/scripts/ci/rust_fuzz_targets.txt
@@ -28,3 +28,14 @@ tx_dep_graph
 da_payload_commit_verify
 tx_relay_announce
 tx_relay_receive
+block_header_surface
+connect_block_parallel_determinism
+connect_block_parallel_worker_parity
+featurebits_state
+flagday_helpers
+marshal_tx_roundtrip
+parse_tx_determinism
+sig_cache_concurrent
+spend_dispatch_structural
+suite_registry_surface
+validate_tx_local

--- a/tools/FUZZING.md
+++ b/tools/FUZZING.md
@@ -39,7 +39,7 @@ scripts/dev-env.sh -- bash -lc 'cd clients/go/consensus && go test -run=^$ -fuzz
 
 ## Rust (cargo-fuzz / libFuzzer)
 
-Targets live in `clients/rust/fuzz/fuzz_targets/`:
+Targets live in `clients/rust/fuzz/fuzz_targets/` (one per file); the nightly-wired set is `scripts/ci/rust_fuzz_targets.txt`. Examples:
 
 - `parse_tx`
 - `parse_block_bytes`
@@ -63,18 +63,65 @@ Notes:
 - Fuzz artifacts/corpora are ignored via `clients/rust/fuzz/.gitignore`.
 - Keep fuzz runs bounded (`-max_total_time=...`) for reproducibility during triage.
 
-## Nightly stage-2 fuzz run (CI)
+## Nightly fuzz run (CI)
 
-Nightly workflow:
+Nightly workflow: `.github/workflows/fuzz-nightly.yml`. This section mirrors the
+live implementation; on any doubt the cited files are the authority.
 
-- `.github/workflows/fuzz-nightly.yml`
+Fan-out (single-source lists, derived at run time by the `prepare` job):
 
-Runner script:
+- Go: one matrix job per `pkg:Target` from
+  `scripts/ci/run_fuzz_stage2.sh --list-json`; the single source is the
+  `TARGETS` array in that script.
+- Rust: `scripts/ci/rust_fuzz_targets.txt` (blank/`#` lines skipped), chunked
+  into groups of 5 — the chunking amortises the per-job nightly-toolchain +
+  cargo-fuzz + fuzz-crate build cost while keeping wall clock flat.
+- Adding a target is therefore a list edit only, never a workflow edit.
 
-- `scripts/ci/run_fuzz_stage2.sh`
+Budgets (deliberate, overridable via `workflow_dispatch` inputs):
 
-Behavior:
+- Go: `FUZZ_TIME` default `300s` per target, `FUZZ_MINIMIZE_TIME=5s`.
+- Rust: `RUST_FUZZ_TIME` default `300` seconds per target (`-max_total_time`).
+- The Go runner passes an explicit `go test -timeout` of fuzztime + 600s
+  (`scripts/ci/run_fuzz_stage2.sh`): the margin covers baseline-coverage
+  gathering, minimisation, coordinator shutdown, and runner starvation;
+  without it the default 10m `go test` timeout would become the binding kill
+  once fuzztime reaches minutes.
 
-- runs timeboxed stage-2 Go targets (covenant/sig/retarget/DA/UTXO);
-- uploads artifacts (`.artifacts/fuzz-stage2/**` and `clients/go/consensus/testdata/fuzz/**`);
-- preserves crash/regression evidence even when fuzz target fails.
+Go verdict classification (`scripts/ci/run_fuzz_stage2.sh` +
+`scripts/ci/classify_go_fuzz_exit.sh`) — red only on defect evidence:
+
+- Zero exit (#2731): PASS only with fuzz-execution evidence (a
+  `fuzz: elapsed:` log line). Otherwise, if the test binary's own `-list`
+  output proves the target exists, the run is a loud `SKIP_FUZZ_SETUP` and
+  the job stays green (setup `f.Skipf()`, e.g. unavailable ML-DSA backend;
+  repair owned by RUB-1064); a missing target or failed `-list` probe is red.
+- Non-zero exit: red unless the classifier proves the benign fuzztime-expiry
+  shutdown race; the summary then records `PASS_AFTER_BENIGN_DEADLINE`. All
+  four conjuncts must hold:
+  1. exactly one FAIL block in the log, benign-shaped
+     (`--- FAIL: <target> (<N>s)`), whose bare `context deadline exceeded`
+     line is followed immediately by the package `FAIL` verdict;
+  2. the recorded duration is at least the fuzztime budget (an early deadline
+     means the fuzz coverage was not delivered — red);
+  3. none of the crash/instability markers anywhere in the log (failing input
+     written, hung/terminated worker, worker communication error, internal
+     fuzz-engine failure, `panic:`, `fatal error:`);
+  4. the sorted file list under the target's `testdata/fuzz/<Target>/` corpus
+     dir is unchanged (no crasher was recorded).
+
+The classifier is Go-only by design: libFuzzer exits cleanly when
+`-max_total_time` expires, while the suppressed race lives in the go1.26.5
+fuzz coordinator shutdown (`src/internal/fuzz/fuzz.go:129`; the coordinator
+can observe the fuzztime deadline before its own context reports it). Rust
+chunk jobs are plain per-target pass/fail.
+
+Scope of the suppression: the classification turns a non-zero exit green for
+exactly one named upstream race signature, and a zero exit green-with-warning
+for exactly one `-list`-proven setup-skip shape — nothing else.
+
+Artifacts: Go jobs upload `.artifacts/fuzz-stage2/**` plus the
+`testdata/fuzz/**` trees (consensus, node, node/p2p); Rust chunk jobs upload
+`.artifacts/fuzz-rust/**` and `clients/rust/fuzz/artifacts/` — crash evidence
+survives a failing target. A final `verdict` job fails unless both matrices
+ended in exact `success`.


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1063
- GitHub Issue mirror (non-authoritative): #1063

Refs: Q-CI-FUZZ-NIGHTLY-WIRING-02

## Summary
The nightly Rust fuzz list catches up with the fuzz_targets directory: 11 targets that landed 2026-03-28..30 without nightly wiring (workflow list last extended 2026-03-28, #965) join `scripts/ci/rust_fuzz_targets.txt`, bringing the matrix to 8 chunks over 37 names with zero workflow edits — the single-source acceptance of RUB-1061 exercised for real. Every one of the 11 was smoked locally under cargo fuzz before wiring: clean build, clean bounded run, per-target receipts below. The list now matches the directory 1:1 (37/37, no exclusions needed).

tools/FUZZING.md replaces its pre-fan-out nightly stub with a section mirroring the live implementation, citing the source files as authority: single-source matrices, deliberate 300s budgets with the explicit `go test -timeout` fuzztime+600s margin, the four-conjunct benign shutdown-race classification with `PASS_AFTER_BENIGN_DEADLINE`, the `-list`-proven `SKIP_FUZZ_SETUP` zero-exit path (backend repair owned by RUB-1064), the classifier's Go-only scope, and the exact artifact surface.

## Invariant
Every buildable Rust fuzz target in the tree is wired into the nightly single-source list, each newly wired target is proven locally to build and fuzz cleanly before touching a nightly verdict, and the fuzzing documentation states the nightly's classification semantics exactly as the code implements them.

## Scope
- Changed files: 2
- Surfaces: tooling (single-source target list), docs
- Non-scope: no workflow, runner, or classifier change; no fuzz target body or Cargo.toml change; no Go-side list change; no budget retuning
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: per-target smoke of all 11 via `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo +nightly fuzz run "<t>" -- -max_total_time=5'` (cargo-fuzz 0.13.1, rustc 1.99.0-nightly) — 11/11 exit 0 with real throughput (e.g. block_header_surface `Done 1165139 runs in 6 second(s)`, sig_cache_concurrent `Done 79338 runs`); prepare-job chunking expression over the edited file — `[8, 37]`, order preserved (26 wired first, 11 appended); sorted list == sorted fuzz_targets directory (37/37); `git diff --check` — PASS; `workflow_dispatch` run on this head: PASS — 42/42 jobs green (prepare + 32 Go + 8 Rust chunks + verdict), artifacts c0-a1..c7-a1 present, new targets visibly fuzzing (suite_registry_surface: Done 2564711 runs; validate_tx_local: Done 1305831 runs). https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30455269136

## Follow-ups / Waivers
- RUB-1064 provisions the ML-DSA backend so the two Go signature-path targets fuzz in CI (independent of this slice).