### PR TITLE
RUB-1064: provision an ML-DSA-capable OpenSSL bundle for the Go fuzz matrix

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -57,6 +57,10 @@ jobs:
     # Must exceed GO_TEST_TIMEOUT at the documented fuzz_time=600s example
     # (1200s) plus checkout/setup-go/instrumented-build, so a hung target dies
     # by go test's own -timeout (writing the panic dump), never by the job cap.
+    # The OpenSSL bundle steps fit too: warm path (shared cache hit) is a
+    # restore plus one sha256, seconds; worst case cold path is ~2 min
+    # checkout/setup + <=~8 min source build (4-vCPU runner) + the 1200s
+    # hung-target kill + instrumented build ~= 36 min < 40.
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -79,11 +83,98 @@ jobs:
           cache: true
           cache-dependency-path: clients/go/go.mod
 
+      # ML-DSA backend provisioning (RUB-1064). The runner's system OpenSSL
+      # lacks ML-DSA, so the ML-DSA-gated targets f.Skipf during setup and
+      # produce zero fuzz coverage (surfaced as SKIP_FUZZ_SETUP since
+      # RUB-1061). The four steps below mirror the proven pair in ci.yml
+      # `test` (cache + guarded build + PQ visibility check); the identical
+      # cache key means nightly legs normally restore the bundle regular CI
+      # already built, and only build from source on a cold cache.
+      - name: Cache OpenSSL 3.5 bundle
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
+            ~/.cache/rubin-openssl/bundle-3.5.5
+            ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+
+      - name: Verify OpenSSL 3.5.5 source integrity
+        run: |
+          set -euo pipefail
+          # Pinned sha256 of the upstream source tarball, from the official
+          # release asset openssl-3.5.5.tar.gz.sha256 at
+          # https://github.com/openssl/openssl/releases/tag/openssl-3.5.5
+          # (independently re-downloaded and re-hashed on 2026-07-29).
+          EXPECTED_SHA256="b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
+          WORK_ROOT="$HOME/.cache/rubin-openssl/work"
+          TARBALL="$WORK_ROOT/openssl-3.5.5.tar.gz"
+          mkdir -p "$WORK_ROOT"
+          if [ ! -f "$TARBALL" ]; then
+            curl -fL --retry 3 \
+              "https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz" \
+              -o "$TARBALL"
+          fi
+          # Runs on the warm path too: the tarball may come from the shared
+          # actions cache, and a poisoned cache entry must fail closed here,
+          # never feed the build. (The built bundle itself cannot be pinned —
+          # the build is not bit-reproducible — so the trust chain is verified
+          # source plus a repo-scoped cache written only by this repo's CI.)
+          if ! echo "$EXPECTED_SHA256  $TARBALL" | sha256sum -c -; then
+            echo "ERROR: openssl-3.5.5.tar.gz sha256 mismatch (tampered download or poisoned cache); refusing to build" >&2
+            rm -f -- "$TARBALL"
+            exit 1
+          fi
+
+      - name: Build OpenSSL 3.5.5 bundle
+        run: |
+          set -euo pipefail
+          PREFIX="$HOME/.cache/rubin-openssl/bundle-3.5.5"
+          MODULES_DIR="$PREFIX/lib/ossl-modules"
+          if [ ! -d "$MODULES_DIR" ] && [ -d "$PREFIX/lib64/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib64/ossl-modules"
+          fi
+          if [ ! -x "$PREFIX/bin/openssl" ] || [ ! -f "$PREFIX/ssl/openssl-fips.cnf" ] || [ ! -d "$MODULES_DIR" ]; then
+            OPENSSL_VERSION=3.5.5 PREFIX="$PREFIX" bash scripts/crypto/openssl/build-openssl-bundle.sh
+          fi
+          if [ -d "$PREFIX/lib/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib/ossl-modules"
+          elif [ -d "$PREFIX/lib64/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib64/ossl-modules"
+          else
+            echo "ERROR: OpenSSL modules directory not found under $PREFIX/lib*/ossl-modules" >&2
+            exit 1
+          fi
+          {
+            echo "$PREFIX/bin"
+          } >> "$GITHUB_PATH"
+          # LD_LIBRARY_PATH is exported here deliberately: dev-env.sh
+          # select_openssl() wires PATH/OPENSSL_DIR/PKG_CONFIG_PATH/
+          # OPENSSL_MODULES from RUBIN_OPENSSL_PREFIX but does NOT export
+          # LD_LIBRARY_PATH, and the fuzz test binary links the bundle's
+          # libcrypto dynamically (#cgo pkg-config: openssl), so the runtime
+          # linker needs it exactly as in ci.yml `test`.
+          {
+            echo "OPENSSL_DIR=$PREFIX"
+            echo "PKG_CONFIG_PATH=$PREFIX/lib64/pkgconfig:$PREFIX/lib/pkgconfig"
+            echo "LD_LIBRARY_PATH=$PREFIX/lib64:$PREFIX/lib"
+            echo "OPENSSL_MODULES=$MODULES_DIR"
+            echo "OPENSSL_CONF=$PREFIX/ssl/openssl-fips.cnf"
+          } >> "$GITHUB_ENV"
+
+      # Fail fast with a precise diagnostic if the provisioned backend does
+      # not expose ML-DSA-87: a red step here means "backend broken", never
+      # "fuzzing found a defect".
+      - name: Verify OpenSSL PQ algorithms
+        run: |
+          openssl version
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
+
       - name: Run stage2 fuzz target (timeboxed)
         env:
           FUZZ_TIME: ${{ github.event.inputs.fuzz_time || '300s' }}
           FUZZ_MINIMIZE_TIME: "5s"
           FUZZ_TARGET: ${{ matrix.target }}
+          RUBIN_OPENSSL_PREFIX: ${{ env.OPENSSL_DIR }}
         run: |
           scripts/dev-env.sh -- bash -lc "cd \"$GITHUB_WORKSPACE\" && scripts/ci/run_fuzz_stage2.sh --target \"$FUZZ_TARGET\""
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -57,8 +57,8 @@ jobs:
     # Must exceed GO_TEST_TIMEOUT at the documented fuzz_time=600s example
     # (1200s) plus checkout/setup-go/instrumented-build, so a hung target dies
     # by go test's own -timeout (writing the panic dump), never by the job cap.
-    # The OpenSSL bundle steps fit too: warm path (shared cache hit) is a
-    # restore plus one sha256, seconds; worst case cold path is ~2 min
+    # The OpenSSL bundle steps fit too: warm path (dedicated-key cache hit)
+    # is a restore plus one sha256, seconds; worst case cold path is ~2 min
     # checkout/setup + <=~8 min source build (4-vCPU runner) + the 1200s
     # hung-target kill + instrumented build ~= 36 min < 40.
     timeout-minutes: 40
@@ -86,17 +86,28 @@ jobs:
       # ML-DSA backend provisioning (RUB-1064). The runner's system OpenSSL
       # lacks ML-DSA, so the ML-DSA-gated targets f.Skipf during setup and
       # produce zero fuzz coverage (surfaced as SKIP_FUZZ_SETUP since
-      # RUB-1061). The four steps below mirror the proven pair in ci.yml
-      # `test` (cache + guarded build + PQ visibility check); the identical
-      # cache key means nightly legs normally restore the bundle regular CI
-      # already built, and only build from source on a cold cache.
+      # RUB-1061). The four steps below follow the proven ci.yml `test` shape
+      # (cache + guarded build + PQ visibility check) with one deliberate
+      # deviation: a dedicated cache key plus a provenance marker, so the
+      # bundle the fuzz binary links provably descends from the
+      # sha256-verified source tarball.
+      #
+      # Dedicated key, deliberately NOT the shared openssl-bundle-*-v2 key:
+      # that one is also written by ci.yml and four other workflows whose
+      # build paths never verify the tarball, so a warm shared bundle has
+      # unverifiable provenance. This key is written exclusively by this
+      # workflow's verified-build path below — a warm bundle under it is one
+      # this job built from a sha256-verified source. No restore-keys
+      # fallback: a fallback would reintroduce unverified bundles. Cost:
+      # cold on first use (every matrix leg builds once, ~6-8 min, until the
+      # first successful save); warm restores afterwards are seconds.
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-mldsa-verified-${{ runner.os }}-3.5.5-v1
 
       - name: Verify OpenSSL 3.5.5 source integrity
         run: |
@@ -124,17 +135,43 @@ jobs:
             rm -f -- "$TARBALL"
             exit 1
           fi
+          # Single definition of the pin: the build step consumes this export
+          # for its provenance marker instead of repeating the literal, so the
+          # two steps cannot drift apart silently. Written only after the
+          # check above passed.
+          echo "RUBIN_OPENSSL_TARBALL_SHA256=$EXPECTED_SHA256" >> "$GITHUB_ENV"
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
           set -euo pipefail
+          # :? fails closed if the verify step did not run (reordered/removed):
+          # the build must never proceed without a verified pin in hand.
+          PINNED_SHA256="${RUBIN_OPENSSL_TARBALL_SHA256:?verify step must export the pin first}"
           PREFIX="$HOME/.cache/rubin-openssl/bundle-3.5.5"
+          # Provenance marker: records the sha256 of the source tarball this
+          # bundle was built from, making "this bundle descends from the
+          # verified source" checkable rather than inferred — and keeping the
+          # guard honest even if a future workflow starts writing this cache
+          # key without verification.
+          MARKER="$PREFIX/.rubin-verified-source-sha256"
           MODULES_DIR="$PREFIX/lib/ossl-modules"
           if [ ! -d "$MODULES_DIR" ] && [ -d "$PREFIX/lib64/ossl-modules" ]; then
             MODULES_DIR="$PREFIX/lib64/ossl-modules"
           fi
+          NEED_BUILD=0
           if [ ! -x "$PREFIX/bin/openssl" ] || [ ! -f "$PREFIX/ssl/openssl-fips.cnf" ] || [ ! -d "$MODULES_DIR" ]; then
+            NEED_BUILD=1
+          elif [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$PINNED_SHA256" ]; then
+            # A complete-looking bundle without a matching marker did not come
+            # from this workflow's verified-build path: rebuild it.
+            NEED_BUILD=1
+          fi
+          if [ "$NEED_BUILD" -eq 1 ]; then
+            # Wipe first so nothing from an unverified or partial bundle
+            # survives the reinstall (make install overwrites, never prunes).
+            rm -rf -- "$PREFIX"
             OPENSSL_VERSION=3.5.5 PREFIX="$PREFIX" bash scripts/crypto/openssl/build-openssl-bundle.sh
+            printf '%s\n' "$PINNED_SHA256" > "$MARKER"
           fi
           if [ -d "$PREFIX/lib/ossl-modules" ]; then
             MODULES_DIR="$PREFIX/lib/ossl-modules"


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1064
- GitHub Issue mirror (non-authoritative): #1064

Refs: Q-CI-FUZZ-MLDSA-BACKEND-01

## Summary
The Go fuzz matrix jobs gain an ML-DSA-capable OpenSSL 3.5.5 bundle via the proven ci.yml provisioning pair — the shared `openssl-bundle-*-3.5.5-v2` cache (warm from regular CI) and the guarded source build — so FuzzUtxoApplyNonCoinbase and FuzzDaFeeFloorPolicyBoundaries stop skipping on `ML-DSA backend unavailable` and actually fuzz in the nightly for the first time.

Beyond the ci.yml mirror, the source tarball's sha256 is pinned from the official openssl release asset (independently re-downloaded and re-hashed twice: by the writer and by the orchestrator) and verified before every build — including tarballs restored from the shared cache, so a poisoned cache entry fails closed instead of feeding the build. A PQ visibility step asserts `openssl list -signature-algorithms` exposes ML-DSA-87, making a broken backend a precise red step rather than a fuzz skip. The run step receives `RUBIN_OPENSSL_PREFIX` (dev-env's designed CI knob); `LD_LIBRARY_PATH` is exported exactly as in ci.yml because dev-env wires PATH/OPENSSL_DIR/PKG_CONFIG_PATH/OPENSSL_MODULES but not the runtime linker. The RUB-1061 SKIP classification is untouched and remains the guard for any future backend regression.

Review hardening (78203aa): the fuzz lane no longer shares the `openssl-bundle-*-v2` cache key — that key is also written by workflows whose build paths never verify the tarball, so a warm shared bundle had unverifiable provenance while the sha check validated a tarball the build never consumed. The lane now uses a dedicated `openssl-bundle-mldsa-verified-*` key with no restore-keys fallback, written exclusively by its own verified-build path; the verify step exports the single pin definition, and the build guard requires a provenance marker inside the bundle recording that pin — a complete-looking bundle without a matching marker is wiped and rebuilt from the verified tarball. Cold on first use by design; warm restores stay seconds.

## Invariant
Both ML-DSA-gated Go fuzz targets produce real fuzzing evidence in the nightly on GitHub-hosted runners, with the backend provisioned deterministically from a pinned, integrity-checked source, and no other job, client behavior, or consensus surface changes.

## Scope
- Changed files: 1
- Surfaces: tooling (nightly fuzz workflow, Go matrix job provisioning only)
- Non-scope: no fuzz target body, no client source, no dev-env change, no Rust job change (sig_verify_openssl coverage measured from the dispatch run and recorded below), no change to the other workflows that call build-openssl-bundle.sh without verification (deferred sibling family, separate issue)
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `actionlint` — PASS; `bash -n` + `shellcheck` on both extracted step scripts — PASS; sha256 pin `b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89` matches the official `openssl-3.5.5.tar.gz.sha256` release asset (verified independently twice); adversarial step matrix executed locally (fresh download OK; cached tarball OK; poisoned tarball → FAILED, file removed, exit 1; warm bundle skips build with correct env exports; cold path builds; missing ossl-modules → exit 1 before any export) — PASS; `scripts/ci/test_classify_go_fuzz_exit.sh` — 11/11 PASS (guard untouched); `git diff --check` — PASS; `workflow_dispatch` run on this head: https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30455396657 — PASS, 40/40 jobs green; both ML-DSA-gated targets FUZZ instead of skipping: FuzzUtxoApplyNonCoinbase `fuzz: elapsed: 16s, execs: 9930, new interesting: 15` and FuzzDaFeeFloorPolicyBoundaries `fuzz: elapsed: 15s, execs: 16009, new interesting: 14`, zero SKIP_FUZZ_SETUP lines; warm-path cost measured on the pre-hardening head (0bad6ff, shared key): the whole matrix job ran 44s wall — a cache restore plus one sha check, no source build; adversarial rows re-executed for the hardened guard (marker match => build skipped; marker missing => rebuild; marker mismatch => rebuild; cold => verify+build+marker written; poisoned tarball => fail closed before build; absent pin export => `:?` fails the step) — PASS; cold-path acceptance dispatch on head 78203aa (dedicated key starts empty): https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/30461634994 — PASS, 42/42 jobs green; both ML-DSA-gated targets PASS via the fuzz-evidence path (the runner emits PASS only with `fuzz: elapsed:` proof), zero SKIP lines; cold legs verified the source (`openssl-3.5.5.tar.gz: OK`), built the bundle, exposed ML-DSA-87 in the PQ visibility step and saved the dedicated-key cache, while later legs restored it warm — measured per-job wall: max 208s (cold, includes the verified build), min 45s (warm restore); the save race across matrix legs degraded gracefully as designed.

## Follow-ups / Waivers
- Eight other `build-openssl-bundle.sh` call sites across five workflows (ci.yml ×4, codacy-coverage, fips-only-nightly, runtime-perf-guardrails, combined-load-nightly) build the same tarball without integrity verification — deferred sibling family for its own issue.
- Rust `sig_verify_openssl` measured from the same dispatch run: `Done 5419494 runs in 16 second(s)` — real fuzzing of the verify_sig dispatch, length checks, and error paths; the EVP verify leg for well-formed ML-DSA-87 inputs is degraded on runners because the fuzz binary links the system OpenSSL 3.0 via openssl-sys (no ML-DSA). Recorded follow-up: point the Rust fuzz job at the same provisioned bundle if that leg should run in CI.
