### PR TITLE
RUB-1066: gate formal CI jobs on change relevance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,19 @@ jobs:
   formal:
     needs: policy
     runs-on: ubuntu-latest
+    outputs:
+      run_formal: ${{ steps.formal_gate.outputs.run_formal }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify formal relevance
+        id: formal_gate
+        run: python3 tools/ci_formal_relevance.py
 
       - name: Cache Lean toolchain
+        if: steps.formal_gate.outputs.run_formal == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -156,6 +165,7 @@ jobs:
             lean-toolchain-${{ runner.os }}-
 
       - name: Install elan (Lean toolchain manager)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.elan/bin/elan" ]; then
@@ -167,6 +177,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Pin Lean toolchain (deterministic)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           set -euo pipefail
           TOOLCHAIN="$(cat rubin-formal/lean-toolchain)"
@@ -189,6 +200,7 @@ jobs:
           done
 
       - name: Cache Lean .lake build artifacts
+        if: steps.formal_gate.outputs.run_formal == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: rubin-formal/.lake
@@ -197,6 +209,7 @@ jobs:
             lake-formal-${{ runner.os }}-
 
       - name: Lean package checks (rubin-formal)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           cd rubin-formal
           lake env lean --version
@@ -205,18 +218,23 @@ jobs:
           python3 -m tools.check_formal_registry_truth
 
       - name: Formal coverage baseline check
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: python3 tools/check_formal_coverage.py
 
       - name: Formal refinement bridge check
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: python3 tools/check_formal_refinement_bridge.py
 
       - name: Formal claims lint
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: python3 tools/check_formal_claims_lint.py
 
       - name: Formal risk gate (Phase-0/devnet)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: python3 tools/check_formal_risk_gate.py --profile phase0
 
       - name: Map iteration determinism lint (Go/Rust)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: python3 tools/check_map_iteration_determinism.py
 
   test:
@@ -522,10 +540,19 @@ jobs:
   formal_refinement:
     needs: policy
     runs-on: ubuntu-latest
+    outputs:
+      run_formal: ${{ steps.formal_gate.outputs.run_formal }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify formal relevance
+        id: formal_gate
+        run: python3 tools/ci_formal_relevance.py
 
       - name: Cache Lean toolchain
+        if: steps.formal_gate.outputs.run_formal == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -540,6 +567,7 @@ jobs:
             lean-toolchain-${{ runner.os }}-
 
       - name: Install elan (Lean toolchain manager)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           set -euo pipefail
           if [ ! -x "$HOME/.elan/bin/elan" ]; then
@@ -551,6 +579,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Pin Lean toolchain (deterministic)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           set -euo pipefail
           TOOLCHAIN="$(cat rubin-formal/lean-toolchain)"
@@ -573,6 +602,7 @@ jobs:
           done
 
       - name: Cache OpenSSL 3.5 bundle
+        if: steps.formal_gate.outputs.run_formal == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -581,6 +611,7 @@ jobs:
           key: openssl-bundle-${{ runner.os }}-3.5.5-v2
 
       - name: Build OpenSSL 3.5.5 bundle
+        if: steps.formal_gate.outputs.run_formal == 'true'
         id: openssl
         run: |
           set -euo pipefail
@@ -612,6 +643,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify OpenSSL PQ algorithms
+        if: steps.formal_gate.outputs.run_formal == 'true'
         env:
           OPENSSL_DIR: ${{ steps.openssl.outputs.openssl_dir }}
           OPENSSL_MODULES: ${{ steps.openssl.outputs.openssl_modules }}
@@ -623,12 +655,14 @@ jobs:
           openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: steps.formal_gate.outputs.run_formal == 'true'
         with:
           go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
       - name: Generate Go trace v1
+        if: steps.formal_gate.outputs.run_formal == 'true'
         env:
           OPENSSL_DIR: ${{ steps.openssl.outputs.openssl_dir }}
           OPENSSL_MODULES: ${{ steps.openssl.outputs.openssl_modules }}
@@ -640,15 +674,18 @@ jobs:
           go run ./cmd/formal-trace --fixtures-dir ../../conformance/fixtures --out ../../rubin-formal/traces/go_trace_v1.jsonl
 
       - name: Generate Lean expected outputs (GoTraceV1.lean)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           python3 tools/formal/gen_lean_refinement_from_traces.py --traces rubin-formal/traces/go_trace_v1.jsonl --out rubin-formal/RubinFormal/Refinement/GoTraceV1.lean
           git diff --exit-code -- rubin-formal/RubinFormal/Refinement/GoTraceV1.lean
 
       - name: Check Lean conformance vector staleness
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           python3 tools/check_lean_conformance_staleness.py
 
       - name: Cache Lean .lake build artifacts (refinement)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: rubin-formal/.lake
@@ -657,12 +694,14 @@ jobs:
             lake-refinement-${{ runner.os }}-
 
       - name: Lean build (rubin-formal)
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           cd rubin-formal
           lake env lean --version
           lake build
 
       - name: Run Go→Lean refinement check
+        if: steps.formal_gate.outputs.run_formal == 'true'
         run: |
           cd rubin-formal
           lake env lean --run RubinFormal/Refinement/Main.lean

--- a/tools/ci_formal_relevance.py
+++ b/tools/ci_formal_relevance.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Decide whether a pull request must run formal CI jobs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from typing import Callable, NamedTuple
+
+PROTECTED_PREFIXES = (
+    "rubin-formal/",
+    "conformance/",
+    "clients/go/",
+    "clients/rust/crates/rubin-consensus/src/",
+    "tools/formal/",
+)
+PROTECTED_EXACT = {
+    ".github/workflows/ci.yml",
+    "README.md",
+    "SPEC_LOCATION.md",
+    "scripts/crypto/openssl/build-openssl-bundle.sh",
+    "tools/check_formal_claims_lint.py",
+    "tools/check_formal_coverage.py",
+    "tools/check_formal_refinement_bridge.py",
+    "tools/check_formal_risk_gate.py",
+    "tools/check_lean_conformance_staleness.py",
+    "tools/check_map_iteration_determinism.py",
+    "tools/ci_formal_relevance.py",
+    "tools/formal_risk_score.py",
+    "tools/tests/test_ci_formal_relevance.py",
+}
+SKIPPABLE_PREFIXES = ("tools/", "scripts/", "clients/rust/")
+SKIPPABLE_EXACT = {
+    f".github/workflows/{name}"
+    for name in (
+        "auto-approve.yml",
+        "codacy-coverage.yml",
+        "codeql.yml",
+        "combined-load-nightly.yml",
+        "dependency-review.yml",
+        "dependency-submission.yml",
+        "fips-only-nightly.yml",
+        "fuzz-nightly.yml",
+        "kani.yml",
+        "parity-gate.yml",
+        "runtime-perf-guardrails.yml",
+        "sbom.yml",
+        "security-supply-chain-nightly.yml",
+        "spec-checks.yml",
+        "workflow-hygiene.yml",
+    )
+} | {
+    ".codacy.yml",
+    ".coderabbit.yaml",
+    ".jscpd.json",
+    ".node-version",
+    ".nvmrc",
+    "CODACY_CCN_SUMMARY.md",
+    "package-lock.json",
+    "package.json",
+    "tree-api.json",
+}
+
+class Decision(NamedTuple):
+    run_formal: bool
+    reason: str
+    path_count: int = 0
+
+def parse_name_status(data: bytes) -> tuple[list[str], str | None]:
+    if not data or not data.endswith(b"\0"):
+        return [], "empty or malformed diff"
+    fields = data[:-1].split(b"\0")
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        try:
+            status = fields[index].decode("ascii")
+        except UnicodeDecodeError:
+            return [], "malformed diff status"
+        index += 1
+        path_fields = 2 if status.startswith(("R", "C")) else 1
+        if status[:1] not in {"A", "C", "D", "M", "R", "T"}:
+            return [], f"unknown diff status: {status or '<empty>'}"
+        if status[:1] not in {"R", "C"} and len(status) != 1:
+            return [], f"malformed diff status: {status}"
+        if status[:1] in {"R", "C"} and (
+            len(status) != 4 or not status[1:].isdigit() or int(status[1:]) > 100
+        ):
+            return [], f"malformed diff status: {status}"
+        if index + path_fields > len(fields):
+            return [], "malformed diff record"
+        try:
+            record_paths = [field.decode("utf-8") for field in fields[index:index + path_fields]]
+        except UnicodeDecodeError:
+            return [], "malformed diff path"
+        if any(not path or path.startswith("/") or "\0" in path for path in record_paths):
+            return [], "malformed diff path"
+        paths.extend(record_paths)
+        index += path_fields
+    return paths, None
+
+def classify_paths(paths: list[str]) -> Decision:
+    if not paths:
+        return Decision(True, "empty or malformed diff")
+    for path in paths:
+        if path in PROTECTED_EXACT or path.startswith(PROTECTED_PREFIXES):
+            return Decision(True, f"protected path: {path}", len(paths))
+        if path not in SKIPPABLE_EXACT and not path.startswith(SKIPPABLE_PREFIXES):
+            return Decision(True, f"path not in allowlist: {path}", len(paths))
+    return Decision(False, "all paths are in allowlist", len(paths))
+
+def decide(
+    event_name: str,
+    base_ref: str,
+    run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Decision:
+    if event_name != "pull_request":
+        return Decision(True, f"event {event_name or '<missing>'} is not pull_request")
+    if not base_ref:
+        return Decision(True, "missing pull request base")
+    base = f"origin/{base_ref}"
+    verify = run(
+        ["git", "rev-parse", "--verify", f"{base}^{{commit}}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if verify.returncode:
+        return Decision(True, f"missing pull request base: {base}")
+    diff = run(
+        ["git", "diff", "--name-status", "-z", "--find-renames", f"{base}..HEAD"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if diff.returncode:
+        return Decision(True, f"git diff failed for {base}..HEAD")
+    paths, error = parse_name_status(diff.stdout)
+    return Decision(True, error) if error else classify_paths(paths)
+
+def main() -> int:
+    decision = decide(
+        os.environ.get("GITHUB_EVENT_NAME", ""),
+        os.environ.get("GITHUB_BASE_REF", ""),
+    )
+    if decision.run_formal:
+        print(f"RUN: {decision.reason}")
+    else:
+        print(
+            f"SKIP: formal-irrelevant diff "
+            f"({decision.path_count} paths, all in allowlist)"
+        )
+    output = Path(os.environ["GITHUB_OUTPUT"])
+    with output.open("a", encoding="utf-8") as stream:
+        stream.write(f"run_formal={'true' if decision.run_formal else 'false'}\n")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_ci_formal_relevance.py
+++ b/tools/tests/test_ci_formal_relevance.py
@@ -1,0 +1,136 @@
+import subprocess
+import unittest
+
+from tools import ci_formal_relevance as subject
+
+def diff(*records: tuple[str, ...]) -> bytes:
+    return b"".join(
+        b"\0".join(field.encode() for field in record) + b"\0"
+        for record in records
+    )
+
+def runner(
+    payload: bytes = b"M\0tools/format.py\0",
+    *,
+    verify_code: int = 0,
+    diff_code: int = 0,
+):
+    def run(command, **_kwargs):
+        if command[1] == "rev-parse":
+            return subprocess.CompletedProcess(command, verify_code, b"base\n", b"")
+        return subprocess.CompletedProcess(command, diff_code, payload, b"")
+
+    return run
+
+class FormalRelevanceTests(unittest.TestCase):
+    def decision(self, payload: bytes) -> subject.Decision:
+        return subject.decide("pull_request", "main", runner(payload))
+
+    def test_every_protected_family_runs(self):
+        paths = [
+            ".github/workflows/ci.yml",
+            "rubin-formal/A.lean",
+            "conformance/vector.json",
+            "clients/go/consensus/a.go",
+            "clients/rust/crates/rubin-consensus/src/lib.rs",
+            "tools/formal/generate.py",
+            "scripts/crypto/openssl/build-openssl-bundle.sh",
+            "README.md",
+            "SPEC_LOCATION.md",
+            *sorted(path for path in subject.PROTECTED_EXACT if path.startswith("tools/")),
+        ]
+        for path in paths:
+            with self.subTest(path=path):
+                decision = self.decision(diff(("M", path)))
+                self.assertTrue(decision.run_formal)
+                self.assertEqual(decision.reason, f"protected path: {path}")
+
+    def test_every_skippable_family_skips(self):
+        paths = [
+            "tools/ordinary.py",
+            "scripts/ordinary.sh",
+            "clients/rust/crates/wallet/src/lib.rs",
+            *sorted(subject.SKIPPABLE_EXACT),
+        ]
+        for path in paths:
+            with self.subTest(path=path):
+                decision = self.decision(diff(("M", path)))
+                self.assertFalse(decision.run_formal)
+                self.assertEqual(decision.path_count, 1)
+
+    def test_protected_precedence_over_broad_allowlists(self):
+        for path in (
+            "tools/formal/generate.py",
+            "tools/check_formal_coverage.py",
+            "scripts/crypto/openssl/build-openssl-bundle.sh",
+            "clients/rust/crates/rubin-consensus/src/lib.rs",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(self.decision(diff(("M", path))).run_formal)
+
+    def test_unknown_mixed_and_nearest_misses_run(self):
+        cases = [
+            diff(("A", "docs/new.md")),
+            diff(("A", ".github/workflows/new.yml")),
+            diff(("M", "tools/ok.py"), ("M", "README.md")),
+            diff(("M", "README.markdown")),
+            diff(("M", "rubin-formality/file")),
+            diff(("M", "client/rust/file")),
+        ]
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.assertTrue(self.decision(payload).run_formal)
+
+    def test_add_delete_rename_and_copy_parse_all_paths(self):
+        cases = [
+            (diff(("A", "tools/a.py"), ("D", "scripts/b.sh")), False),
+            (diff(("R100", "README.md", "tools/readme.txt")), True),
+            (diff(("R090", "tools/readme.txt", "README.md")), True),
+            (diff(("C075", "tools/a.py", "scripts/a.py")), False),
+            (diff(("C100", "tools/a.py", "rubin-formal/A.lean")), True),
+        ]
+        for payload, expected in cases:
+            with self.subTest(payload=payload):
+                self.assertEqual(self.decision(payload).run_formal, expected)
+
+    def test_fips_preflight_skips_but_bundle_build_runs(self):
+        self.assertFalse(
+            self.decision(diff(("M", "scripts/crypto/openssl/fips-preflight.sh"))).run_formal
+        )
+        self.assertTrue(
+            self.decision(
+                diff(("M", "scripts/crypto/openssl/build-openssl-bundle.sh"))
+            ).run_formal
+        )
+
+    def test_malformed_unknown_and_empty_diffs_run(self):
+        for payload in (
+            b"",
+            b"M\0tools/a.py",
+            b"R\0tools/a.py\0scripts/a.py\0",
+            *(f"{status}\0tools/a.py\0scripts/a.py\0".encode() for status in ("R1", "R1000", "R101", "Cabc")),
+            b"M100\0tools/a.py\0",
+            b"Z\0tools/a.py\0",
+            b"M\0\0",
+            b"M\0\xff\0",
+        ):
+            with self.subTest(payload=payload):
+                self.assertTrue(self.decision(payload).run_formal)
+
+    def test_environment_and_git_failures_run(self):
+        self.assertTrue(subject.decide("push", "", runner()).run_formal)
+        self.assertTrue(subject.decide("pull_request", "", runner()).run_formal)
+        self.assertTrue(
+            subject.decide(
+                "pull_request", "main", runner(verify_code=1)
+            ).run_formal
+        )
+        self.assertTrue(
+            subject.decide(
+                "pull_request", "main", runner(diff_code=1)
+            ).run_formal
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1066
- GitHub Issue mirror (non-authoritative): #2735

Refs: Q-CI-FORMAL-PATH-GATE-01

## Summary
Add one shared fail-closed PR diff classifier so the required formal jobs skip expensive setup only for explicitly reviewed formal-irrelevant changes.

## Invariant
Both required formal jobs retain every existing verification step and run the full pair for protected, unknown, ambiguous, malformed, empty-diff, base/diff-failure, and non-PR cases.

## Scope
- Changed files: 3
- Surfaces: tooling
- Non-scope: formal proofs, consensus or client behavior, required job names/checks, branch protection, and workflows other than ci.yml
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `python3 -m unittest tools.tests.test_ci_formal_relevance` — PASS

## Follow-ups / Waivers
- After merge, record the first allowlist-only PR fast-skip timing in RUB-1066.