### PR TITLE
RUB-1067: verify the OpenSSL source tarball in the bundle script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
@@ -489,7 +489,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
@@ -608,7 +608,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         if: steps.formal_gate.outputs.run_formal == 'true'
@@ -718,7 +718,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
       - name: Build OpenSSL 3.5.5 bundle
         run: |
           set -euo pipefail

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -23,7 +23,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle (PQC-enabled)
         run: |

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/.github/workflows/fips-only-nightly.yml
+++ b/.github/workflows/fips-only-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -89,14 +89,15 @@ jobs:
       # RUB-1061). The three steps below follow the proven ci.yml `test` shape
       # (cache + guarded build + PQ visibility check).
       #
-      # Dedicated key, deliberately NOT the shared openssl-bundle-*-v2 key: this
+      # Dedicated key, deliberately NOT the shared openssl-bundle-*-v3 key: this
       # one is written only by this workflow, and since RUB-1067 the bundle
       # script verifies the source tarball against a version-pinned sha256
       # before extracting, so every bundle stored under this key descends from a
-      # verified tarball. The shared key still holds entries built before that
-      # verification existed, and the build step below skips the script whenever
-      # the restored bundle looks complete, so such an entry would never be
-      # checked. No restore-keys, for the same reason.
+      # verified tarball. The shared key was rotated v2 -> v3 in the same change
+      # to drop entries built before verification existed; this lane keeps its
+      # own key because its entries are already verified and rotating them would
+      # buy nothing. No restore-keys: a prefix fallback reaches pre-rotation
+      # entries and would undo both.
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -86,92 +86,29 @@ jobs:
       # ML-DSA backend provisioning (RUB-1064). The runner's system OpenSSL
       # lacks ML-DSA, so the ML-DSA-gated targets f.Skipf during setup and
       # produce zero fuzz coverage (surfaced as SKIP_FUZZ_SETUP since
-      # RUB-1061). The four steps below follow the proven ci.yml `test` shape
-      # (cache + guarded build + PQ visibility check) with one deliberate
-      # deviation: a dedicated cache key plus a provenance marker, so the
-      # bundle the fuzz binary links provably descends from the
-      # sha256-verified source tarball.
-      #
-      # Dedicated key, deliberately NOT the shared openssl-bundle-*-v2 key:
-      # that one is also written by ci.yml and four other workflows whose
-      # build paths never verify the tarball, so a warm shared bundle has
-      # unverifiable provenance. This key is written exclusively by this
-      # workflow's verified-build path below — a warm bundle under it is one
-      # this job built from a sha256-verified source. No restore-keys
-      # fallback: a fallback would reintroduce unverified bundles. Cost:
-      # cold on first use (every matrix leg builds once, ~6-8 min, until the
-      # first successful save); warm restores afterwards are seconds.
+      # RUB-1061). The three steps below follow the proven ci.yml `test` shape
+      # and share its cache key: since RUB-1067 the bundle script verifies the
+      # source tarball against a version-pinned sha256 before extracting, on the
+      # cold and the cache-warm path alike, so every workflow writing this key
+      # builds from verified source.
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-mldsa-verified-${{ runner.os }}-3.5.5-v1
-
-      - name: Verify OpenSSL 3.5.5 source integrity
-        run: |
-          set -euo pipefail
-          # Pinned sha256 of the upstream source tarball, from the official
-          # release asset openssl-3.5.5.tar.gz.sha256 at
-          # https://github.com/openssl/openssl/releases/tag/openssl-3.5.5
-          # (independently re-downloaded and re-hashed on 2026-07-29).
-          EXPECTED_SHA256="b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
-          WORK_ROOT="$HOME/.cache/rubin-openssl/work"
-          TARBALL="$WORK_ROOT/openssl-3.5.5.tar.gz"
-          mkdir -p "$WORK_ROOT"
-          if [ ! -f "$TARBALL" ]; then
-            curl -fL --retry 3 \
-              "https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz" \
-              -o "$TARBALL"
-          fi
-          # Runs on the warm path too: the tarball may come from the shared
-          # actions cache, and a poisoned cache entry must fail closed here,
-          # never feed the build. (The built bundle itself cannot be pinned —
-          # the build is not bit-reproducible — so the trust chain is verified
-          # source plus a repo-scoped cache written only by this repo's CI.)
-          if ! echo "$EXPECTED_SHA256  $TARBALL" | sha256sum -c -; then
-            echo "ERROR: openssl-3.5.5.tar.gz sha256 mismatch (tampered download or poisoned cache); refusing to build" >&2
-            rm -f -- "$TARBALL"
-            exit 1
-          fi
-          # Single definition of the pin: the build step consumes this export
-          # for its provenance marker instead of repeating the literal, so the
-          # two steps cannot drift apart silently. Written only after the
-          # check above passed.
-          echo "RUBIN_OPENSSL_TARBALL_SHA256=$EXPECTED_SHA256" >> "$GITHUB_ENV"
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
           set -euo pipefail
-          # :? fails closed if the verify step did not run (reordered/removed):
-          # the build must never proceed without a verified pin in hand.
-          PINNED_SHA256="${RUBIN_OPENSSL_TARBALL_SHA256:?verify step must export the pin first}"
           PREFIX="$HOME/.cache/rubin-openssl/bundle-3.5.5"
-          # Provenance marker: records the sha256 of the source tarball this
-          # bundle was built from, making "this bundle descends from the
-          # verified source" checkable rather than inferred — and keeping the
-          # guard honest even if a future workflow starts writing this cache
-          # key without verification.
-          MARKER="$PREFIX/.rubin-verified-source-sha256"
           MODULES_DIR="$PREFIX/lib/ossl-modules"
           if [ ! -d "$MODULES_DIR" ] && [ -d "$PREFIX/lib64/ossl-modules" ]; then
             MODULES_DIR="$PREFIX/lib64/ossl-modules"
           fi
-          NEED_BUILD=0
           if [ ! -x "$PREFIX/bin/openssl" ] || [ ! -f "$PREFIX/ssl/openssl-fips.cnf" ] || [ ! -d "$MODULES_DIR" ]; then
-            NEED_BUILD=1
-          elif [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$PINNED_SHA256" ]; then
-            # A complete-looking bundle without a matching marker did not come
-            # from this workflow's verified-build path: rebuild it.
-            NEED_BUILD=1
-          fi
-          if [ "$NEED_BUILD" -eq 1 ]; then
-            # Wipe first so nothing from an unverified or partial bundle
-            # survives the reinstall (make install overwrites, never prunes).
-            rm -rf -- "$PREFIX"
             OPENSSL_VERSION=3.5.5 PREFIX="$PREFIX" bash scripts/crypto/openssl/build-openssl-bundle.sh
-            printf '%s\n' "$PINNED_SHA256" > "$MARKER"
           fi
           if [ -d "$PREFIX/lib/ossl-modules" ]; then
             MODULES_DIR="$PREFIX/lib/ossl-modules"

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -87,17 +87,23 @@ jobs:
       # lacks ML-DSA, so the ML-DSA-gated targets f.Skipf during setup and
       # produce zero fuzz coverage (surfaced as SKIP_FUZZ_SETUP since
       # RUB-1061). The three steps below follow the proven ci.yml `test` shape
-      # and share its cache key: since RUB-1067 the bundle script verifies the
-      # source tarball against a version-pinned sha256 before extracting, on the
-      # cold and the cache-warm path alike, so every workflow writing this key
-      # builds from verified source.
+      # (cache + guarded build + PQ visibility check).
+      #
+      # Dedicated key, deliberately NOT the shared openssl-bundle-*-v2 key: this
+      # one is written only by this workflow, and since RUB-1067 the bundle
+      # script verifies the source tarball against a version-pinned sha256
+      # before extracting, so every bundle stored under this key descends from a
+      # verified tarball. The shared key still holds entries built before that
+      # verification existed, and the build step below skips the script whenever
+      # the restored bundle looks complete, so such an entry would never be
+      # checked. No restore-keys, for the same reason.
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-mldsa-verified-${{ runner.os }}-3.5.5-v1
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |

--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
+++ b/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
@@ -40,7 +40,10 @@ If SLA cannot be met, incident owner MUST publish a blocker note with ETA and mi
    - **Consensus-impacting**: can alter accept/reject decisions or signature verification outcomes.
    - **Operational-only**: availability/perf/compliance without consensus drift.
 3. Prepare mitigation:
-   - version bump and bundle rebuild,
+   - version bump and bundle rebuild — the build refuses an unpinned version, so add
+     the new version's sha256 to the `case` block in
+     `scripts/crypto/openssl/build-openssl-bundle.sh` from the upstream
+     `openssl-<version>.tar.gz.sha256` asset named in the refusal message,
    - temporary runtime guard (if needed),
    - tests for regression and deterministic behavior.
 4. Open one PR for code/tooling updates and one PR for spec/ops updates when required.

--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -7,6 +7,12 @@ cd <REPO_ROOT>
 OPENSSL_VERSION=3.5.5 scripts/dev-env.sh -- bash scripts/crypto/openssl/build-openssl-bundle.sh
 ```
 
+Before extracting, the script verifies the source tarball — freshly downloaded or
+cached — against a sha256 pinned per version in its own `case` block, and refuses
+to build on a mismatch or on a version with no pin entry. A version bump therefore
+adds one `case` entry with the digest from the upstream
+`openssl-<version>.tar.gz.sha256` release asset.
+
 Default install prefix:
 
 `$HOME/.cache/rubin-openssl/bundle-<version>`

--- a/scripts/crypto/openssl/build-openssl-bundle.sh
+++ b/scripts/crypto/openssl/build-openssl-bundle.sh
@@ -51,7 +51,7 @@ echo "[openssl-bundle] prefix=${PREFIX}"
 if [ ! -f "${TARBALL_PATH}" ]; then
   # Retrying is safe because of the check below: a truncated or partial result
   # fails verification rather than being consumed.
-  curl -fL --retry 5 --retry-delay 2 --retry-all-errors "${ARCHIVE_URL}" -o "${TARBALL_PATH}"
+  curl -fL --retry 5 --retry-delay 2 "${ARCHIVE_URL}" -o "${TARBALL_PATH}"
 fi
 
 # One verification point covers both paths: a freshly downloaded tarball and one

--- a/scripts/crypto/openssl/build-openssl-bundle.sh
+++ b/scripts/crypto/openssl/build-openssl-bundle.sh
@@ -49,7 +49,9 @@ echo "[openssl-bundle] work=${WORK_ROOT}"
 echo "[openssl-bundle] prefix=${PREFIX}"
 
 if [ ! -f "${TARBALL_PATH}" ]; then
-  curl -fL "${ARCHIVE_URL}" -o "${TARBALL_PATH}"
+  # Retrying is safe because of the check below: a truncated or partial result
+  # fails verification rather than being consumed.
+  curl -fL --retry 5 --retry-delay 2 --retry-all-errors "${ARCHIVE_URL}" -o "${TARBALL_PATH}"
 fi
 
 # One verification point covers both paths: a freshly downloaded tarball and one

--- a/scripts/crypto/openssl/build-openssl-bundle.sh
+++ b/scripts/crypto/openssl/build-openssl-bundle.sh
@@ -12,6 +12,35 @@ TARBALL_PATH="${WORK_ROOT}/${ARCHIVE}"
 JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8)}"
 FIPS_SECTION_NAME="${FIPS_SECTION_NAME:-fips_sect}"
 
+# Pinned sha256 of the upstream source tarball, one entry per supported version,
+# from the official release asset openssl-<version>.tar.gz.sha256. Selected by
+# OPENSSL_VERSION and never by ARCHIVE_URL, so a mirror serving the pinned bytes
+# passes and anything else fails without any URL-specific logic.
+case "${OPENSSL_VERSION}" in
+  3.5.5)
+    EXPECTED_SHA256="b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
+    ;;
+  *)
+    echo "ERROR: no pinned sha256 for OpenSSL ${OPENSSL_VERSION}; refusing to build" >&2
+    echo "Add a case entry for ${OPENSSL_VERSION} in scripts/crypto/openssl/build-openssl-bundle.sh" >&2
+    echo "using the digest published at https://github.com/openssl/openssl/releases/download/${OPENSSL_TAG}/${ARCHIVE}.sha256" >&2
+    exit 1
+    ;;
+esac
+
+compute_sha256() {
+  local output
+  if command -v sha256sum >/dev/null 2>&1; then
+    output="$(sha256sum "$1")" || { echo "ERROR: sha256sum failed for $1" >&2; return 1; }
+  elif command -v shasum >/dev/null 2>&1; then
+    output="$(shasum -a 256 "$1")" || { echo "ERROR: shasum failed for $1" >&2; return 1; }
+  else
+    echo "ERROR: no sha256 tool available (need sha256sum or shasum -a 256)" >&2
+    return 1
+  fi
+  printf '%s\n' "${output%% *}"
+}
+
 mkdir -p "${WORK_ROOT}"
 
 echo "[openssl-bundle] version=${OPENSSL_VERSION}"
@@ -22,6 +51,18 @@ echo "[openssl-bundle] prefix=${PREFIX}"
 if [ ! -f "${TARBALL_PATH}" ]; then
   curl -fL "${ARCHIVE_URL}" -o "${TARBALL_PATH}"
 fi
+
+# One verification point covers both paths: a freshly downloaded tarball and one
+# restored from a CI or developer cache reach it alike, before extraction.
+if ! ACTUAL_SHA256="$(compute_sha256 "${TARBALL_PATH}")"; then
+  exit 1
+fi
+if [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then
+  echo "ERROR: ${ARCHIVE} sha256 mismatch (expected ${EXPECTED_SHA256}, got ${ACTUAL_SHA256}); refusing to build" >&2
+  rm -f -- "${TARBALL_PATH}"
+  exit 1
+fi
+echo "[openssl-bundle] source-sha256=${ACTUAL_SHA256}"
 
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"

--- a/tools/tests/test_openssl_bundle_contract.py
+++ b/tools/tests/test_openssl_bundle_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Executing contract for build-openssl-bundle.sh: each row drives the real script with
+curl and the OpenSSL compile stubbed, asserting exit status and whether it extracted."""
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "crypto" / "openssl" / "build-openssl-bundle.sh"
+VERSION = "3.5.5"
+PUBLISHED_SHA256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
+MIRROR_URL = "https://mirror.example/openssl.tar.gz"
+GARBAGE = b"not the pinned openssl source"
+
+CURL_STUB = '#!/usr/bin/env bash\n: > "$CURL_RAN"\ncp -- "$SERVED" "${@: -1}"\n'
+MAKE_STUB = """#!/usr/bin/env bash
+mkdir -p "$PREFIX/bin" "$PREFIX/lib/ossl-modules"
+printf '#!/bin/sh\\nexit 0\\n' > "$PREFIX/bin/openssl"
+chmod +x "$PREFIX/bin/openssl"
+: > "$PREFIX/lib/ossl-modules/fips.so"
+"""
+FAILING_STUB = "#!/usr/bin/env bash\nexit 1\n"
+
+
+def write_stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def source_tarball() -> bytes:
+    """A real tar.gz shaped like the upstream archive: strip-components=1 plus ./config."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        for name, body in (("EXTRACTED", b"marker\n"), ("config", b"#!/bin/sh\nexit 0\n")):
+            info = tarfile.TarInfo(f"openssl-{VERSION}/{name}")
+            info.size, info.mode = len(body), 0o755
+            archive.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+def repin(root: Path, payload: bytes) -> Path:
+    """The real script with its 3.5.5 pin repointed at a locally built payload."""
+    patched, count = re.subn(
+        r'(?<=EXPECTED_SHA256=")[0-9a-f]{64}(?=")',
+        hashlib.sha256(payload).hexdigest(),
+        SCRIPT_PATH.read_text(encoding="utf-8"),
+    )
+    assert count == 1, f"expected one pinned digest in {SCRIPT_PATH}, found {count}"
+    path = root / "build-openssl-bundle.sh"
+    path.write_text(patched, encoding="utf-8")
+    return path
+
+
+class OpenSSLBundleContractTests(unittest.TestCase):
+    def run_bundle(self, tmp, *, served, repinned=False, precache=False, version=VERSION,
+                   archive_url=None, break_sha_tools=False):
+        root = Path(tmp)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        work = root / "work"
+        tarball = work / f"openssl-{version}.tar.gz"
+        write_stub(bin_dir / "curl", CURL_STUB)
+        write_stub(bin_dir / "make", MAKE_STUB)
+        for tool in ("sha256sum", "shasum") if break_sha_tools else ():
+            write_stub(bin_dir / tool, FAILING_STUB)
+        if precache:
+            work.mkdir(parents=True)
+            tarball.write_bytes(served)
+        (root / "served.tar.gz").write_bytes(served)
+        env = {"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(root), "JOBS": "1",
+               "WORK_ROOT": str(work), "PREFIX": str(root / "prefix"),
+               "OPENSSL_VERSION": version, "SERVED": str(root / "served.tar.gz"),
+               "CURL_RAN": str(root / "curl-ran")}
+        if archive_url is not None:
+            env["ARCHIVE_URL"] = archive_url
+        proc = subprocess.run(["/bin/bash", str(repin(root, served) if repinned else SCRIPT_PATH)],
+                              capture_output=True, text=True, env=env, cwd=root)
+        return SimpleNamespace(proc=proc, tarball=tarball, curl_ran=root / "curl-ran",
+                               extracted=work / f"openssl-{version}" / "EXTRACTED")
+
+    def test_verified_source_is_extracted_and_built(self):
+        for name, kwargs, downloaded in (
+            ("fresh download", {}, True),
+            ("cached tarball", {"precache": True}, False),
+            ("mirror serving pinned bytes", {"archive_url": MIRROR_URL}, True),
+        ):
+            with self.subTest(name), tempfile.TemporaryDirectory() as tmp:
+                run = self.run_bundle(tmp, served=source_tarball(), repinned=True, **kwargs)
+                self.assertEqual(run.proc.returncode, 0, run.proc.stderr)
+                self.assertEqual(run.curl_ran.exists(), downloaded)
+                self.assertTrue(run.extracted.exists())
+
+    def test_unverified_source_is_refused_and_removed_without_extraction(self):
+        for name, kwargs in (
+            ("fresh download", {}),
+            ("poisoned cache", {"precache": True}),
+            ("mirror serving other bytes", {"archive_url": MIRROR_URL}),
+        ):
+            with self.subTest(name), tempfile.TemporaryDirectory() as tmp:
+                run = self.run_bundle(tmp, served=GARBAGE, **kwargs)
+                self.assertNotEqual(run.proc.returncode, 0)
+                self.assertIn("sha256 mismatch", run.proc.stderr)
+                self.assertFalse(run.tarball.exists())
+                self.assertFalse(run.extracted.exists())
+
+    def test_unpinned_version_refuses_before_any_download(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self.run_bundle(tmp, served=source_tarball(), version="9.9.9")
+            self.assertNotEqual(run.proc.returncode, 0)
+            self.assertFalse(run.curl_ran.exists())
+            self.assertIn("no pinned sha256 for OpenSSL 9.9.9", run.proc.stderr)
+            self.assertIn("scripts/crypto/openssl/build-openssl-bundle.sh", run.proc.stderr)
+            self.assertIn("openssl-9.9.9.tar.gz.sha256", run.proc.stderr)
+
+    def test_hash_tool_failure_is_not_reported_as_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self.run_bundle(tmp, served=source_tarball(), precache=True, break_sha_tools=True)
+            self.assertNotEqual(run.proc.returncode, 0)
+            self.assertRegex(run.proc.stderr, r"(sha256sum|shasum) failed")
+            self.assertNotIn("mismatch", run.proc.stderr)
+            self.assertTrue(run.tarball.exists())
+
+    def test_script_is_the_single_definition_of_the_published_pin(self):
+        self.assertIn(f'EXPECTED_SHA256="{PUBLISHED_SHA256}"',
+                      SCRIPT_PATH.read_text(encoding="utf-8"))
+        for workflow in sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml")):
+            self.assertNotIn(PUBLISHED_SHA256, workflow.read_text(encoding="utf-8"),
+                             f"pin duplicated in {workflow.name}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_openssl_bundle_contract.py
+++ b/tools/tests/test_openssl_bundle_contract.py
@@ -46,16 +46,19 @@ def source_tarball() -> bytes:
     return buf.getvalue()
 
 
-def repin(root: Path, payload: bytes) -> Path:
-    """The real script with its 3.5.5 pin repointed at a locally built payload."""
-    patched, count = re.subn(
-        r'(?<=EXPECTED_SHA256=")[0-9a-f]{64}(?=")',
-        hashlib.sha256(payload).hexdigest(),
-        SCRIPT_PATH.read_text(encoding="utf-8"),
-    )
-    assert count == 1, f"expected one pinned digest in {SCRIPT_PATH}, found {count}"
+def repin_text(text: str, digest: str, version: str) -> str:
+    """Repoint one version's case arm, leaving every other pinned version intact."""
+    patched, count = re.subn(rf'({re.escape(version)}\)\s+EXPECTED_SHA256=")[0-9a-f]{{64}}',
+                             rf"\g<1>{digest}", text)
+    assert count == 1, f"expected one pinned digest for {version}, found {count}"
+    return patched
+
+
+def repin(root: Path, payload: bytes, version: str) -> Path:
+    """The real script with the selected version's pin repointed at a local payload."""
     path = root / "build-openssl-bundle.sh"
-    path.write_text(patched, encoding="utf-8")
+    path.write_text(repin_text(SCRIPT_PATH.read_text(encoding="utf-8"),
+                               hashlib.sha256(payload).hexdigest(), version), encoding="utf-8")
     return path
 
 
@@ -81,7 +84,7 @@ class OpenSSLBundleContractTests(unittest.TestCase):
                "CURL_RAN": str(root / "curl-ran")}
         if archive_url is not None:
             env["ARCHIVE_URL"] = archive_url
-        proc = subprocess.run(["/bin/bash", str(repin(root, served) if repinned else SCRIPT_PATH)],
+        proc = subprocess.run(["/bin/bash", str(repin(root, served, version) if repinned else SCRIPT_PATH)],
                               capture_output=True, text=True, env=env, cwd=root)
         return SimpleNamespace(proc=proc, tarball=tarball, curl_ran=root / "curl-ran",
                                extracted=work / f"openssl-{version}" / "EXTRACTED")
@@ -127,6 +130,14 @@ class OpenSSLBundleContractTests(unittest.TestCase):
             self.assertRegex(run.proc.stderr, r"(sha256sum|shasum) failed")
             self.assertNotIn("mismatch", run.proc.stderr)
             self.assertTrue(run.tarball.exists())
+
+    def test_repin_targets_one_arm_when_a_second_version_is_pinned(self):
+        second = f'  3.6.0)\n    EXPECTED_SHA256="{"a" * 64}"\n    ;;\n'
+        text = SCRIPT_PATH.read_text(encoding="utf-8").replace("  3.5.5)\n", second + "  3.5.5)\n", 1)
+        patched = repin_text(text, "b" * 64, VERSION)
+        self.assertIn(f'EXPECTED_SHA256="{"a" * 64}"', patched)
+        self.assertIn(f'EXPECTED_SHA256="{"b" * 64}"', patched)
+        self.assertNotIn(PUBLISHED_SHA256, patched)
 
     def test_script_is_the_single_definition_of_the_published_pin(self):
         self.assertIn(f'EXPECTED_SHA256="{PUBLISHED_SHA256}"',


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1067
- GitHub Issue mirror (non-authoritative): #1067

Refs: Q-SUPPLY-CHAIN-OPENSSL-SRC-01

## Summary
`scripts/crypto/openssl/build-openssl-bundle.sh` was the only download in the tree that fetched an artifact and consumed it without verification — it curled the OpenSSL source tarball and extracted, configured and compiled it, and that artifact becomes the libcrypto both clients link for ML-DSA-87. Every other download already verifies (actionlint and shellcheck via sha256 in workflow-hygiene, elan twice in ci.yml, the Codacy reporter via per-platform SHA512), so this restores a convention rather than inventing one. The version was already pinned at 3.5.5 everywhere; what was missing was content authenticity, which `CVE_RESPONSE_RUNBOOK.md` section 4 already lists as required release evidence.

The script now selects a per-version pinned sha256 and checks it immediately before `tar -xzf`, so a freshly downloaded tarball and one restored from a CI or developer cache reach the same gate; a mismatch removes the file and exits non-zero, so a poisoned cache cannot feed the next run either. The pin is selected by `OPENSSL_VERSION` and never by `ARCHIVE_URL`, so a mirror serving the pinned bytes passes and anything else fails with no URL-specific logic. An unpinned version refuses before any download, naming the version, the file to edit and the official digest asset, so the runbook's approval-free operational bump stays a one-line change.

Fixing the shared script covers all nine call sites and the documented local invocation at once, which retires most of the workflow-level workaround RUB-1064 had to add while the source was unverified: the duplicated literal, the verify step and the provenance marker are deleted. The dedicated cache key is deliberately KEPT, byte-identical — an earlier revision of this branch consolidated it onto the shared key and that was wrong, as review caught: the shared key holds entries written before verification existed, and because every workflow's build guard skips the script whenever the bundle looks complete, an exact hit would restore an unverified-provenance bundle that reaches no check at all. With the script verifying universally, a key written only by this workflow supplies the provenance the marker used to, without a marker or a duplicate pin.

The shared key the other eight call sites use is rotated here from `v2` to `v3` (absorbed from RUB-1068, closed as superseded — splitting the rotation from the verification it completes was a planning error). Without it the verification is unreachable for those lanes: their guards skip the build script whenever a restored bundle looks complete, so an exact hit keeps handing them a pre-verification bundle. No `restore-keys` is added anywhere, since a prefix fallback would reach the very entries the rotation flushes. Cost is one build per affected lane, once (~208s measured cold, ~45s warm afterwards) against a 360-minute default job budget, as none of those jobs sets `timeout-minutes`.

Note on FIPS, so it is not later mistaken for coverage: `fipsinstall` HMACs the `fips.so` produced by the build and the provider self-verifies at load, which detects tampering after the build but not a substituted source — a malicious source yields a malicious module over which a valid MAC is computed. Source authenticity and post-build module integrity are orthogonal; only the latter existed before this change.

## Invariant
Every OpenSSL source tarball this repository compiles is verified against a version-pinned checksum before it is extracted, in one place that covers every caller including local developer runs, with an unknown version or a non-matching source refused rather than built, and exactly one definition of each pin in the tree.

## Scope
- Changed files: 10
- Surfaces: crypto backend build script, its documentation, tooling test, nightly fuzz workflow (deletions only), and the cache-key string in five workflows that build the bundle
- Non-scope: no OpenSSL version bump; no GPG/signature verification; no change to build flags, FIPS configuration or install layout; no policy checker scanning the tree for unverified downloads; the eight other call sites keep their build logic, guards and cache paths untouched — only their cache-key string is rotated
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `python3 -m unittest discover -s tools/tests -p 'test_*.py'` — `Ran 550 tests, OK`; the new `tools/tests/test_openssl_bundle_contract.py` executing fault-injection matrix over the real script (verified fresh download, verified cached tarball, checksum mismatch, unpinned version, mirror with pinned bytes, mirror with other bytes) with 8/8 mutation receipts killed (including `repin-unscoped-across-versions`, whose row is the one that would have caught the test-helper defect review found); refusal rows executed against the real script with no stubs — corrupt cache (exit 1, tarball removed, no build), `OPENSSL_VERSION=4.0.0` (exit 1 before any download, WORK_ROOT not created), PATH without sha256sum/shasum (exit 1, tarball deliberately NOT removed so a tool failure is not reported as a mismatch), WORK_ROOT containing spaces, piped stdin, `env -u HOME`; real end-to-end build from a clean WORK_ROOT (`source-sha256=b28c915…` → `[openssl-bundle] done`, and the built `openssl list -signature-algorithms` contains ML-DSA-87); warm-restore check with a PATH shim proving the workflow's build step invokes the bundle script 0 times on a warm cache and 1 time when the bundle is removed, i.e. no lane rebuilds; pin re-verified twice independently against the official `openssl-3.5.5.tar.gz.sha256` release asset; the cache key proven byte-identical to the pre-change string by git comparison, with no `restore-keys` field; a second real cold build executed after the retry flags were added (`source-sha256=b28c915…` → `[openssl-bundle] done`), so the changed curl line is executed rather than merely read; `grep` proving a single pin definition; `shellcheck` and `bash -n` on the script; `actionlint` on all six changed workflows plus `tools/check_workflow_yaml_syntax.py` (16 files parsed); a third real cold build after the final curl flags (`source-sha256=b28c915…` → `[openssl-bundle] done`); `grep` proving zero `-v2` occurrences remain and eight `-v3`, with the five workflows' diff containing nothing but those eight key lines; the six existing `restore-keys` fields confirmed to belong to unrelated Lean and cargo caches, none on an OpenSSL step; `git diff --check`

## Follow-ups / Waivers
- None.
