### PR TITLE
RUB-1062: bound the two operator config reads

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -683,7 +683,9 @@ type headerStore interface {
 }
 
 func printFeatureBitsTelemetry(w io.Writer, bs headerStore, height uint64, deploymentsPath string) error {
-	raw, err := os.ReadFile(filepath.Clean(deploymentsPath))
+	// Operator config read, bounded pre-allocation (RUB-1062 rider A; see
+	// node.ReadConfigFile for the ceiling derivation).
+	raw, err := node.ReadConfigFile(filepath.Clean(deploymentsPath))
 	if err != nil {
 		return err
 	}
@@ -838,7 +840,9 @@ func parseGenesisConfigFull(path string) (parsedGenesisConfig, error) {
 	if strings.TrimSpace(path) == "" {
 		return cfg, nil
 	}
-	raw, err := os.ReadFile(filepath.Clean(path))
+	// Operator config read, bounded pre-allocation (RUB-1062 rider A; see
+	// node.ReadConfigFile for the ceiling derivation).
+	raw, err := node.ReadConfigFile(filepath.Clean(path))
 	if err != nil {
 		return cfg, err
 	}

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -2762,3 +2762,56 @@ func TestRunOpenExistingStartupDoesNotSynthesizeStore(t *testing.T) {
 		t.Fatalf("reopen exit %d (stderr=%q)", code, stderr)
 	}
 }
+
+// configBoundTestFile writes a config file padded with trailing JSON
+// whitespace to exactly size bytes (1<<24 pins node's configFileMaxBytes via
+// TestReadFileConfigBoundPinsDerivedValue).
+func configBoundTestFile(t *testing.T, dir, name, payload string, size int) string {
+	t.Helper()
+	if len(payload) > size {
+		t.Fatalf("payload longer than target size")
+	}
+	content := append([]byte(payload), bytes.Repeat([]byte{' '}, size-len(payload))...)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestReadFileConfigBoundDeploymentsSite pins RUB-1062 rider A at the
+// featurebits-deployments call site: an at-bound file loads exactly as
+// before, one byte over is refused with the typed size error.
+func TestReadFileConfigBoundDeploymentsSite(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	at := configBoundTestFile(t, dir, "at.json", "[]", 1<<24)
+	if err := printFeatureBitsTelemetry(&out, nil, 0, at); err != nil {
+		t.Fatalf("at-bound deployments must load: %v", err)
+	}
+	over := configBoundTestFile(t, dir, "over.json", "[]", 1<<24+1)
+	if err := printFeatureBitsTelemetry(&out, nil, 0, over); err == nil || !strings.Contains(err.Error(), "exceeds size bound") {
+		t.Fatalf("over-bound deployments must be refused with the typed size error, got %v", err)
+	}
+}
+
+// TestReadFileConfigBoundGenesisSite pins RUB-1062 rider A at the
+// genesis-pack call site: an at-bound file parses exactly as before, one
+// byte over is refused with the typed size error.
+func TestReadFileConfigBoundGenesisSite(t *testing.T) {
+	dir := t.TempDir()
+	chainID := strings.Repeat("ab", 32)
+	pack := `{"chain_id_hex":"` + chainID + `","genesis_hash_hex":"` + strings.Repeat("cd", 32) + `"}`
+	at := configBoundTestFile(t, dir, "at.json", pack, 1<<24)
+	cfg, err := parseGenesisConfigFull(at)
+	if err != nil {
+		t.Fatalf("at-bound genesis pack must parse: %v", err)
+	}
+	if fmt.Sprintf("%x", cfg.ChainID[:]) != chainID {
+		t.Fatalf("at-bound genesis pack parsed wrong chain id: %x", cfg.ChainID[:])
+	}
+	over := configBoundTestFile(t, dir, "over.json", pack, 1<<24+1)
+	if _, err := parseGenesisConfigFull(over); err == nil || !strings.Contains(err.Error(), "exceeds size bound") {
+		t.Fatalf("over-bound genesis pack must be refused with the typed size error, got %v", err)
+	}
+}

--- a/clients/go/node/blockstore_write_if_absent.go
+++ b/clients/go/node/blockstore_write_if_absent.go
@@ -38,8 +38,17 @@ import (
 //	                    O_CREATE|O_EXCL (no O_TRUNC), so a later call
 //	                    hitting the same tmp path gets os.ErrExist from
 //	                    allocateAndWriteTemp and retries with a fresh
-//	                    seq (16-retry budget). Startup reconcile (E.2)
-//	                    sweeps orphan .tmp.* siblings. Crash before
+//	                    seq (16-retry budget). NOTHING removes that
+//	                    sibling today: a crash between the temp write
+//	                    and the link or rename leaks one
+//	                    <dest>.tmp.<pid>.<seq> file, and there is no
+//	                    startup sweep. The leak exists only because the
+//	                    name is unique per write; the fix is a FIXED
+//	                    temp name per destination (which the next write
+//	                    truncates) plus a datadir lock, not a startup
+//	                    deletion pass — Bitcoin Core and Monero take
+//	                    the naming route and sweep nothing at startup.
+//	                    Tracked as its own contract. Crash before
 //	                    syncDir leaves the dirent in page cache; the
 //	                    fast-path on retry re-runs syncDir and
 //	                    propagates its error so durability is surfaced.

--- a/clients/go/node/safeio.go
+++ b/clients/go/node/safeio.go
@@ -23,7 +23,9 @@ var errStoreFileTooLarge = errors.New("store file exceeds size bound")
 // size a consensus rule already caps, so the bound is derived rather than
 // invented. Artifacts that grow with chain length or UTXO-set size (the
 // chainstate snapshot, the canonical index marker) admit no such ceiling and
-// are deliberately NOT bounded here — they are owned by RUB-1062. The numbers
+// are deliberately left UNBOUNDED: no fixed byte number is defensible on
+// them, which is a settled decision rather than missing work — readFileByPath
+// carries the measurements and the alternative that was tried. The numbers
 // are a cross-client contract mirrored byte-for-byte by the Rust client; each
 // derivation and margin is recorded here and must not drift from the Rust
 // copy. The measured per-entry figure below is pinned by
@@ -63,10 +65,22 @@ const (
 //   - LoadChainState (chainstate_io.go) — the chainstate snapshot, which
 //     grows with UTXO-SET SIZE.
 //
-// Both belong to RUB-1062, and each needs its OWN derivation: the two grow
-// along different axes, so a single bound added at this helper would silently
-// cover both with one number that fits neither. Bounded readers are
-// readFileFromDir (per-class) and readFileByPathCapped.
+// Leaving them unbounded is a standing decision, not a gap awaiting an owner.
+// No byte ceiling on either artifact is defensible: RUB-1057 measured a 1 GB
+// chainstate bound as reachable in ~29 blocks of maximum-size CORE_VAULT
+// outputs, and any marker ceiling is only a hard cap on chain length. A
+// single bound at this helper would be worse still — the two grow along
+// different axes, so one number would silently cover both and fit neither.
+// Bounded readers are readFileFromDir (per-class) and readFileByPathCapped.
+//
+// An incremental-decode alternative to reading these whole was implemented
+// and measured, then withdrawn; do not re-derive it. It does not close the
+// finding — an oversized hostile file still kills the node — it is several
+// times WORSE than the whole-buffer path on a document holding one huge
+// value, and its equivalence to the whole-buffer decoders is only ever
+// provable by sampling: a nesting-depth divergence hid in two call sites and
+// was caught by a hand-written probe, not by the 70-plus-row corpus written
+// to catch exactly that. RUB-1057 is the finding of record.
 func readFileByPath(path string) ([]byte, error) {
 	dir := filepath.Dir(path)
 	name := filepath.Base(path)
@@ -228,14 +242,50 @@ func errFileTooLarge(name string, observed, maxBytes int64) error {
 // only production caller is PutUndo. Same typed class as the read-side
 // refusal; the message is clearly save-side. Block and header writes need no
 // guard — the wire format already fixes their size. The chainstate snapshot
-// and index marker have NO guard on either end in this slice: they are
-// unbounded on read too (see readFileByPath) and belong to RUB-1062, which
-// must add both ends together. Rust twin: `check_store_save_bound` in
-// io_utils.rs.
+// and index marker have NO guard on either end, deliberately and for good:
+// they grow with accumulated state, so no ceiling is defensible on the save
+// side either, and they are read whole and unbounded to match (the decision
+// and its measurements live on readFileByPath). Rust twin:
+// `check_store_save_bound` in io_utils.rs.
 func checkStoreSaveBound(name string, size int, maxBytes int64) error {
 	if int64(size) > maxBytes {
 		return fmt.Errorf("refusing to save %s: %d bytes marshaled, class bound %d: %w",
 			name, size, maxBytes, errStoreFileTooLarge)
 	}
 	return nil
+}
+
+// configFileMaxBytes bounds the two operator-supplied config files the Go
+// node reads at startup: the featurebits deployments JSON
+// (cmd/rubin-node --featurebits-deployments) and the genesis pack JSON
+// (--genesis-file). Derivation (RUB-1062 rider A): both schemas are small
+// and fixed —
+//   - deployments: a JSON array of {name, bit, start_height, timeout_height,
+//     activation_height}; bit is a uint8, so even an exhaustive table of all
+//     256 bits with generous 64-char names and 20-digit heights is
+//     ~256*400B ~= 100 KiB, and a realistic handful-of-deployments file is
+//     under 8 KiB;
+//   - genesis pack: four fixed hex fields, the largest the 116-byte header
+//     hex-doubled — a well-formed pack is under 1 KiB.
+//
+// The bound is 16 MiB: >3 orders of magnitude above any legitimate config
+// (~2000x the realistic deployments ceiling, >10^4 x a genesis pack) and
+// still >160x the exhaustive 256-bit table. Reachability (the RUB-1057
+// lesson): both files are operator-authored and do not grow with chain or
+// UTXO state; an input actually filling 16 MiB would need ~40k deployment
+// entries or megabytes of padding, which no legitimate config approaches —
+// the ceiling cannot fire on honest use, while a mistakenly-pointed-at huge
+// file is refused before allocation. Cross-client disposition: the
+// DEPLOYMENTS surface is Go-only (the Rust node has no such flag; the
+// born-bounded obligation for a future port is RUB-1065), while the
+// GENESIS-FILE surface exists in Rust (load_genesis_config and
+// load_chain_id_from_genesis_file in crates/rubin-node/src/genesis.rs) and
+// is still unbounded there — the Rust mirror (RUB-1069) carries this same
+// 16 MiB ceiling and the same typed pre-allocation refusal.
+const configFileMaxBytes = 1 << 24
+
+// ReadConfigFile reads an operator config file under configFileMaxBytes with
+// the typed pre-allocation refusal from RUB-1057 (errStoreFileTooLarge).
+func ReadConfigFile(path string) ([]byte, error) {
+	return readFileByPathCapped(path, configFileMaxBytes)
 }

--- a/clients/go/node/safeio_test.go
+++ b/clients/go/node/safeio_test.go
@@ -20,8 +20,9 @@ const testReadBound = 8
 // removed at-production-bound row of the undo class: that caller shares the
 // bounded reader at these hard-wired constants, and its at/over verdicts run
 // at small injectable bounds in this file. The chainstate snapshot and index
-// marker are deliberately absent — they grow with accumulated state, admit
-// no fixed ceiling, and are owned by RUB-1062. The write-if-absent verify
+// marker are deliberately absent — they grow with accumulated state and admit
+// no fixed ceiling; readFileByPath's comment is the decision of record. The
+// write-if-absent verify
 // reads have no constant of their own: they are bounded by the length of the
 // content being written (see readVerifyTarget).
 func TestSafeIOClassBoundConstantsPinFrozenValues(t *testing.T) {
@@ -397,5 +398,37 @@ func TestSafeIOReadAllCappedPropagatesRawErrors(t *testing.T) {
 				t.Fatalf("want raw probe error, got %v", err)
 			}
 		})
+	}
+}
+
+// TestReadFileConfigBoundPinsDerivedValue pins the RUB-1062 rider A
+// operator-config ceiling; the derivation lives on configFileMaxBytes in
+// safeio.go. A red row means the derived cross-surface contract number
+// drifted.
+func TestReadFileConfigBoundPinsDerivedValue(t *testing.T) {
+	if configFileMaxBytes != 1<<24 {
+		t.Fatalf("configFileMaxBytes = %d, want %d (16 MiB, see derivation)", configFileMaxBytes, 1<<24)
+	}
+}
+
+// TestReadFileConfigBoundAtAndOverBound pins the typed pre-allocation
+// refusal at the shared helper: at-bound accepted byte-for-byte, one byte
+// over refused with errStoreFileTooLarge.
+func TestReadFileConfigBoundAtAndOverBound(t *testing.T) {
+	dir := t.TempDir()
+	at := filepath.Join(dir, "at.json")
+	if err := os.WriteFile(at, make([]byte, configFileMaxBytes), 0o600); err != nil {
+		t.Fatalf("write at-bound: %v", err)
+	}
+	raw, err := ReadConfigFile(at)
+	if err != nil || len(raw) != configFileMaxBytes {
+		t.Fatalf("at-bound config must be read whole: len=%d err=%v", len(raw), err)
+	}
+	over := filepath.Join(dir, "over.json")
+	if err := os.WriteFile(over, make([]byte, configFileMaxBytes+1), 0o600); err != nil {
+		t.Fatalf("write over-bound: %v", err)
+	}
+	if _, err := ReadConfigFile(over); !errors.Is(err, errStoreFileTooLarge) {
+		t.Fatalf("over-bound config must be refused with errStoreFileTooLarge, got %v", err)
 	}
 }


### PR DESCRIPTION
## Issue
- Linear: RUB-1062

Refs: Q-SEC-STORE-CONFIG-BOUND-AND-TEMP-SWEEP-01-GO

## Summary
The Go node read two operator-supplied config files with no size bound at all — the feature-bits deployments JSON and the genesis pack — so a mistakenly-pointed-at large file was answered by an allocation failure instead of the typed local error RUB-1057 established for exactly this class. Both reads now go through the bounded path reader merged by that slice, under one derived ceiling of 16 MiB, refusing over-bound input before its contents are allocated and leaving each call site's existing error handling otherwise untouched.

The ceiling is derived from the two schemas rather than picked. A deployments table is a JSON array of fixed-shape entries whose `bit` is a uint8, so even an exhaustive 256-bit table with generous names and 20-digit heights is about 100 KiB and a realistic file is under 8 KiB; a genesis pack is four hex fields, the largest a 116-byte header hex-doubled, so a well-formed pack is under 1 KiB. 16 MiB is over three orders of magnitude above either. The comment also records what an input filling the ceiling would have to be — roughly 40k deployment entries or megabytes of padding — because a bound whose reachability is not stated is the failure RUB-1057 was split over.

## Invariant
Every operator config file the Go node reads at startup is read under a fixed derived bound with the typed pre-allocation refusal, and no legitimate config approaches that bound.

## Scope
- Changed files: 5
- Surfaces: clients/go
- Non-scope: the chainstate snapshot and canonical index marker read/write paths, which are byte-identical to the baseline in this PR; no streaming or incremental decoder; no startup deletion pass of any kind; no datadir lock; no configurable or operator-overridable cap; no new persistent artifact or schema field; no CI or gate wiring; no consensus, wire, peer-scoring, spec, formal, or conformance-schema change
- Consensus rules unchanged: YES — the bound applies to two node-local startup config reads; accept/reject outcomes, public error codes and their ordering are untouched, and the refusal is a node-private local error class
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `go test -race -timeout=20m -shuffle=on -count=1 ./...` — PASS; `go test ./node ./cmd/rubin-node -count=1` — PASS; `go test ./... -count=1` — PASS; `go vet ./...` — PASS; `gofumpt -l` on every changed file — clean; `golangci-lint` in diff mode against the baseline — 0 issues; `cargo nextest run --workspace --all-targets` — PASS; `cargo test --workspace --doc` — PASS; `cargo fmt --check` — PASS; `cargo clippy -p rubin-node --all-targets -- -D warnings` — PASS; `git diff --check` — PASS

## Follow-ups / Waivers
- An earlier revision of this branch also carried a startup sweep of orphan `<dest>.tmp.<pid>.<seq>` files. It was withdrawn after a survey of Bitcoin Core, Monero, btcd and Bitcoin Knots read from source: none of them sweeps temp files at startup, and they avoid the leak one layer earlier — an exclusive datadir lock plus a fixed temp name per destination that the next write truncates. RUB-1078 carries that mechanism for both clients; the comment in `blockstore_write_if_absent.go` now states the leak honestly instead of promising a sweep that does not exist.
- RUB-1069 mirrors this config bound in Rust, where `--genesis-file` is still read unbounded (`genesis.rs` `load_genesis_config` and `load_chain_id_from_genesis_file`), and corrects four stale comments there.
- RUB-1071 records a pre-existing defect found while reviewing this change and not addressed here: `--dry-run` is documented and treated as read-only, but it reaches `chainState.Save` and rewrites the chainstate on every invocation.
- RUB-1065 tracks the born-bounded obligation for a future Rust port of the feature-bits deployments surface, which does not exist in that client today.
