### PR TITLE
RUB-676: move the OpenSSL source pin into a repository-owned checksum file

### DIFF
--- a/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
+++ b/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
@@ -41,8 +41,8 @@ If SLA cannot be met, incident owner MUST publish a blocker note with ETA and mi
    - **Operational-only**: availability/perf/compliance without consensus drift.
 3. Prepare mitigation:
    - version bump and bundle rebuild — the build refuses an unpinned version, so add
-     the new version's sha256 to the `case` block in
-     `scripts/crypto/openssl/build-openssl-bundle.sh` from the upstream
+     the new version's `<sha256>  openssl-<version>.tar.gz` line to
+     `scripts/crypto/openssl/source-checksums.sha256` from the upstream
      `openssl-<version>.tar.gz.sha256` asset named in the refusal message,
    - temporary runtime guard (if needed),
    - tests for regression and deterministic behavior.

--- a/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
+++ b/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
@@ -40,10 +40,25 @@ If SLA cannot be met, incident owner MUST publish a blocker note with ETA and mi
    - **Consensus-impacting**: can alter accept/reject decisions or signature verification outcomes.
    - **Operational-only**: availability/perf/compliance without consensus drift.
 3. Prepare mitigation:
-   - version bump and bundle rebuild — the build refuses an unpinned version, so add
-     the new version's `<sha256>  openssl-<version>.tar.gz` line to
-     `scripts/crypto/openssl/source-checksums.sha256` from the upstream
-     `openssl-<version>.tar.gz.sha256` asset named in the refusal message,
+   - version bump and bundle rebuild. Pinning only ALLOWLISTS an archive, it does not
+     select one, so all four steps are mandatory — stopping after the pin leaves every
+     lane building the old, vulnerable release:
+     1. add the new `<sha256>  openssl-<version>.tar.gz` line to
+        `scripts/crypto/openssl/source-checksums.sha256`, taking the digest from the
+        upstream `openssl-<version>.tar.gz.sha256` asset named in the refusal message,
+     2. change the builder default in
+        `scripts/crypto/openssl/build-openssl-bundle.sh` (1 site):
+        `grep -n 'OPENSSL_VERSION=' scripts/crypto/openssl/build-openssl-bundle.sh`,
+     3. change every explicit selector (10 sites: 9 workflow steps + 1 README example):
+        `git grep -n 'OPENSSL_VERSION=3\.5\.5'`,
+     4. change every version-bearing cache prefix, cache path and cache key (36 sites):
+        `git grep -nE 'bundle-3\.5\.5|openssl-3\.5\.5\.tar\.gz|3\.5\.5-v[0-9]' -- .github/workflows`.
+     The counts are as of 2026-07-29 and will drift — re-derive them with the commands
+     above (substituting the outgoing version) rather than trusting the numbers. No
+     checker enforces bump completeness, so finish with `git grep -n '3\.5\.5'` and
+     confirm every remaining hit is deliberate: workflow step titles, the
+     `scripts/crypto/openssl/bench-pq-*.py` defaults, the `scripts/dev-env.sh` example,
+     the contract test constant, and any superseded pin line kept for rollback.
    - temporary runtime guard (if needed),
    - tests for regression and deterministic behavior.
 4. Open one PR for code/tooling updates and one PR for spec/ops updates when required.

--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -8,10 +8,11 @@ OPENSSL_VERSION=3.5.5 scripts/dev-env.sh -- bash scripts/crypto/openssl/build-op
 ```
 
 Before extracting, the script verifies the source tarball — freshly downloaded or
-cached — against a sha256 pinned per version in its own `case` block, and refuses
-to build on a mismatch or on a version with no pin entry. A version bump therefore
-adds one `case` entry with the digest from the upstream
-`openssl-<version>.tar.gz.sha256` release asset.
+cached — against a sha256 pinned per version in `source-checksums.sha256` beside
+it, and refuses to build on a mismatch, on a version with no pin entry, or on a
+pin file that is unreadable, malformed, or ambiguous. A version bump therefore
+adds one `<sha256>  openssl-<version>.tar.gz` line to that file with the digest
+from the upstream `openssl-<version>.tar.gz.sha256` release asset.
 
 Default install prefix:
 

--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -10,9 +10,11 @@ OPENSSL_VERSION=3.5.5 scripts/dev-env.sh -- bash scripts/crypto/openssl/build-op
 Before extracting, the script verifies the source tarball — freshly downloaded or
 cached — against a sha256 pinned per version in `source-checksums.sha256` beside
 it, and refuses to build on a mismatch, on a version with no pin entry, or on a
-pin file that is unreadable, malformed, or ambiguous. A version bump therefore
-adds one `<sha256>  openssl-<version>.tar.gz` line to that file with the digest
-from the upstream `openssl-<version>.tar.gz.sha256` release asset.
+pin file that is unreadable, malformed, or ambiguous. That file is the allowlist of
+buildable archives, not the version selector: adding a
+`<sha256>  openssl-<version>.tar.gz` line permits a version, while switching to it also
+requires the builder default, the `OPENSSL_VERSION=` selectors and the version-bearing
+cache paths and keys — see `CVE_RESPONSE_RUNBOOK.md` section 3 for the full procedure.
 
 Default install prefix:
 

--- a/scripts/crypto/openssl/build-openssl-bundle.sh
+++ b/scripts/crypto/openssl/build-openssl-bundle.sh
@@ -11,22 +11,48 @@ BUILD_DIR="${WORK_ROOT}/openssl-${OPENSSL_VERSION}"
 TARBALL_PATH="${WORK_ROOT}/${ARCHIVE}"
 JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8)}"
 FIPS_SECTION_NAME="${FIPS_SECTION_NAME:-fips_sect}"
+CHECKSUM_FILE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/source-checksums.sha256"
+CHECKSUM_LINE_RE='^([0-9a-f]{64})  ([^[:space:]]+)$'
 
-# Pinned sha256 of the upstream source tarball, one entry per supported version,
-# from the official release asset openssl-<version>.tar.gz.sha256. Selected by
-# OPENSSL_VERSION and never by ARCHIVE_URL, so a mirror serving the pinned bytes
-# passes and anything else fails without any URL-specific logic.
-case "${OPENSSL_VERSION}" in
-  3.5.5)
-    EXPECTED_SHA256="b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
-    ;;
-  *)
+# The pinned sha256 of every supported upstream source tarball lives in
+# CHECKSUM_FILE, selected by archive name — i.e. by OPENSSL_VERSION — and never by
+# ARCHIVE_URL, so a mirror serving the pinned bytes passes and anything else fails
+# without any URL-specific logic. A pin file that is unreadable, malformed anywhere,
+# or ambiguous about the selected archive fails the build rather than being trusted.
+lookup_pinned_sha256() {
+  local archive="$1" line digest="" lineno=0
+  if [ ! -r "${CHECKSUM_FILE}" ]; then
+    echo "ERROR: cannot read pinned checksum file ${CHECKSUM_FILE}; refusing to build" >&2
+    return 1
+  fi
+  while IFS= read -r line || [ -n "${line}" ]; do
+    lineno=$((lineno + 1))
+    case "${line}" in ''|'#'*) continue ;; esac
+    if [[ ! "${line}" =~ ${CHECKSUM_LINE_RE} ]]; then
+      echo "ERROR: malformed entry at ${CHECKSUM_FILE}:${lineno}" >&2
+      echo "Every entry must be '<64 lowercase hex>  <archive>'; refusing to build" >&2
+      return 1
+    fi
+    if [ "${BASH_REMATCH[2]}" = "${archive}" ]; then
+      if [ -n "${digest}" ]; then
+        echo "ERROR: duplicate pinned sha256 for ${archive} at ${CHECKSUM_FILE}:${lineno}; refusing to build" >&2
+        return 1
+      fi
+      digest="${BASH_REMATCH[1]}"
+    fi
+  done < "${CHECKSUM_FILE}"
+  if [ -z "${digest}" ]; then
     echo "ERROR: no pinned sha256 for OpenSSL ${OPENSSL_VERSION}; refusing to build" >&2
-    echo "Add a case entry for ${OPENSSL_VERSION} in scripts/crypto/openssl/build-openssl-bundle.sh" >&2
+    echo "Add a '<sha256>  ${ARCHIVE}' line to ${CHECKSUM_FILE}" >&2
     echo "using the digest published at https://github.com/openssl/openssl/releases/download/${OPENSSL_TAG}/${ARCHIVE}.sha256" >&2
-    exit 1
-    ;;
-esac
+    return 1
+  fi
+  printf '%s\n' "${digest}"
+}
+
+if ! EXPECTED_SHA256="$(lookup_pinned_sha256 "${ARCHIVE}")"; then
+  exit 1
+fi
 
 compute_sha256() {
   local output

--- a/scripts/crypto/openssl/source-checksums.sha256
+++ b/scripts/crypto/openssl/source-checksums.sha256
@@ -1,0 +1,8 @@
+# Authoritative sha256 pins for the upstream OpenSSL source tarballs this repository
+# is allowed to build, in sha256sum format so `sha256sum -c` works here by hand.
+# build-openssl-bundle.sh selects a line by OPENSSL_VERSION and refuses to build a
+# version that has none. Each digest is the one published in the official release asset
+# https://github.com/openssl/openssl/releases/download/openssl-<version>/openssl-<version>.tar.gz.sha256
+# Supporting a new version is one line here and nothing else; keep it that way, since
+# CVE_RESPONSE_RUNBOOK.md section 5 makes an operational bump approval-free.
+b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89  openssl-3.5.5.tar.gz

--- a/scripts/crypto/openssl/source-checksums.sha256
+++ b/scripts/crypto/openssl/source-checksums.sha256
@@ -1,8 +1,10 @@
-# Authoritative sha256 pins for the upstream OpenSSL source tarballs this repository
-# is allowed to build, in sha256sum format so `sha256sum -c` works here by hand.
-# build-openssl-bundle.sh selects a line by OPENSSL_VERSION and refuses to build a
-# version that has none. Each digest is the one published in the official release asset
+# Allowlist of the upstream OpenSSL source archives this repository may build, and the
+# authority for their digests, in sha256sum format so `sha256sum -c` works here by hand.
+# Each digest is the one published in the official release asset
 # https://github.com/openssl/openssl/releases/download/openssl-<version>/openssl-<version>.tar.gz.sha256
-# Supporting a new version is one line here and nothing else; keep it that way, since
-# CVE_RESPONSE_RUNBOOK.md section 5 makes an operational bump approval-free.
+# Adding a line PERMITS a version; it does not SELECT one. build-openssl-bundle.sh looks
+# up OPENSSL_VERSION here and refuses a version with no entry, but switching lanes to a
+# new version also requires the builder default, every OPENSSL_VERSION= selector, and
+# every version-bearing cache path and key — CVE_RESPONSE_RUNBOOK.md section 3 has the
+# procedure and the greps that enumerate those sites.
 b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89  openssl-3.5.5.tar.gz

--- a/tools/ci_formal_relevance.py
+++ b/tools/ci_formal_relevance.py
@@ -20,6 +20,7 @@ PROTECTED_EXACT = {
     "README.md",
     "SPEC_LOCATION.md",
     "scripts/crypto/openssl/build-openssl-bundle.sh",
+    "scripts/crypto/openssl/source-checksums.sha256",
     "tools/check_formal_claims_lint.py",
     "tools/check_formal_coverage.py",
     "tools/check_formal_refinement_bridge.py",

--- a/tools/tests/test_ci_formal_relevance.py
+++ b/tools/tests/test_ci_formal_relevance.py
@@ -35,6 +35,7 @@ class FormalRelevanceTests(unittest.TestCase):
             "clients/rust/crates/rubin-consensus/src/lib.rs",
             "tools/formal/generate.py",
             "scripts/crypto/openssl/build-openssl-bundle.sh",
+            "scripts/crypto/openssl/source-checksums.sha256",
             "README.md",
             "SPEC_LOCATION.md",
             *sorted(path for path in subject.PROTECTED_EXACT if path.startswith("tools/")),

--- a/tools/tests/test_openssl_bundle_contract.py
+++ b/tools/tests/test_openssl_bundle_contract.py
@@ -15,6 +15,9 @@ from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "crypto" / "openssl" / "build-openssl-bundle.sh"
+CHECKSUM_PATH = SCRIPT_PATH.with_name("source-checksums.sha256")
+PAYLOAD = object()  # pin the served bytes; ABSENT writes no checksum file at all
+ABSENT = object()
 VERSION = "3.5.5"
 PUBLISHED_SHA256 = "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
 MIRROR_URL = "https://mirror.example/openssl.tar.gz"
@@ -47,24 +50,18 @@ def source_tarball() -> bytes:
 
 
 def repin_text(text: str, digest: str, version: str) -> str:
-    """Repoint one version's case arm, leaving every other pinned version intact."""
-    patched, count = re.subn(rf'({re.escape(version)}\)\s+EXPECTED_SHA256=")[0-9a-f]{{64}}',
-                             rf"\g<1>{digest}", text)
+    """Repoint one version's pinned line, leaving every other pinned version intact."""
+    patched, count = re.subn(rf"^[0-9a-f]{{64}}(  openssl-{re.escape(version)}\.tar\.gz)$",
+                             rf"{digest}\g<1>", text, flags=re.MULTILINE)
     assert count == 1, f"expected one pinned digest for {version}, found {count}"
     return patched
 
 
-def repin(root: Path, payload: bytes, version: str) -> Path:
-    """The real script with the selected version's pin repointed at a local payload."""
-    path = root / "build-openssl-bundle.sh"
-    path.write_text(repin_text(SCRIPT_PATH.read_text(encoding="utf-8"),
-                               hashlib.sha256(payload).hexdigest(), version), encoding="utf-8")
-    return path
-
-
 class OpenSSLBundleContractTests(unittest.TestCase):
-    def run_bundle(self, tmp, *, served, repinned=False, precache=False, version=VERSION,
+    def run_bundle(self, tmp, *, served, pin=None, precache=False, version=VERSION,
                    archive_url=None, break_sha_tools=False):
+        """pin=None runs the real script against the repository pin file; anything else copies
+        the script beside PAYLOAD (pin the served bytes), ABSENT (no file), or literal text."""
         root = Path(tmp)
         bin_dir = root / "bin"
         bin_dir.mkdir()
@@ -84,7 +81,16 @@ class OpenSSLBundleContractTests(unittest.TestCase):
                "CURL_RAN": str(root / "curl-ran")}
         if archive_url is not None:
             env["ARCHIVE_URL"] = archive_url
-        proc = subprocess.run(["/bin/bash", str(repin(root, served, version) if repinned else SCRIPT_PATH)],
+        script = SCRIPT_PATH
+        if pin is not None:
+            script = root / "build-openssl-bundle.sh"
+            script.write_text(SCRIPT_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+            if pin is not ABSENT:
+                (root / "source-checksums.sha256").write_text(
+                    repin_text(CHECKSUM_PATH.read_text(encoding="utf-8"),
+                               hashlib.sha256(served).hexdigest(), version)
+                    if pin is PAYLOAD else pin, encoding="utf-8")
+        proc = subprocess.run(["/bin/bash", str(script)],
                               capture_output=True, text=True, env=env, cwd=root)
         return SimpleNamespace(proc=proc, tarball=tarball, curl_ran=root / "curl-ran",
                                extracted=work / f"openssl-{version}" / "EXTRACTED")
@@ -96,7 +102,7 @@ class OpenSSLBundleContractTests(unittest.TestCase):
             ("mirror serving pinned bytes", {"archive_url": MIRROR_URL}, True),
         ):
             with self.subTest(name), tempfile.TemporaryDirectory() as tmp:
-                run = self.run_bundle(tmp, served=source_tarball(), repinned=True, **kwargs)
+                run = self.run_bundle(tmp, served=source_tarball(), pin=PAYLOAD, **kwargs)
                 self.assertEqual(run.proc.returncode, 0, run.proc.stderr)
                 self.assertEqual(run.curl_ran.exists(), downloaded)
                 self.assertTrue(run.extracted.exists())
@@ -120,8 +126,26 @@ class OpenSSLBundleContractTests(unittest.TestCase):
             self.assertNotEqual(run.proc.returncode, 0)
             self.assertFalse(run.curl_ran.exists())
             self.assertIn("no pinned sha256 for OpenSSL 9.9.9", run.proc.stderr)
-            self.assertIn("scripts/crypto/openssl/build-openssl-bundle.sh", run.proc.stderr)
+            self.assertIn("scripts/crypto/openssl/source-checksums.sha256", run.proc.stderr)
             self.assertIn("openssl-9.9.9.tar.gz.sha256", run.proc.stderr)
+
+    def test_unusable_pin_file_refuses_before_any_download(self):
+        pinned = f"{'d' * 64}  openssl-{VERSION}.tar.gz\n"
+        for name, pin, expected in (
+            ("no pin file at all", ABSENT, "cannot read pinned checksum file"),
+            ("only another version pinned", f"{'d' * 64}  openssl-3.4.0.tar.gz\n", "no pinned sha256"),
+            ("digest too short", f"{'d' * 63}  openssl-{VERSION}.tar.gz\n", "malformed entry"),
+            ("uppercase digest", f"{'D' * 64}  openssl-{VERSION}.tar.gz\n", "malformed entry"),
+            ("single-space separator", f"{'d' * 64} openssl-{VERSION}.tar.gz\n", "malformed entry"),
+            ("malformed line for another version", pinned + "garbage\n", "malformed entry"),
+            ("duplicate entry", pinned + pinned, "duplicate pinned sha256"),
+        ):
+            with self.subTest(name), tempfile.TemporaryDirectory() as tmp:
+                run = self.run_bundle(tmp, served=source_tarball(), pin=pin)
+                self.assertNotEqual(run.proc.returncode, 0)
+                self.assertFalse(run.curl_ran.exists())
+                self.assertFalse(run.extracted.exists())
+                self.assertIn(expected, run.proc.stderr)
 
     def test_hash_tool_failure_is_not_reported_as_mismatch(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -131,17 +155,17 @@ class OpenSSLBundleContractTests(unittest.TestCase):
             self.assertNotIn("mismatch", run.proc.stderr)
             self.assertTrue(run.tarball.exists())
 
-    def test_repin_targets_one_arm_when_a_second_version_is_pinned(self):
-        second = f'  3.6.0)\n    EXPECTED_SHA256="{"a" * 64}"\n    ;;\n'
-        text = SCRIPT_PATH.read_text(encoding="utf-8").replace("  3.5.5)\n", second + "  3.5.5)\n", 1)
+    def test_repin_targets_one_line_when_a_second_version_is_pinned(self):
+        text = CHECKSUM_PATH.read_text(encoding="utf-8") + f"{'a' * 64}  openssl-3.6.0.tar.gz\n"
         patched = repin_text(text, "b" * 64, VERSION)
-        self.assertIn(f'EXPECTED_SHA256="{"a" * 64}"', patched)
-        self.assertIn(f'EXPECTED_SHA256="{"b" * 64}"', patched)
+        self.assertIn(f"{'a' * 64}  openssl-3.6.0.tar.gz", patched)
+        self.assertIn(f"{'b' * 64}  openssl-{VERSION}.tar.gz", patched)
         self.assertNotIn(PUBLISHED_SHA256, patched)
 
-    def test_script_is_the_single_definition_of_the_published_pin(self):
-        self.assertIn(f'EXPECTED_SHA256="{PUBLISHED_SHA256}"',
-                      SCRIPT_PATH.read_text(encoding="utf-8"))
+    def test_checksum_file_is_the_single_definition_of_the_published_pin(self):
+        self.assertIn(f"{PUBLISHED_SHA256}  openssl-{VERSION}.tar.gz",
+                      CHECKSUM_PATH.read_text(encoding="utf-8"))
+        self.assertNotIn(PUBLISHED_SHA256, SCRIPT_PATH.read_text(encoding="utf-8"))
         for workflow in sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml")):
             self.assertNotIn(PUBLISHED_SHA256, workflow.read_text(encoding="utf-8"),
                              f"pin duplicated in {workflow.name}")


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-676
- GitHub Issue mirror (non-authoritative): #676

Refs: Q-CI-OPENSSL-ARCHIVE-DIGEST-01

## Summary
The pinned OpenSSL source digest moves from an inline `case` block in the builder into `scripts/crypto/openssl/source-checksums.sha256`, the repository-owned checksum file this leaf specifies and the input RUB-677 binds cache keys to. The builder resolves it beside itself and refuses, before any download, an unreadable file, a missing entry, a malformed line anywhere, or a duplicate entry. The new path joins `PROTECTED_EXACT` in `tools/ci_formal_relevance.py`, without which a pin-only version bump would skip the formal jobs that build this bundle.

## Invariant
For the selected OPENSSL_VERSION, the bundle builder verifies every existing-cache or freshly downloaded archive against the repository-pinned SHA-256 digest before any extraction; missing, malformed, mismatched, or unavailable digest verification exits nonzero before extraction.

## Scope
- Changed files: 7
- Surfaces: crypto backend build script and its new checksum file, its documentation, the formal-relevance classifier's protected set, two tooling tests
- Non-scope: no workflow or cache-key edit (RUB-677 owns that), no OpenSSL version upgrade, no runtime provider/FFI/FIPS behaviour change, no classifier logic change
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS; `python3 tools/check_openssl_cve_response.py --code-root .` — PASS; `OPENSSL_VERSION=3.5.5 WORK_ROOT=<clean> PREFIX=<clean> bash scripts/crypto/openssl/build-openssl-bundle.sh` — PASS; `shasum -a 256 -c scripts/crypto/openssl/source-checksums.sha256` — PASS; `shellcheck scripts/crypto/openssl/build-openssl-bundle.sh` — PASS; `bash -n scripts/crypto/openssl/build-openssl-bundle.sh` — PASS; `git diff --check` — PASS

## Follow-ups / Waivers
- RUB-1075 (triage) records that nothing asserts a version bump reached every site.
- RUB-677 binds the OpenSSL cache keys to `hashFiles('scripts/crypto/openssl/source-checksums.sha256')`; this change creates that input.
