### PR TITLE
RUB-1073: sync protocol PR template projection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,8 @@ Refs: {{Q_TOKEN}}
 - Wire format unchanged: {{WIRE_FORMAT_UNCHANGED}}
 
 ## Validation
-- `cl push`: {{VERDICT}} for HEAD {{HEAD}}
-- Focused checks: {{FOCUSED_CHECKS}}
-- Not run / skipped: {{SKIPPED}}
+<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
+- Dynamic checks: {{FOCUSED_CHECKS}}
 
 ## Follow-ups / Waivers
 - {{FOLLOW_UPS}}

--- a/tools/ci_formal_relevance.py
+++ b/tools/ci_formal_relevance.py
@@ -52,6 +52,7 @@ SKIPPABLE_EXACT = {
         "workflow-hygiene.yml",
     )
 } | {
+    ".github/PULL_REQUEST_TEMPLATE.md",
     ".codacy.yml",
     ".coderabbit.yaml",
     ".jscpd.json",

--- a/tools/tests/test_ci_formal_relevance.py
+++ b/tools/tests/test_ci_formal_relevance.py
@@ -59,6 +59,11 @@ class FormalRelevanceTests(unittest.TestCase):
                 self.assertFalse(decision.run_formal)
                 self.assertEqual(decision.path_count, 1)
 
+    def test_pr_template_only_skips(self):
+        self.assertFalse(
+            self.decision(diff(("M", ".github/PULL_REQUEST_TEMPLATE.md"))).run_formal
+        )
+
     def test_protected_precedence_over_broad_allowlists(self):
         for path in (
             "tools/formal/generate.py",


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1073
- GitHub Issue mirror (non-authoritative): #2746

Refs: Q-PROTOCOL-PR-TEMPLATE-PROJECTION-01

## Summary
Synchronize the tracked protocol pull-request template with its canonical
control-plane projection and classify template-only changes as formal-irrelevant.

## Invariant
The repository template is byte-identical to the canonical protocol profile,
and changing only that template skips Lean while retaining required green jobs.

## Scope
- Changed files: 3
- Surfaces: docs, tooling
- Non-scope: workflow structure, protected formal paths, and protocol code
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `cmp -s "$(cl repo-path rubin-control-plane)/templates/pr-body/rubin-protocol.md" .github/PULL_REQUEST_TEMPLATE.md && python3 -m unittest tools.tests.test_ci_formal_relevance` — PASS

## Follow-ups / Waivers
- None
