### PR TITLE
RUB-677: bind every OpenSSL bundle cache key to the pinned digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
@@ -489,7 +489,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |
@@ -608,7 +608,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         if: steps.formal_gate.outputs.run_formal == 'true'
@@ -718,7 +718,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
       - name: Build OpenSSL 3.5.5 bundle
         run: |
           set -euo pipefail

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -23,7 +23,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle (PQC-enabled)
         run: |

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/.github/workflows/fips-only-nightly.yml
+++ b/.github/workflows/fips-only-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -98,13 +98,15 @@ jobs:
       # own key because its entries are already verified and rotating them would
       # buy nothing. No restore-keys: a prefix fallback reaches pre-rotation
       # entries and would undo both.
+      # The key also binds hashFiles of the pinned-digest file, so a pin change
+      # rotates it; the prefix stays dedicated because only this lane writes it.
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-mldsa-verified-${{ runner.os }}-3.5.5-v1
+          key: openssl-bundle-mldsa-verified-${{ runner.os }}-3.5.5-v1-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         run: |

--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
             ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
-          key: openssl-bundle-${{ runner.os }}-3.5.5-v3
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v3-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}
 
       - name: Build OpenSSL 3.5.5 bundle
         id: openssl

--- a/tools/list_workflow_shell_targets.py
+++ b/tools/list_workflow_shell_targets.py
@@ -5,7 +5,7 @@ import re
 import sys
 from pathlib import Path
 
-WORKFLOW_SCRIPT_RE = re.compile(r"scripts/[A-Za-z0-9_./-]+\.sh")
+WORKFLOW_SCRIPT_RE = re.compile(r"scripts/[A-Za-z0-9_./-]+\.sh(?![A-Za-z0-9_./-])")
 
 
 def iter_workflows(workflow_dir: Path) -> list[Path]:

--- a/tools/tests/test_check_workflow_yaml_syntax.py
+++ b/tools/tests/test_check_workflow_yaml_syntax.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import re
 import sys
 import tempfile
 import unittest
@@ -13,6 +14,47 @@ sys.path.insert(0, str(TOOLS_DIR))
 import check_workflow_yaml_syntax as m
 
 HAS_PYYAML = m.load_yaml_module() is not None
+
+WORKFLOWS_DIR = TOOLS_DIR.parent / ".github" / "workflows"
+BUILDER = "scripts/crypto/openssl/build-openssl-bundle.sh"
+CHECKSUMS = "scripts/crypto/openssl/source-checksums.sha256"
+CACHE_ACTION = "actions/cache@"
+# The binding must be an evaluated expression: a literal substring or a trailing
+# YAML comment carries the text without ever rotating the cache identity.
+PIN_BINDING = re.compile(r"\$\{\{[^{}]*hashFiles\(\s*'" + re.escape(CHECKSUMS) + r"'\s*\)[^{}]*\}\}")
+BUNDLE_DIR = re.compile(r"~/\.cache/rubin-openssl/bundle-\S+")
+SOURCE_ARCHIVE = re.compile(r"~/\.cache/rubin-openssl/work/openssl-\S+\.tar\.gz")
+
+
+def workflow_files() -> list[Path]:
+    return sorted(p for p in WORKFLOWS_DIR.iterdir() if p.suffix in (".yml", ".yaml"))
+
+
+def is_builder_call(step: object) -> bool:
+    return isinstance(step, dict) and BUILDER in str(step.get("run", ""))
+
+
+def bundle_cache_settings(step: object) -> dict | None:
+    """The `with:` block of an OpenSSL bundle cache step, or None for any other step."""
+    if not isinstance(step, dict) or CACHE_ACTION not in str(step.get("uses", "")):
+        return None
+    settings = step.get("with") or {}
+    return settings if "rubin-openssl" in str(settings.get("path", "")) else None
+
+
+def job_steps(document: object) -> list[tuple[str, list]]:
+    return [(job_id, (job or {}).get("steps") or [])
+            for job_id, job in ((document or {}).get("jobs") or {}).items()]
+
+
+def builder_jobs(yaml):
+    """Yield (label, steps, call_indexes) for every job that builds the OpenSSL bundle."""
+    for path in workflow_files():
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_id, steps in job_steps(document):
+            calls = [i for i, step in enumerate(steps) if is_builder_call(step)]
+            if calls:
+                yield f"{path.name}:{job_id}", steps, calls
 
 
 class WorkflowYamlSyntaxTests(unittest.TestCase):
@@ -69,6 +111,29 @@ class WorkflowYamlSyntaxTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIn("SKIP: PyYAML unavailable", message)
+
+
+class OpenSSLBundleCacheIdentityTests(unittest.TestCase):
+    @unittest.skipUnless(HAS_PYYAML, "PyYAML unavailable")
+    def test_bundle_cache_keys_bind_the_pinned_source_digest(self):
+        builder_calls = 0
+        bound_keys = 0
+
+        for label, steps, calls in builder_jobs(m.load_yaml_module()):
+            builder_calls += len(calls)
+            caches = [s for s in map(bundle_cache_settings, steps[: calls[0]]) if s]
+            with self.subTest(job=label):
+                self.assertEqual(len(caches), 1, f"{label}: expected exactly one OpenSSL bundle cache step before the builder call")
+                settings = caches[0]
+                paths = str(settings.get("path", "")).split()
+                self.assertRegex(str(settings.get("key", "")), PIN_BINDING, f"{label}: cache key does not evaluate hashFiles('{CHECKSUMS}')")
+                self.assertTrue(any(BUNDLE_DIR.fullmatch(p) for p in paths), f"{label}: cache path no longer covers the installed bundle")
+                self.assertTrue(any(SOURCE_ARCHIVE.fullmatch(p) for p in paths), f"{label}: cache path no longer covers the downloaded source archive")
+                self.assertIsNone(settings.get("restore-keys"), f"{label}: a prefix fallback restores entries predating the pin binding")
+                bound_keys += 1
+
+        self.assertGreater(builder_calls, 0, "no bundle builder call site found; the parse or the builder path is stale")
+        self.assertEqual(builder_calls, bound_keys, "every bundle builder call must sit behind a pin-bound cache key")
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_list_workflow_shell_targets.py
+++ b/tools/tests/test_list_workflow_shell_targets.py
@@ -58,6 +58,29 @@ class WorkflowShellTargetTests(unittest.TestCase):
 
             self.assertEqual(m.collect_targets(repo_root), ["scripts/ci/sample.sh"])
 
+    def test_collect_targets_ignores_longer_suffixes_on_a_sh_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            workflow_dir = repo_root / ".github" / "workflows"
+            script_dir = repo_root / "scripts" / "crypto" / "openssl"
+            workflow_dir.mkdir(parents=True)
+            script_dir.mkdir(parents=True)
+            (script_dir / "build-openssl-bundle.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            # source-checksums.sha256 is deliberately absent: an unanchored `.sh`
+            # match would read it as a shell target and fail closed on it.
+            (workflow_dir / "cache.yml").write_text(
+                "jobs:\n  build:\n    steps:\n"
+                "      - with:\n"
+                "          key: openssl-${{ hashFiles('scripts/crypto/openssl/source-checksums.sha256') }}\n"
+                "      - run: scripts/crypto/openssl/build-openssl-bundle.sh\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                m.collect_targets(repo_root),
+                ["scripts/crypto/openssl/build-openssl-bundle.sh"],
+            )
+
     def test_collect_targets_fail_closed_on_missing_shell_target(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-677
- GitHub Issue mirror (non-authoritative): #677

Refs: Q-CI-OPENSSL-CACHE-IDENTITY-01

## Summary
Each of the nine jobs that build the OpenSSL bundle now carries `hashFiles('scripts/crypto/openssl/source-checksums.sha256')` in its cache key, appended to the existing prefix so the manual rotation knob survives. A changed pinned digest changes every key, so no lane can restore a bundle built from the previous source; this replaces manual key rotation permanently. No `restore-keys` is introduced, since a prefix fallback would reach pre-binding entries. The fuzz lane's dedicated prefix stays distinct because only that workflow writes it.

The structural test parses the workflows and derives the job list from the parse, so a workflow added later is covered without editing the test. Naming the checksum file in a workflow tripped a latent defect in the shell-target scanner, whose suffix regex was unanchored and prefix-matched the `.sha256` path as `.sh`, fail-closing inside `workflow-hygiene`; it is anchored here with a regression row.

## Invariant
Every workflow that invokes scripts/crypto/openssl/build-openssl-bundle.sh includes hashFiles('scripts/crypto/openssl/source-checksums.sha256') in each corresponding OpenSSL archive or bundle cache key, so a changed pinned digest cannot reuse an earlier cache identity.

## Scope
- Changed files: 9
- Surfaces: the six workflows that build the bundle (cache-key strings and one comment), the workflow structural test, the shell-target scanner and its test
- Non-scope: no builder, checksum-value or OpenSSL version change; no cache path change; no restore-keys; no step reordering
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS; `python3 tools/list_workflow_shell_targets.py` — PASS; `python3 tools/check_workflow_yaml_syntax.py` — PASS; `python3 tools/check_no_remote_shell_bootstrap.py --repo-root .` — PASS; `actionlint .github/workflows/{ci,codacy-coverage,combined-load-nightly,fips-only-nightly,fuzz-nightly,runtime-perf-guardrails}.yml` — PASS; `git diff --check` — PASS
- Explicit skips: the one-time cold bundle build each lane performs after the key change is exercised in CI on this PR, not locally.

## Follow-ups / Waivers
- RUB-1075 (triage) records that nothing asserts a version bump reached every site, and carries the adjacent observation that the Rust and Go build caches hold objects linked against the bundle without rotating on a same-version repin.
