### PR TITLE
[Q-CI-FORMAL-INPUT-PROFILES-01] Replace formal skip allowlists with closed job-specific input profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Classify formal relevance
         id: formal_gate
-        run: python3 tools/ci_formal_relevance.py
+        run: python3 tools/ci_formal_relevance.py --job formal
 
       - name: Cache Lean toolchain
         if: steps.formal_gate.outputs.run_formal == 'true'
@@ -549,7 +549,7 @@ jobs:
 
       - name: Classify formal relevance
         id: formal_gate
-        run: python3 tools/ci_formal_relevance.py
+        run: python3 tools/ci_formal_relevance.py --job formal_refinement
 
       - name: Cache Lean toolchain
         if: steps.formal_gate.outputs.run_formal == 'true'

--- a/tools/ci_formal_relevance.py
+++ b/tools/ci_formal_relevance.py
@@ -3,65 +3,44 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 from pathlib import Path
 import subprocess
 from typing import Callable, NamedTuple
 
-PROTECTED_PREFIXES = (
-    "rubin-formal/",
-    "conformance/",
-    "clients/go/",
-    "clients/rust/crates/rubin-consensus/src/",
-    "tools/formal/",
-)
-PROTECTED_EXACT = {
+JOBS = ("formal", "formal_refinement")
+COMMON_EXACT = {
     ".github/workflows/ci.yml",
-    "README.md",
-    "SPEC_LOCATION.md",
-    "scripts/crypto/openssl/build-openssl-bundle.sh",
-    "scripts/crypto/openssl/source-checksums.sha256",
+    "rubin-formal/RubinFormal.lean",
+    "rubin-formal/lake-manifest.json",
+    "rubin-formal/lakefile.lean",
+    "rubin-formal/lean-toolchain",
+    "tools/ci_formal_relevance.py",
+}
+FORMAL_EXACT = COMMON_EXACT | {
+    "README.md", "SPEC_LOCATION.md", "conformance/MATRIX.md",
+    "rubin-formal/PROOF_COVERAGE.md", "rubin-formal/README.md",
+    "rubin-formal/REGISTRY_COMPLETENESS_POLICY.md",
+    "rubin-formal/proof_coverage.json", "rubin-formal/refinement_bridge.json",
+    "rubin-formal/scripts/check.sh",
+    "rubin-formal/tools/LOCAL_CODEX_EXEC_REVIEW.md",
+    "rubin-formal/tools/check_formal_registry_truth.py",
     "tools/check_formal_claims_lint.py",
     "tools/check_formal_coverage.py",
     "tools/check_formal_refinement_bridge.py",
     "tools/check_formal_risk_gate.py",
-    "tools/check_lean_conformance_staleness.py",
     "tools/check_map_iteration_determinism.py",
-    "tools/ci_formal_relevance.py",
     "tools/formal_risk_score.py",
-    "tools/tests/test_ci_formal_relevance.py",
 }
-SKIPPABLE_PREFIXES = ("tools/", "scripts/", "clients/rust/")
-SKIPPABLE_EXACT = {
-    f".github/workflows/{name}"
-    for name in (
-        "auto-approve.yml",
-        "codacy-coverage.yml",
-        "codeql.yml",
-        "combined-load-nightly.yml",
-        "dependency-review.yml",
-        "dependency-submission.yml",
-        "fips-only-nightly.yml",
-        "fuzz-nightly.yml",
-        "kani.yml",
-        "parity-gate.yml",
-        "runtime-perf-guardrails.yml",
-        "sbom.yml",
-        "security-supply-chain-nightly.yml",
-        "spec-checks.yml",
-        "workflow-hygiene.yml",
-    )
-} | {
-    ".github/PULL_REQUEST_TEMPLATE.md",
-    ".codacy.yml",
-    ".coderabbit.yaml",
-    ".jscpd.json",
-    ".node-version",
-    ".nvmrc",
-    "CODACY_CCN_SUMMARY.md",
-    "package-lock.json",
-    "package.json",
-    "tree-api.json",
+REFINEMENT_EXACT = COMMON_EXACT | {
+    "clients/go/go.mod",
+    "clients/go/consensus/live_binding_policy_v1_embedded.json",
+    "scripts/crypto/openssl/build-openssl-bundle.sh",
+    "scripts/crypto/openssl/source-checksums.sha256",
+    "tools/check_lean_conformance_staleness.py",
+    "tools/formal/gen_lean_conformance_vectors.py",
+    "tools/formal/gen_lean_refinement_from_traces.py",
 }
 
 class Decision(NamedTuple):
@@ -102,17 +81,50 @@ def parse_name_status(data: bytes) -> tuple[list[str], str | None]:
         index += path_fields
     return paths, None
 
-def classify_paths(paths: list[str]) -> Decision:
+def is_common(path: str) -> bool:
+    return path in COMMON_EXACT or (
+        path.startswith("rubin-formal/RubinFormal/") and path.endswith(".lean")
+    ) or (
+        path.startswith("conformance/fixtures/CV-")
+        and path.endswith(".json")
+        and path.count("/") == 2
+    )
+
+def is_formal_input(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    return is_common(path) or path in FORMAL_EXACT or (
+        path.startswith("rubin-formal/tests/") and name.startswith("test_")
+        and name.endswith(".py")
+    ) or (
+        path.startswith("clients/go/consensus/") and path.count("/") == 3
+        and path.endswith(".go") and not path.endswith("_test.go")
+    ) or (
+        path.startswith("clients/rust/crates/rubin-consensus/src/")
+        and path.endswith(".rs") and "/tests/" not in path
+        and not name.endswith("_test.rs")
+    )
+
+def is_refinement_input(path: str) -> bool:
+    return is_common(path) or path in REFINEMENT_EXACT or (
+        path.startswith("clients/go/cmd/formal-trace/")
+        and path.count("/") == 4 and path.endswith(".go")
+        and not path.endswith("_test.go")
+    ) or (
+        path.startswith("clients/go/consensus/")
+        and path.endswith(".go") and not path.endswith("_test.go")
+    )
+
+def classify_paths(paths: list[str], job: str) -> Decision:
     if not paths:
         return Decision(True, "empty or malformed diff")
+    predicate = is_formal_input if job == "formal" else is_refinement_input
     for path in paths:
-        if path in PROTECTED_EXACT or path.startswith(PROTECTED_PREFIXES):
-            return Decision(True, f"protected path: {path}", len(paths))
-        if path not in SKIPPABLE_EXACT and not path.startswith(SKIPPABLE_PREFIXES):
-            return Decision(True, f"path not in allowlist: {path}", len(paths))
-    return Decision(False, "all paths are in allowlist", len(paths))
+        if predicate(path):
+            return Decision(True, f"{job} input: {path}", len(paths))
+    return Decision(False, f"no {job} inputs", len(paths))
 
 def decide(
+    job: str,
     event_name: str,
     base_ref: str,
     run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
@@ -131,7 +143,10 @@ def decide(
     if verify.returncode:
         return Decision(True, f"missing pull request base: {base}")
     diff = run(
-        ["git", "diff", "--name-status", "-z", "--find-renames", f"{base}..HEAD"],
+        [
+            "git", "diff", "--name-status", "-z", "--find-renames",
+            "--find-copies", "--find-copies-harder", f"{base}..HEAD",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -139,10 +154,14 @@ def decide(
     if diff.returncode:
         return Decision(True, f"git diff failed for {base}..HEAD")
     paths, error = parse_name_status(diff.stdout)
-    return Decision(True, error) if error else classify_paths(paths)
+    return Decision(True, error) if error else classify_paths(paths, job)
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--job", choices=JOBS, required=True)
+    args = parser.parse_args()
     decision = decide(
+        args.job,
         os.environ.get("GITHUB_EVENT_NAME", ""),
         os.environ.get("GITHUB_BASE_REF", ""),
     )
@@ -150,8 +169,8 @@ def main() -> int:
         print(f"RUN: {decision.reason}")
     else:
         print(
-            f"SKIP: formal-irrelevant diff "
-            f"({decision.path_count} paths, all in allowlist)"
+            f"SKIP: {args.job}-irrelevant diff "
+            f"({decision.path_count} paths, no profile inputs)"
         )
     output = Path(os.environ["GITHUB_OUTPUT"])
     with output.open("a", encoding="utf-8") as stream:

--- a/tools/tests/test_ci_formal_relevance.py
+++ b/tools/tests/test_ci_formal_relevance.py
@@ -23,91 +23,101 @@ def runner(
     return run
 
 class FormalRelevanceTests(unittest.TestCase):
-    def decision(self, payload: bytes) -> subject.Decision:
-        return subject.decide("pull_request", "main", runner(payload))
+    def decision(self, job: str, payload: bytes) -> subject.Decision:
+        return subject.decide(job, "pull_request", "main", runner(payload))
 
-    def test_every_protected_family_runs(self):
-        paths = [
-            ".github/workflows/ci.yml",
-            "rubin-formal/A.lean",
-            "conformance/vector.json",
-            "clients/go/consensus/a.go",
-            "clients/rust/crates/rubin-consensus/src/lib.rs",
-            "tools/formal/generate.py",
-            "scripts/crypto/openssl/build-openssl-bundle.sh",
-            "scripts/crypto/openssl/source-checksums.sha256",
-            "README.md",
-            "SPEC_LOCATION.md",
-            *sorted(path for path in subject.PROTECTED_EXACT if path.startswith("tools/")),
-        ]
-        for path in paths:
-            with self.subTest(path=path):
-                decision = self.decision(diff(("M", path)))
-                self.assertTrue(decision.run_formal)
-                self.assertEqual(decision.reason, f"protected path: {path}")
-
-    def test_every_skippable_family_skips(self):
-        paths = [
-            "tools/ordinary.py",
-            "scripts/ordinary.sh",
-            "clients/rust/crates/wallet/src/lib.rs",
-            *sorted(subject.SKIPPABLE_EXACT),
-        ]
-        for path in paths:
-            with self.subTest(path=path):
-                decision = self.decision(diff(("M", path)))
-                self.assertFalse(decision.run_formal)
-                self.assertEqual(decision.path_count, 1)
-
-    def test_pr_template_only_skips(self):
-        self.assertFalse(
-            self.decision(diff(("M", ".github/PULL_REQUEST_TEMPLATE.md"))).run_formal
+    def assert_jobs(self, path: str, formal: bool, refinement: bool):
+        payload = diff(("M", path))
+        self.assertEqual(self.decision("formal", payload).run_formal, formal, path)
+        self.assertEqual(
+            self.decision("formal_refinement", payload).run_formal, refinement, path
         )
 
-    def test_protected_precedence_over_broad_allowlists(self):
-        for path in (
-            "tools/formal/generate.py",
-            "tools/check_formal_coverage.py",
-            "scripts/crypto/openssl/build-openssl-bundle.sh",
-            "clients/rust/crates/rubin-consensus/src/lib.rs",
-        ):
+    def test_input_families_and_exact_exclusions(self):
+        cases = {
+            ".github/workflows/ci.yml": (True, True),
+            "tools/ci_formal_relevance.py": (True, True),
+            "rubin-formal/RubinFormal/X.lean": (True, True),
+            "conformance/fixtures/CV-X.json": (True, True),
+            "README.md": (True, False),
+            "conformance/MATRIX.md": (True, False),
+            "rubin-formal/tests/test_x.py": (True, False),
+            "tools/check_formal_coverage.py": (True, False),
+            "clients/go/consensus/x.go": (True, True),
+            "clients/go/consensus/sub/x.go": (False, True),
+            "clients/rust/crates/rubin-consensus/src/x.rs": (True, False),
+            "clients/rust/crates/rubin-consensus/src/x_tests.rs": (True, False),
+            "clients/go/go.mod": (False, True),
+            "clients/go/cmd/formal-trace/x.go": (False, True),
+            "tools/formal/gen_lean_conformance_vectors.py": (False, True),
+            "scripts/crypto/openssl/build-openssl-bundle.sh": (False, True),
+            "tools/tests/test_ci_formal_relevance.py": (False, False),
+            ".github/PULL_REQUEST_TEMPLATE.md": (False, False),
+            "rubin-formal/RISK_MODEL.md": (False, False),
+            "rubin-formal/lakefile.toml": (False, False),
+            "rubin-formal/traces/schema_v1.json": (False, False),
+            "conformance/fixtures/devnet/CV-X.json": (False, False),
+            "conformance/fixtures/CHANGELOG.md": (False, False),
+            "clients/go/consensus/x_test.go": (False, False),
+            "clients/rust/crates/rubin-consensus/src/tests/x.rs": (False, False),
+            "clients/rust/crates/rubin-consensus/src/x_test.rs": (False, False),
+            "clients/rust/crates/wallet/src/lib.rs": (False, False),
+            "tools/ordinary.py": (False, False),
+        }
+        for path, expected in cases.items():
             with self.subTest(path=path):
-                self.assertTrue(self.decision(diff(("M", path))).run_formal)
+                self.assert_jobs(path, *expected)
 
-    def test_unknown_mixed_and_nearest_misses_run(self):
-        cases = [
-            diff(("A", "docs/new.md")),
-            diff(("A", ".github/workflows/new.yml")),
-            diff(("M", "tools/ok.py"), ("M", "README.md")),
-            diff(("M", "README.markdown")),
-            diff(("M", "rubin-formality/file")),
-            diff(("M", "client/rust/file")),
-        ]
-        for payload in cases:
-            with self.subTest(payload=payload):
-                self.assertTrue(self.decision(payload).run_formal)
+    def test_tracked_inventory_counts(self):
+        paths = subprocess.run(
+            ["git", "ls-files"], check=True, stdout=subprocess.PIPE, text=True
+        ).stdout.splitlines()
+        formal = {path for path in paths if subject.is_formal_input(path)}
+        refinement = {path for path in paths if subject.is_refinement_input(path)}
+        self.assertEqual(
+            (len(formal), len(refinement), len(formal & refinement), len(formal | refinement)),
+            (416, 336, 323, 429),
+        )
+
+    def test_every_exact_input_uses_its_job_profile(self):
+        for path in subject.FORMAL_EXACT:
+            with self.subTest(job="formal", path=path):
+                self.assertTrue(subject.is_formal_input(path))
+        for path in subject.REFINEMENT_EXACT:
+            with self.subTest(job="formal_refinement", path=path):
+                self.assertTrue(subject.is_refinement_input(path))
+
+    def test_mixed_diff_decides_profiles_independently(self):
+        payload = diff(("M", "README.md"), ("M", "clients/go/go.mod"))
+        for job in subject.JOBS:
+            self.assertTrue(self.decision(job, payload).run_formal)
 
     def test_add_delete_rename_and_copy_parse_all_paths(self):
         cases = [
-            (diff(("A", "tools/a.py"), ("D", "scripts/b.sh")), False),
-            (diff(("R100", "README.md", "tools/readme.txt")), True),
-            (diff(("R090", "tools/readme.txt", "README.md")), True),
-            (diff(("C075", "tools/a.py", "scripts/a.py")), False),
-            (diff(("C100", "tools/a.py", "rubin-formal/A.lean")), True),
+            (diff(("A", "tools/a.py"), ("D", "scripts/b.sh")), False, False),
+            (diff(("R100", "README.md", "tools/readme.txt")), True, False),
+            (diff(("R090", "tools/readme.txt", "clients/go/go.mod")), False, True),
+            (diff(("C075", "tools/a.py", "scripts/a.py")), False, False),
+            (diff(("C100", "README.md", "docs/readme-copy.md")), True, False),
+            (diff(("C100", "tools/a.py", "rubin-formal/RubinFormal/A.lean")), True, True),
         ]
-        for payload, expected in cases:
+        for payload, formal, refinement in cases:
             with self.subTest(payload=payload):
-                self.assertEqual(self.decision(payload).run_formal, expected)
+                self.assertEqual(self.decision("formal", payload).run_formal, formal)
+                self.assertEqual(
+                    self.decision("formal_refinement", payload).run_formal, refinement
+                )
 
-    def test_fips_preflight_skips_but_bundle_build_runs(self):
-        self.assertFalse(
-            self.decision(diff(("M", "scripts/crypto/openssl/fips-preflight.sh"))).run_formal
+    def test_git_diff_enables_copy_detection_for_unchanged_sources(self):
+        commands = []
+        subject.decide(
+            "formal", "pull_request", "main",
+            lambda command, **kwargs: (
+                commands.append(command) or runner()(command, **kwargs)
+            ),
         )
-        self.assertTrue(
-            self.decision(
-                diff(("M", "scripts/crypto/openssl/build-openssl-bundle.sh"))
-            ).run_formal
-        )
+        self.assertIn("--find-copies", commands[1])
+        self.assertIn("--find-copies-harder", commands[1])
 
     def test_malformed_unknown_and_empty_diffs_run(self):
         for payload in (
@@ -121,21 +131,19 @@ class FormalRelevanceTests(unittest.TestCase):
             b"M\0\xff\0",
         ):
             with self.subTest(payload=payload):
-                self.assertTrue(self.decision(payload).run_formal)
+                for job in subject.JOBS:
+                    self.assertTrue(self.decision(job, payload).run_formal)
 
     def test_environment_and_git_failures_run(self):
-        self.assertTrue(subject.decide("push", "", runner()).run_formal)
-        self.assertTrue(subject.decide("pull_request", "", runner()).run_formal)
-        self.assertTrue(
-            subject.decide(
-                "pull_request", "main", runner(verify_code=1)
-            ).run_formal
-        )
-        self.assertTrue(
-            subject.decide(
-                "pull_request", "main", runner(diff_code=1)
-            ).run_formal
-        )
+        for job in subject.JOBS:
+            self.assertTrue(subject.decide(job, "push", "", runner()).run_formal)
+            self.assertTrue(subject.decide(job, "pull_request", "", runner()).run_formal)
+            self.assertTrue(subject.decide(
+                job, "pull_request", "main", runner(verify_code=1)
+            ).run_formal)
+            self.assertTrue(subject.decide(
+                job, "pull_request", "main", runner(diff_code=1)
+            ).run_formal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1077
- GitHub Issue mirror (non-authoritative): #2751

Refs: Q-CI-FORMAL-INPUT-PROFILES-01

## Summary
Replace the shared formal-CI skip allowlist with separate closed input profiles for `formal` and `formal_refinement`.

## Invariant
Each formal job runs exactly when a valid pull-request diff intersects an input consumed by that job; malformed or unavailable diff evidence remains fail-closed.

## Scope
- Changed files: 3
- Surfaces: tooling
- Non-scope: Formal job bodies, required-check names, branch protection, protocol/formal sources, and map-lint ownership are unchanged.
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tools.tests.test_ci_formal_relevance tools.tests.test_check_workflow_yaml_syntax` — PASS; `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS; `python3 tools/check_workflow_yaml_syntax.py .github/workflows/ci.yml` — PASS

## Follow-ups / Waivers
- None.
