### PR TITLE
[Q-CI-FORMAL-LAKE-CACHE-V2-01] Bind Lake build caches to exact formal source content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: rubin-formal/.lake
-          key: lake-formal-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}
+          key: lake-formal-v2-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}-${{ hashFiles('rubin-formal/RubinFormal.lean', 'rubin-formal/RubinFormal/**/*.lean') }}
           restore-keys: |
-            lake-formal-${{ runner.os }}-
+            lake-formal-v2-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}-
 
       - name: Lean package checks (rubin-formal)
         if: steps.formal_gate.outputs.run_formal == 'true'
@@ -689,9 +689,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: rubin-formal/.lake
-          key: lake-refinement-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}
+          key: lake-refinement-v2-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}-${{ hashFiles('rubin-formal/RubinFormal.lean', 'rubin-formal/RubinFormal/**/*.lean') }}
           restore-keys: |
-            lake-refinement-${{ runner.os }}-
+            lake-refinement-v2-${{ runner.os }}-${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}-
 
       - name: Lean build (rubin-formal)
         if: steps.formal_gate.outputs.run_formal == 'true'

--- a/tools/tests/test_ci_formal_relevance.py
+++ b/tools/tests/test_ci_formal_relevance.py
@@ -1,5 +1,6 @@
 import subprocess
 import unittest
+from pathlib import Path
 
 from tools import ci_formal_relevance as subject
 
@@ -86,6 +87,20 @@ class FormalRelevanceTests(unittest.TestCase):
         for path in subject.REFINEMENT_EXACT:
             with self.subTest(job="formal_refinement", path=path):
                 self.assertTrue(subject.is_refinement_input(path))
+
+    def test_lake_cache_keys_bind_compatibility_and_formal_sources(self):
+        workflow = (
+            Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
+        ).read_text()
+        compatibility = "${{ hashFiles('rubin-formal/lean-toolchain', 'rubin-formal/lakefile.lean', 'rubin-formal/lake-manifest.json') }}"
+        sources = "${{ hashFiles('rubin-formal/RubinFormal.lean', 'rubin-formal/RubinFormal/**/*.lean') }}"
+        for namespace in ("lake-formal-v2", "lake-refinement-v2"):
+            key = f"          key: {namespace}-${{{{ runner.os }}}}-{compatibility}-{sources}\n"
+            restore = f"            {namespace}-${{{{ runner.os }}}}-{compatibility}-\n"
+            self.assertEqual(workflow.count(key), 1)
+            self.assertEqual(workflow.count(restore), 1)
+        self.assertNotIn("key: lake-formal-${{", workflow)
+        self.assertNotIn("key: lake-refinement-${{", workflow)
 
     def test_mixed_diff_decides_profiles_independently(self):
         payload = diff(("M", "README.md"), ("M", "clients/go/go.mod"))


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1079
- GitHub Issue mirror (non-authoritative): #2755

Refs: Q-CI-FORMAL-LAKE-CACHE-V2-01

## Summary
Bind each Lean `.lake` cache to the exact formal source tree while retaining an incremental fallback limited to the same toolchain and dependency graph.

## Invariant
An exact cache hit represents the same Lean toolchain, package dependencies, and formal sources; a fallback cache can cross source revisions only within the same toolchain and dependency graph.

## Scope
- Changed files: 2
- Surfaces: tooling
- Non-scope: Lean sources, formal job commands or ordering, relevance classification, cache deletion, and other CI caches
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tools.tests.test_ci_formal_relevance tools.tests.test_check_workflow_yaml_syntax` — PASS; `python3 tools/check_workflow_yaml_syntax.py .github/workflows/ci.yml` — PASS; `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS

## Follow-ups / Waivers
- Measure warm-cache duration on a later formal-relevant run after the new default-branch cache has been populated.
