### PR TITLE
[Q-CI-RUST-CACHE-V2-01] Refresh Rust test and coverage targets by exact source identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,14 +348,16 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}
+          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-v2-${{ runner.os }}-
 
       - name: Cache Rust test target
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             clients/rust/target
-          key: rust-test-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**/*.rs') }}
+          key: rust-test-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**', 'conformance/fixtures/**') }}
           restore-keys: |
             rust-test-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,17 +331,33 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache Rust cargo registry & build
+      - name: Resolve Rust cache identity
+        id: rust_cache_identity
+        run: |
+          release="$(rustc --version --verbose | sed -n 's/^release: //p')"
+          if [[ ! "$release" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "invalid rustc release: ${release:-<empty>}" >&2
+            exit 1
+          fi
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
+          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}
+
+      - name: Cache Rust test target
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
             clients/rust/target
-          key: rust-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock') }}
+          key: rust-test-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**/*.rs') }}
           restore-keys: |
-            rust-${{ runner.os }}-
+            rust-test-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -68,16 +68,33 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Cache Rust deps (coverage)
+      - name: Resolve Rust cache identity
+        id: rust_cache_identity
+        run: |
+          release="$(rustc --version --verbose | sed -n 's/^release: //p')"
+          if [[ ! "$release" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "invalid rustc release: ${release:-<empty>}" >&2
+            exit 1
+          fi
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}
+
+      - name: Cache Rust coverage target
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
             clients/rust/target
-          key: rust-coverage-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock') }}
+          key: rust-coverage-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**/*.rs') }}
           restore-keys: |
-            rust-coverage-${{ runner.os }}-
+            rust-coverage-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-
 
       - name: Cache cargo-tarpaulin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -85,14 +85,16 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}
+          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-v2-${{ runner.os }}-
 
       - name: Cache Rust coverage target
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             clients/rust/target
-          key: rust-coverage-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**/*.rs') }}
+          key: rust-coverage-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**', 'conformance/fixtures/**') }}
           restore-keys: |
             rust-coverage-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-
 

--- a/tools/tests/test_ci_rust_cache_identity.py
+++ b/tools/tests/test_ci_rust_cache_identity.py
@@ -1,0 +1,47 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPATIBILITY = "${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}"
+REGISTRY = "${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}"
+RELEASE = "${{ steps.rust_cache_identity.outputs.release }}"
+SOURCES = "${{ hashFiles('clients/rust/**/*.rs') }}"
+
+
+class RustCacheIdentityTests(unittest.TestCase):
+    def workflow(self, name: str) -> str:
+        return (ROOT / ".github/workflows" / name).read_text()
+
+    def test_test_and_coverage_targets_have_exact_source_keys(self):
+        cases = {
+            "ci.yml": "rust-test-v2",
+            "codacy-coverage.yml": "rust-coverage-v2",
+        }
+        for workflow, namespace in cases.items():
+            text = self.workflow(workflow)
+            with self.subTest(workflow=workflow):
+                key = f"          key: {namespace}-${{{{ runner.os }}}}-{RELEASE}-{COMPATIBILITY}-{SOURCES}\n"
+                restore = f"            {namespace}-${{{{ runner.os }}}}-{RELEASE}-{COMPATIBILITY}-\n"
+                self.assertEqual(text.count(key), 1)
+                self.assertEqual(text.count(restore), 1)
+                self.assertEqual(text.count("      - name: Resolve Rust cache identity\n"), 1)
+
+    def test_registry_is_separate_and_legacy_target_keys_are_absent(self):
+        for workflow in ("ci.yml", "codacy-coverage.yml"):
+            text = self.workflow(workflow)
+            with self.subTest(workflow=workflow):
+                registry = f"          key: cargo-registry-v2-${{{{ runner.os }}}}-{REGISTRY}\n"
+                self.assertEqual(text.count(registry), 1)
+                self.assertIn("            ~/.cargo/registry/index\n", text)
+                self.assertIn("            ~/.cargo/registry/cache\n", text)
+                self.assertIn("            ~/.cargo/git/db\n", text)
+        self.assertNotIn("key: rust-${{ runner.os }}-", self.workflow("ci.yml"))
+        self.assertNotIn(
+            "key: rust-coverage-${{ runner.os }}-",
+            self.workflow("codacy-coverage.yml"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_ci_rust_cache_identity.py
+++ b/tools/tests/test_ci_rust_cache_identity.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 COMPATIBILITY = "${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}"
-REGISTRY = "${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml') }}"
+REGISTRY = "${{ hashFiles('clients/rust/Cargo.lock') }}"
 RELEASE = "${{ steps.rust_cache_identity.outputs.release }}"
-SOURCES = "${{ hashFiles('clients/rust/**/*.rs') }}"
+SOURCES = "${{ hashFiles('clients/rust/**', 'conformance/fixtures/**') }}"
 
 
 class RustCacheIdentityTests(unittest.TestCase):
@@ -32,7 +32,9 @@ class RustCacheIdentityTests(unittest.TestCase):
             text = self.workflow(workflow)
             with self.subTest(workflow=workflow):
                 registry = f"          key: cargo-registry-v2-${{{{ runner.os }}}}-{REGISTRY}\n"
+                restore = "            cargo-registry-v2-${{ runner.os }}-\n"
                 self.assertEqual(text.count(registry), 1)
+                self.assertEqual(text.count(restore), 1)
                 self.assertIn("            ~/.cargo/registry/index\n", text)
                 self.assertIn("            ~/.cargo/registry/cache\n", text)
                 self.assertIn("            ~/.cargo/git/db\n", text)


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1080
- GitHub Issue mirror (non-authoritative): #2757

Refs: Q-CI-RUST-CACHE-V2-01

## Summary
Separate Cargo registry data from compiled targets and give the ordinary test and coverage targets distinct source-aware cache identities.

## Invariant
Each compiled Rust target cache is reusable only for the same runner OS, installed Rust release, dependency and OpenSSL compatibility inputs, build profile, and exact Rust source tree; a fallback may omit only the source hash.

## Scope
- Changed files: 3
- Surfaces: tooling
- Non-scope: executed tests, coverage commands or outputs, runtime-performance CI, workflow triggers, required-check identities, and repository settings
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tools.tests.test_ci_rust_cache_identity tools.tests.test_check_workflow_yaml_syntax` — PASS; `python3 tools/check_workflow_yaml_syntax.py .github/workflows/ci.yml .github/workflows/codacy-coverage.yml` — PASS; `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS

## Follow-ups / Waivers
- None
