### PR TITLE
[Q-CI-RUNTIME-PERF-RUST-CACHE-01] Reuse one source-aware Rust benchmark target across base and head

### DIFF
--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -33,6 +33,35 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Resolve Rust cache identity
+        id: rust_cache_identity
+        run: |
+          release="$(rustc --version --verbose | sed -n 's/^release: //p')"
+          if [[ ! "$release" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "invalid rustc release: ${release:-<empty>}" >&2
+            exit 1
+          fi
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Cargo registry
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-registry-v2-${{ runner.os }}-${{ hashFiles('clients/rust/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-v2-${{ runner.os }}-
+
+      - name: Cache Rust runtime perf target
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ runner.temp }}/runtime-perf-target
+          key: runtime-perf-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-${{ hashFiles('clients/rust/**', 'conformance/fixtures/**') }}
+          restore-keys: |
+            runtime-perf-v2-${{ runner.os }}-${{ steps.rust_cache_identity.outputs.release }}-${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}-
+
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -85,6 +114,8 @@ jobs:
 
       - name: Run base runtime perf suite
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/runtime-perf-target
         run: |
           set +e
           mkdir -p artifacts/runtime-perf/base
@@ -95,6 +126,8 @@ jobs:
           exit 0
 
       - name: Run head runtime perf suite
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/runtime-perf-target
         run: |
           set +e
           mkdir -p artifacts/runtime-perf/head

--- a/scripts/runtime_perf/run_runtime_perf_suite.sh
+++ b/scripts/runtime_perf/run_runtime_perf_suite.sh
@@ -26,6 +26,10 @@ if [[ -z "$REPO_ROOT" || -z "$OUT_DIR" ]]; then
   echo "usage: $0 --repo-root <repo-root> --output-dir <out-dir>" >&2
   exit 2
 fi
+if [[ -z "${CARGO_TARGET_DIR:-}" || "$CARGO_TARGET_DIR" != /* ]]; then
+  echo "CARGO_TARGET_DIR must be an absolute path" >&2
+  exit 2
+fi
 
 mkdir -p "$OUT_DIR"
 
@@ -51,13 +55,14 @@ if [[ $go_status -eq 0 ]]; then
   fi
 fi
 
+CRITERION_ROOT="$CARGO_TARGET_DIR/criterion"
 for path in \
-  clients/rust/target/criterion/rubin_node_txpool \
-  clients/rust/target/criterion/rubin_node_chainstate_clone \
-  clients/rust/target/criterion/rubin_node_sync_chain_state_snapshot \
-  clients/rust/target/criterion/rubin_node_sync \
-  clients/rust/target/criterion/rubin_node_undo \
-  clients/rust/target/criterion/rubin_node_miner_mine_one
+  "$CRITERION_ROOT/rubin_node_txpool" \
+  "$CRITERION_ROOT/rubin_node_chainstate_clone" \
+  "$CRITERION_ROOT/rubin_node_sync_chain_state_snapshot" \
+  "$CRITERION_ROOT/rubin_node_sync" \
+  "$CRITERION_ROOT/rubin_node_undo" \
+  "$CRITERION_ROOT/rubin_node_miner_mine_one"
 do
   rm -rf "$path"
 done
@@ -68,7 +73,7 @@ rust_status=$?
 set -e
 if [[ $rust_status -eq 0 ]]; then
   python3 "$SCRIPT_DIR/parse_rust_runtime_metrics.py" \
-    --criterion-root "$REPO_ROOT/clients/rust/target/criterion" \
+    --criterion-root "$CRITERION_ROOT" \
     --output "$RUST_JSON"
 fi
 

--- a/scripts/runtime_perf/run_runtime_perf_suite.sh
+++ b/scripts/runtime_perf/run_runtime_perf_suite.sh
@@ -68,7 +68,11 @@ do
 done
 
 set +e
-(cd clients/rust && cargo bench -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 1)
+(
+  cd clients/rust
+  cargo clean -p rubin-node -p rubin-consensus -p rubin-consensus-cli
+  cargo bench -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 1
+)
 rust_status=$?
 set -e
 if [[ $rust_status -eq 0 ]]; then

--- a/scripts/runtime_perf/run_runtime_perf_suite.sh
+++ b/scripts/runtime_perf/run_runtime_perf_suite.sh
@@ -70,7 +70,10 @@ done
 set +e
 (
   cd clients/rust
-  cargo clean -p rubin-node -p rubin-consensus -p rubin-consensus-cli
+  if ! cargo clean --workspace; then
+    echo "failed to invalidate Rust workspace artifacts" >&2
+    exit 2
+  fi
   cargo bench -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 1
 )
 rust_status=$?

--- a/tools/tests/test_ci_runtime_perf_cache.py
+++ b/tools/tests/test_ci_runtime_perf_cache.py
@@ -35,9 +35,10 @@ class RuntimePerfCacheTests(unittest.TestCase):
         self.assertIn('CRITERION_ROOT="$CARGO_TARGET_DIR/criterion"', text)
         self.assertIn('--criterion-root "$CRITERION_ROOT"', text)
         self.assertNotIn("clients/rust/target/criterion", text)
-        clean = "cargo clean -p rubin-node -p rubin-consensus -p rubin-consensus-cli"
+        clean = "if ! cargo clean --workspace; then"
         self.assertEqual(text.count(clean), 1)
         self.assertLess(text.index(clean), text.index("cargo bench -p rubin-node"))
+        self.assertIn('echo "failed to invalidate Rust workspace artifacts" >&2', text)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_ci_runtime_perf_cache.py
+++ b/tools/tests/test_ci_runtime_perf_cache.py
@@ -35,6 +35,9 @@ class RuntimePerfCacheTests(unittest.TestCase):
         self.assertIn('CRITERION_ROOT="$CARGO_TARGET_DIR/criterion"', text)
         self.assertIn('--criterion-root "$CRITERION_ROOT"', text)
         self.assertNotIn("clients/rust/target/criterion", text)
+        clean = "cargo clean -p rubin-node -p rubin-consensus -p rubin-consensus-cli"
+        self.assertEqual(text.count(clean), 1)
+        self.assertLess(text.index(clean), text.index("cargo bench -p rubin-node"))
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_ci_runtime_perf_cache.py
+++ b/tools/tests/test_ci_runtime_perf_cache.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/runtime-perf-guardrails.yml"
+SUITE = ROOT / "scripts/runtime_perf/run_runtime_perf_suite.sh"
+COMPATIBILITY = "${{ hashFiles('clients/rust/Cargo.lock', 'clients/rust/Cargo.toml', 'clients/rust/crates/**/Cargo.toml', 'scripts/crypto/openssl/source-checksums.sha256') }}"
+SOURCES = "${{ hashFiles('clients/rust/**', 'conformance/fixtures/**') }}"
+RELEASE = "${{ steps.rust_cache_identity.outputs.release }}"
+
+
+class RuntimePerfCacheTests(unittest.TestCase):
+    def test_workflow_has_one_compatible_shared_target(self):
+        text = WORKFLOW.read_text()
+        key = (
+            "          key: runtime-perf-v2-${{ runner.os }}-"
+            f"{RELEASE}-{COMPATIBILITY}-{SOURCES}\n"
+        )
+        restore = (
+            "            runtime-perf-v2-${{ runner.os }}-"
+            f"{RELEASE}-{COMPATIBILITY}-\n"
+        )
+        self.assertEqual(text.count(key), 1)
+        self.assertEqual(text.count(restore), 1)
+        self.assertEqual(
+            text.count("          CARGO_TARGET_DIR: ${{ runner.temp }}/runtime-perf-target\n"),
+            2,
+        )
+        self.assertIn("          path: ${{ runner.temp }}/runtime-perf-target\n", text)
+
+    def test_suite_uses_only_the_explicit_target_for_criterion(self):
+        text = SUITE.read_text()
+        self.assertIn('CARGO_TARGET_DIR must be an absolute path', text)
+        self.assertIn('CRITERION_ROOT="$CARGO_TARGET_DIR/criterion"', text)
+        self.assertIn('--criterion-root "$CRITERION_ROOT"', text)
+        self.assertNotIn("clients/rust/target/criterion", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1081
- GitHub Issue mirror (non-authoritative): #2758

Refs: [Q-CI-RUNTIME-PERF-RUST-CACHE-01]

## Summary
Reuse one source-aware Rust build target across the base and head runtime-performance suites while continuing to execute both benchmark sets from scratch.

## Invariant
Exact cache publication is source-bound; fallback reuse remains limited to the same Rust, dependency, OpenSSL, and build profile. All local workspace artifacts and measured Criterion results are deleted before each base and head execution, so only third-party compilation is reused; cleanup failure aborts the Rust benchmark.

## Scope
- Changed files: 3
- Surfaces: tooling
- Non-scope: Benchmark definitions, sample counts, comparison thresholds, artifacts, triggers, permissions, required-check names, test/coverage caches, and production code.
- Consensus rules unchanged: Yes.
- SECTION_HASHES.json unchanged: Yes.
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tools.tests.test_ci_runtime_perf_cache tools.tests.test_check_workflow_yaml_syntax` — PASS; `python3 tools/check_workflow_yaml_syntax.py .github/workflows/runtime-perf-guardrails.yml` — PASS; `bash -n scripts/runtime_perf/run_runtime_perf_suite.sh` — PASS; `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS

## Follow-ups / Waivers
- None.
