### PR TITLE
RUB-1083: mirror the Go read-only --dry-run in the Rust node

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -460,12 +460,6 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// chainstate as loaded from disk — a snapshot that disagrees with the
 	// blockstore is reported, not fixed. Ordinary startup is unaffected:
 	// same two calls, same order, same errors, same exit codes.
-	//
-	// The Rust mirror named above therefore holds for ordinary startup ONLY.
-	// It is deliberately broken for --dry-run until RUB-1083 lands the same
-	// skip: Rust still reconciles and saves before its own dry-run return, so
-	// on a datadir with an incomplete canonical suffix Go reports the tip and
-	// leaves the index alone where Rust truncates it and reports the loss.
 	if !*dryRun {
 		if _, err := node.ReconcileChainStateWithBlockStore(chainState, blockStore, syncCfg); err != nil {
 			_, _ = fmt.Fprintf(stderr, "chainstate reconcile failed: %v\n", err)

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -293,20 +293,50 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     // A reconcile error is fatal: continuing would let the engine run
     // with a chainstate tip that no longer points at any canonical
     // block on disk.
-    if let Err(err) =
-        reconcile_chain_state_with_block_store(&mut chain_state, &mut block_store, &sync_cfg)
-    {
-        let _ = writeln!(stderr, "chainstate reconcile failed: {err}");
-        return 2;
+    //
+    // RUB-1083: both steps are skipped under `--dry-run`, which reports the
+    // datadir and must not repair it — reconcile can truncate the canonical
+    // index, and `save` rewrites the snapshot through a temp file + rename (a
+    // fresh inode) on EVERY invocation. The report below therefore describes
+    // the chainstate as loaded from disk. Ordinary startup is unaffected.
+    // Go reference: the `if !*dryRun` guard in `cmd/rubin-node/main.go`.
+    if !cfg.dry_run {
+        if let Err(err) =
+            reconcile_chain_state_with_block_store(&mut chain_state, &mut block_store, &sync_cfg)
+        {
+            let _ = writeln!(stderr, "chainstate reconcile failed: {err}");
+            return 2;
+        }
+        if let Err(err) = chain_state.save(&chain_state_file) {
+            let _ = writeln!(
+                stderr,
+                "chainstate save failed ({}): {err}",
+                chain_state_file.display()
+            );
+            return 2;
+        }
     }
-    if let Err(err) = chain_state.save(&chain_state_file) {
-        let _ = writeln!(
-            stderr,
-            "chainstate save failed ({}): {err}",
-            chain_state_file.display()
-        );
-        return 2;
-    }
+
+    // RUB-1083: the `--dry-run`-only store report, captured here because
+    // `chain_state` is moved into the sync engine below and the values must be
+    // the ones loaded from disk. Go emits the same pair UNCONDITIONALLY
+    // (`clients/go/cmd/rubin-node/main.go:513-519`, outside its dry-run branch)
+    // while this client emits it only under `--dry-run`, and
+    // `dry_run_emits_store_report_between_json_and_sync_banner` pins that as an
+    // invariant — the cross-client difference on ordinary startup is frozen,
+    // not an oversight. Go's `mustTip` treats a tip-read failure as fatal with
+    // this exact message and exit code, so the Rust mirror does too.
+    let dry_run_store_report = if cfg.dry_run {
+        match block_store.tip() {
+            Ok(store_tip) => Some(format_dry_run_store_report(&chain_state, store_tip)),
+            Err(err) => {
+                let _ = writeln!(stderr, "blockstore tip read failed: {err}");
+                return 2;
+            }
+        }
+    } else {
+        None
+    };
 
     // NOTE: `block_store.clone()` here mirrors the pre-existing
     // pattern in `main.rs` (the RPC handoff at `Some(block_store)`
@@ -320,7 +350,19 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     // BLOCKSTORE-SHARING follow-up for the proper Arc<BlockStore>
     // fix that touches both `SyncEngine::new` and
     // `new_devnet_rpc_state_with_tx_pool` signatures.
-    let mut sync_engine = match SyncEngine::new(chain_state, Some(block_store.clone()), sync_cfg) {
+    //
+    // RUB-1083: the `--dry-run` reporting engine is built with NO blockstore, on
+    // every invocation and every store shape. `load_persisted_tip_timestamp` is
+    // the constructor's only store read, and `None` takes its `Ok(0)` arm, so the
+    // dry-run path never opens, reads or parses the canonical tip header at all —
+    // matching Go, whose `NewSyncEngine` never reads it either and therefore
+    // exits 0 whatever shape sits at the header path. The constructor itself is
+    // unchanged: it still validates the config, and `header_sync_request` and
+    // `tip()` both still serve the claimed tip from `chain_state`. The
+    // `blockstore:` line above still comes from the real opened index. Ordinary
+    // startup always gets the real clone and stays strict.
+    let engine_block_store = (!cfg.dry_run).then(|| block_store.clone());
+    let mut sync_engine = match SyncEngine::new(chain_state, engine_block_store, sync_cfg) {
         Ok(engine) => engine,
         Err(err) => {
             let _ = writeln!(stderr, "sync engine init failed: {err}");
@@ -358,6 +400,9 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         return 1;
     }
     let _ = writeln!(stdout);
+    if let Some(report) = dry_run_store_report.as_deref() {
+        let _ = writeln!(stdout, "{report}");
+    }
 
     // RUB-13 / GitHub #1157: operator-facing startup banners that pin
     // the cross-client format. Mixed-client devnet diagnostic scripts
@@ -817,6 +862,34 @@ fn format_peer_slots_banner(max_peers: usize, connected: usize) -> String {
     format!("p2p: peer_slots={max_peers} connected={connected}")
 }
 
+/// RUB-1083: the frozen `--dry-run` store report — the `chainstate:` +
+/// `blockstore:` line pair as one two-line string whose trailing newline the
+/// caller's `writeln!` supplies. Token-for-token mirror of the two
+/// `fmt.Fprintf` sites in `clients/go/cmd/rubin-node/main.go`, including their
+/// gating: both lines follow the BLOCKSTORE tip, never `chain_state.has_tip`,
+/// so an empty canonical index drops `tip=` even for a chainstate that still
+/// claims one. The chainstate fields are always the values loaded from disk.
+fn format_dry_run_store_report(
+    chain_state: &rubin_node::ChainState,
+    store_tip: Option<(u64, [u8; 32])>,
+) -> String {
+    let chainstate_head = format!(
+        "chainstate: has_tip={} height={} utxos={} already_generated={}",
+        chain_state.has_tip,
+        chain_state.height,
+        chain_state.utxos.len(),
+        chain_state.already_generated
+    );
+    match store_tip {
+        Some((tip_height, tip_hash)) => format!(
+            "{chainstate_head} tip={}\nblockstore: tip_height={tip_height} tip_hash={}",
+            hex::encode(chain_state.tip_hash),
+            hex::encode(tip_hash)
+        ),
+        None => format!("{chainstate_head}\nblockstore: empty"),
+    }
+}
+
 fn runtime_genesis_hash(genesis_cfg: &LoadedGenesisConfig) -> Result<[u8; 32], String> {
     genesis_cfg.genesis_hash.ok_or_else(|| {
         "runtime p2p requires genesis_hash_hex in the genesis file when chain_id is not devnet"
@@ -844,6 +917,16 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         dry_run: false,
         create_store: false,
     };
+    // RUB-1083: one CSV slot plus one repeated-value list, not one argv-ordered
+    // list. Go registers `--peers` with `flag.String`
+    // (`clients/go/cmd/rubin-node/main.go:292`), whose `Set` assigns rather than
+    // appends — a repeated `--peers` is accepted and only the last one survives
+    // — and builds the raw list as `append([]string{*peerCSV}, peers...)`
+    // (`main.go:319`): exactly one CSV element ahead of every repeated `--peer`,
+    // wherever they sit in argv. Go's unset zero value is the empty string,
+    // which normalization drops, so the slot is unconditionally the first raw
+    // token here too.
+    let mut peers_csv = String::new();
     let mut peer_tokens = Vec::new();
 
     let mut idx = 0usize;
@@ -882,7 +965,7 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
                 let value = args
                     .get(idx)
                     .ok_or_else(|| "missing value for --peers".to_string())?;
-                peer_tokens.push(value.clone());
+                peers_csv.clone_from(value);
             }
             "--peer" => {
                 idx += 1;
@@ -967,7 +1050,9 @@ fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         }
         idx += 1;
     }
-    cfg.peers = normalize_peers(&peer_tokens);
+    let mut raw_peers = vec![peers_csv];
+    raw_peers.extend(peer_tokens);
+    cfg.peers = normalize_peers(&raw_peers);
     cfg.legacy_suite_ids.sort_unstable();
     cfg.legacy_suite_ids.dedup();
 
@@ -1369,8 +1454,8 @@ mod tests {
     use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        advance_da_ttl_for_block, announce_tx_after_local_admission, format_peer_slots_banner,
-        handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
+        advance_da_ttl_for_block, announce_tx_after_local_admission, format_dry_run_store_report,
+        format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
         live_devnet_loopback_mining_allowed, maybe_shutdown_if_requested, parse_args, run,
         runtime_genesis_hash, stop_signal_pair, validate_config, wait_for_stop_and_shutdown,
         LegacyExposureReport, PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
@@ -1614,10 +1699,14 @@ mod tests {
     }
 
     /// RUB-13 / GitHub #1157: stdout helper for tests that parse the
-    /// effective-config JSON dump. After RUB-13 the dry-run/full
-    /// startup stdout layout is
+    /// effective-config JSON dump. After RUB-13 the ordinary-startup
+    /// stdout layout is
     /// `{<EffectiveConfig>}\n<sync line>\n<peer_slots line>\n`
-    /// rather than the previous `{<EffectiveConfig>}\n` only, so a
+    /// rather than the previous `{<EffectiveConfig>}\n` only, and after
+    /// RUB-1083 a `--dry-run` invocation inserts the store report pair
+    /// between the JSON and the sync line, giving
+    /// `{<EffectiveConfig>}\n<chainstate line>\n<blockstore line>\n<sync line>\n<peer_slots line>\n`.
+    /// Either way a
     /// caller using the strict `serde_json::from_slice(&buf)` reads
     /// the JSON object cleanly but then hits the trailing post-JSON
     /// banner bytes and rejects via the strict trailing-character
@@ -2253,9 +2342,13 @@ mod tests {
         ])
         .expect("parse");
         assert_eq!(cfg.bind_addr, "127.0.0.1:19111");
+        // RUB-1083: the `--peers` CSV entries come first even though `--peer`
+        // appears earlier in argv, so deduplication keeps the CSV occurrence of
+        // the repeated address. Go builds the same raw list as
+        // `append([]string{*peerCSV}, peers...)`.
         assert_eq!(
             cfg.peers,
-            vec!["127.0.0.1:19112".to_string(), "127.0.0.1:19113".to_string(),]
+            vec!["127.0.0.1:19113".to_string(), "127.0.0.1:19112".to_string(),]
         );
         assert_eq!(cfg.max_peers, 32);
     }
@@ -2684,6 +2777,421 @@ mod tests {
         assert!(
             json_pos < json_close_pos,
             "JSON object well-formed; json_pos={json_pos}, json_close_pos={json_close_pos}"
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// RUB-1083: pin the frozen `--dry-run` store report token-for-token against
+    /// the two `fmt.Fprintf` sites in `clients/go/cmd/rubin-node/main.go`. Row
+    /// three is the one the public path cannot easily reach and an intuitive
+    /// rewrite gets wrong: a chainstate claiming a tip over an EMPTY canonical
+    /// index still drops `tip=` and still prints `blockstore: empty`.
+    #[test]
+    fn dry_run_store_report_matches_go_format() {
+        let mut empty = rubin_node::ChainState::new();
+        empty.tip_hash = [0u8; 32];
+        assert_eq!(
+            format_dry_run_store_report(&empty, None),
+            "chainstate: has_tip=false height=0 utxos=0 already_generated=0\nblockstore: empty"
+        );
+
+        let mut tipped = rubin_node::ChainState::new();
+        tipped.has_tip = true;
+        tipped.height = 7;
+        tipped.already_generated = 42;
+        tipped.tip_hash = [0xab; 32];
+        assert_eq!(
+            format_dry_run_store_report(&tipped, Some((7, [0xab; 32]))),
+            format!(
+                "chainstate: has_tip=true height=7 utxos=0 already_generated=42 tip={hash}\n\
+                 blockstore: tip_height=7 tip_hash={hash}",
+                hash = "ab".repeat(32)
+            )
+        );
+
+        assert_eq!(
+            format_dry_run_store_report(&tipped, None),
+            "chainstate: has_tip=true height=7 utxos=0 already_generated=42\nblockstore: empty"
+        );
+
+        // A no-tip chainstate over a non-empty index still prints `tip=`, with
+        // the all-zero chainstate tip hash — the absent-chainstate parity row.
+        assert_eq!(
+            format_dry_run_store_report(&empty, Some((1, [0x5c; 32]))),
+            format!(
+                "chainstate: has_tip=false height=0 utxos=0 already_generated=0 tip={zero}\n\
+                 blockstore: tip_height=1 tip_hash={tip}",
+                zero = "00".repeat(32),
+                tip = "5c".repeat(32)
+            )
+        );
+    }
+
+    /// RUB-1083: the store report is emitted only under `--dry-run`, and only
+    /// between the effective-config JSON and the sync banner. Ordinary startup
+    /// keeps its RUB-13 two-banner layout.
+    #[test]
+    fn dry_run_emits_store_report_between_json_and_sync_banner() {
+        let dir = unique_temp_dir("rubin-node-bin-store-report");
+        let d = dir.display().to_string();
+        let (code, err) = cli(&[
+            "--datadir",
+            &d,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ]);
+        assert_eq!(code, 0, "{err}");
+
+        let args = vec!["--datadir".to_string(), d.clone(), "--dry-run".to_string()];
+        let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+        let code = run(&args, &mut stdout, &mut stderr);
+        assert_eq!(code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
+        let stdout_str = String::from_utf8(stdout).expect("stdout utf8");
+        let banners: Vec<&str> = stdout_str
+            .lines()
+            .skip_while(|line| !line.starts_with("chainstate: "))
+            .collect();
+        assert_eq!(
+            banners.len(),
+            4,
+            "expected exactly four banner lines after the JSON; stdout=\n{stdout_str}"
+        );
+        // The pure unit test pins the format against Go; this row proves the
+        // public path renders the chainstate ACTUALLY on disk together with the
+        // canonical tip actually in the index.
+        let on_disk = rubin_node::load_chain_state(chain_state_path(&dir))
+            .expect("load the on-disk chainstate");
+        let store_tip = on_disk_store_tip(&dir);
+        assert!(
+            store_tip.is_some() && on_disk.has_tip,
+            "the mined fixture must have both a canonical tip and a tipped chainstate"
+        );
+        assert_eq!(
+            format!("{}\n{}", banners[0], banners[1]),
+            format_dry_run_store_report(&on_disk, store_tip),
+            "the store report must render the on-disk state"
+        );
+        assert!(
+            banners[2].starts_with("sync: header_request_has_from="),
+            "unexpected sync banner: {}",
+            banners[2]
+        );
+        assert!(
+            banners[3].starts_with("p2p: peer_slots="),
+            "unexpected p2p banner: {}",
+            banners[3]
+        );
+        let json_close = stdout_str.rfind('}').expect("json close");
+        let report_pos = stdout_str.find("chainstate: ").expect("store report");
+        assert!(
+            json_close < report_pos,
+            "the store report must follow the effective-config JSON; stdout=\n{stdout_str}"
+        );
+
+        // Ordinary startup must NOT gain the banner pair: the same datadir
+        // mined once more emits only the RUB-13 sync / peer_slots banners.
+        let args = vec![
+            "--datadir".to_string(),
+            d.clone(),
+            "--mine-blocks".to_string(),
+            "1".to_string(),
+            "--mine-exit".to_string(),
+        ];
+        let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+        let code = run(&args, &mut stdout, &mut stderr);
+        assert_eq!(code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
+        let stdout_str = String::from_utf8(stdout).expect("stdout utf8");
+        assert!(
+            !stdout_str.contains("chainstate: ") && !stdout_str.contains("blockstore: "),
+            "ordinary startup must not emit the dry-run store report; stdout=\n{stdout_str}"
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// RUB-1083 zero-write guard: three consecutive `--dry-run` invocations
+    /// move no inode, link count, permission bit, size or nanosecond mtime on
+    /// the two files a save would rewrite, nor on the directories that would
+    /// record a create/rename. A byte-identical rewrite still reddens this,
+    /// which a content comparison alone would miss. The exhaustive recursive
+    /// snapshot over every storage shape lives in
+    /// `scripts/test_node_dry_run_parity.sh`; this is the in-tree guard that
+    /// `cargo test` alone catches.
+    #[cfg(unix)]
+    #[test]
+    fn dry_run_moves_no_inode_or_mtime_in_the_datadir() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = unique_temp_dir("rubin-node-bin-zero-write");
+        let d = dir.display().to_string();
+        let (code, err) = cli(&[
+            "--datadir",
+            &d,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ]);
+        assert_eq!(code, 0, "{err}");
+
+        let store_root = block_store_path(&dir);
+        let watched = [
+            dir.clone(),
+            chain_state_path(&dir),
+            store_root.clone(),
+            store_root.join("index.json"),
+            store_root.join("blocks"),
+            store_root.join("headers"),
+            store_root.join("undo"),
+        ];
+        let stamp = || -> Vec<String> {
+            watched
+                .iter()
+                .map(|path| {
+                    let meta = fs::symlink_metadata(path)
+                        .unwrap_or_else(|err| panic!("stat {}: {err}", path.display()));
+                    format!(
+                        "{} ino={} nlink={} mode={:o} len={} mtime={}.{:09}",
+                        path.display(),
+                        meta.ino(),
+                        meta.nlink(),
+                        meta.permissions().mode(),
+                        meta.len(),
+                        meta.mtime(),
+                        meta.mtime_nsec()
+                    )
+                })
+                .collect()
+        };
+
+        let before = stamp();
+        for attempt in 1..=3 {
+            let (code, err) = cli(&["--datadir", &d, "--dry-run"]);
+            assert_eq!(code, 0, "attempt {attempt}: {err}");
+            assert_eq!(stamp(), before, "attempt {attempt}: --dry-run wrote");
+        }
+
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// RUB-1083: the stale shape — a dense canonical index over a chainstate
+    /// reset to the encoded empty/no-tip state. `--dry-run` reports what is on
+    /// disk and repairs nothing, while a non-dry-run invocation still
+    /// reconciles and saves in the existing order.
+    #[test]
+    fn dry_run_reports_stale_chainstate_while_ordinary_startup_still_repairs_it() {
+        let dir = unique_temp_dir("rubin-node-bin-stale-chainstate");
+        let d = dir.display().to_string();
+        let (code, err) = cli(&[
+            "--datadir",
+            &d,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ]);
+        assert_eq!(code, 0, "{err}");
+
+        let chain_state_file = chain_state_path(&dir);
+        rubin_node::ChainState::new()
+            .save(&chain_state_file)
+            .expect("reset chainstate to the encoded empty state");
+        let stale_bytes = fs::read(&chain_state_file).expect("read stale chainstate");
+        let (store_tip_height, store_tip_hash) =
+            on_disk_store_tip(&dir).expect("the mined fixture must have a canonical tip");
+
+        let args = vec!["--datadir".to_string(), d.clone(), "--dry-run".to_string()];
+        let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+        let code = run(&args, &mut stdout, &mut stderr);
+        assert_eq!(code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
+        let stdout_str = String::from_utf8(stdout).expect("stdout utf8");
+        assert!(
+            stdout_str.contains(
+                "chainstate: has_tip=false height=0 utxos=0 already_generated=0 tip=\
+                 0000000000000000000000000000000000000000000000000000000000000000\n"
+            ),
+            "dry-run must report the on-disk chainstate, not a repaired one; stdout=\n{stdout_str}"
+        );
+        assert!(
+            stdout_str.contains(&format!(
+                "blockstore: tip_height={store_tip_height} tip_hash={}\n",
+                hex::encode(store_tip_hash)
+            )),
+            "dry-run must report the still-indexed blockstore tip; stdout=\n{stdout_str}"
+        );
+        assert_eq!(
+            fs::read(&chain_state_file).expect("re-read chainstate"),
+            stale_bytes,
+            "dry-run must not rewrite the stale chainstate"
+        );
+        assert_eq!(
+            on_disk_store_tip(&dir),
+            Some((store_tip_height, store_tip_hash)),
+            "dry-run must not truncate the canonical index"
+        );
+
+        // Ordinary startup keeps the reconcile-then-save behaviour: the same
+        // datadir replays the canonical index back into the chainstate before
+        // mining one more block on top of it.
+        let (code, err) = cli(&["--datadir", &d, "--mine-blocks", "1", "--mine-exit"]);
+        assert_eq!(code, 0, "{err}");
+        let repaired = rubin_node::load_chain_state(&chain_state_file).expect("reload chainstate");
+        assert!(
+            repaired.has_tip && repaired.height == store_tip_height + 1,
+            "ordinary startup must still reconcile and save: has_tip={} height={} expected={}",
+            repaired.has_tip,
+            repaired.height,
+            store_tip_height + 1
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// RUB-1083 tip-header shapes: chainstate and the canonical index both name
+    /// a tip whose header blob is absent, empty, malformed or replaced by a
+    /// directory. The dry-run reporting engine gets no blockstore, so it never
+    /// reads the header and every shape exits 0 reporting the on-disk
+    /// chainstate and the still-indexed tip — Go's disposition. Zero-write is
+    /// pinned by `dry_run_moves_no_inode_or_mtime_in_the_datadir`; the full
+    /// six-shape cross-client table (these plus the dangling symlink and the
+    /// mode-000 header) lives in `scripts/test_node_dry_run_parity.sh`.
+    #[test]
+    fn dry_run_reports_every_tip_header_shape_without_reading_the_header() {
+        for shape in ["absent", "zero-length", "malformed", "directory"] {
+            let dir = unique_temp_dir("rubin-node-bin-tip-header");
+            let d = dir.display().to_string();
+            let (code, err) = cli(&[
+                "--datadir",
+                &d,
+                "--create-store",
+                "--mine-blocks",
+                "1",
+                "--mine-exit",
+            ]);
+            assert_eq!(code, 0, "{shape}: {err}");
+
+            let chain_state_file = chain_state_path(&dir);
+            let (tip_height, tip_hash) =
+                on_disk_store_tip(&dir).expect("the mined fixture must have a canonical tip");
+            let on_disk = rubin_node::load_chain_state(&chain_state_file).expect("load chainstate");
+            assert!(
+                on_disk.has_tip && on_disk.tip_hash == tip_hash,
+                "{shape}: the row needs chainstate and the canonical index to name the same tip"
+            );
+            let header = block_store_path(&dir)
+                .join("headers")
+                .join(format!("{}.bin", hex::encode(tip_hash)));
+            match shape {
+                "absent" => fs::remove_file(&header).expect("remove the tip header blob"),
+                "zero-length" => fs::write(&header, b"").expect("truncate the tip header blob"),
+                "malformed" => fs::write(&header, b"not a header").expect("corrupt the tip header"),
+                _ => {
+                    fs::remove_file(&header).expect("remove the tip header blob");
+                    fs::create_dir(&header).expect("directory at the header path");
+                }
+            }
+
+            let args = vec!["--datadir".to_string(), d.clone(), "--dry-run".to_string()];
+            let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+            let code = run(&args, &mut stdout, &mut stderr);
+            assert!(
+                code == 0 && stderr.is_empty(),
+                "{shape}: code={code} stderr={}",
+                String::from_utf8_lossy(&stderr)
+            );
+            let stdout_str = String::from_utf8(stdout).expect("stdout utf8");
+            assert!(
+                stdout_str.contains(&format!(
+                    "{}\n",
+                    format_dry_run_store_report(&on_disk, Some((tip_height, tip_hash)))
+                )),
+                "{shape}: the report must keep the on-disk chainstate and the indexed tip; \
+                 stdout=\n{stdout_str}"
+            );
+            assert!(
+                stdout_str.contains(
+                    "sync: header_request_has_from=true header_request_limit=512 ibd=true\n"
+                ),
+                "{shape}: unexpected projected sync line; stdout=\n{stdout_str}"
+            );
+
+            fs::remove_dir_all(&dir).expect("cleanup");
+        }
+    }
+
+    /// RUB-1083 frozen peer-collection precedence: Go builds the raw peer list
+    /// as `append([]string{*peerCSV}, peers...)`, so every `--peers` CSV entry
+    /// precedes every repeated `--peer` entry no matter where they sit in
+    /// argv. Both permutations must therefore yield the same ordered list.
+    #[test]
+    fn peers_csv_entries_precede_repeated_peer_entries_in_either_argv_order() {
+        let argv =
+            |args: &[&str]| -> Vec<String> { args.iter().map(|arg| (*arg).to_string()).collect() };
+        let expected = ["127.0.0.1:29114", "127.0.0.1:29115", "127.0.0.1:29112"];
+        for permutation in [
+            argv(&[
+                "--peers",
+                "127.0.0.1:29114,127.0.0.1:29115",
+                "--peer",
+                "127.0.0.1:29112",
+            ]),
+            argv(&[
+                "--peer",
+                "127.0.0.1:29112",
+                "--peers",
+                "127.0.0.1:29114,127.0.0.1:29115",
+            ]),
+        ] {
+            assert_eq!(
+                parse_args(&permutation).expect("parse").peers,
+                expected,
+                "argv {permutation:?} must yield the frozen Go peer order"
+            );
+        }
+    }
+
+    /// RUB-1083 `F3_PEERS_LAST_WINS`: an earlier `--peers` is overwritten, not
+    /// accumulated (see the `peers_csv` comment in `parse_args` for the Go
+    /// citation), while every `--peer` survives after the winning CSV. The
+    /// contract pins this on both surfaces, so one argv drives ordinary
+    /// `parse_args` and the `--dry-run` reported `peers`.
+    #[test]
+    #[rustfmt::skip]
+    fn last_peers_occurrence_replaces_earlier_ones_in_parsing_and_dry_run() {
+        let expected = ["127.0.0.1:29117", "127.0.0.1:29112", "127.0.0.1:29113"];
+        let dir = unique_temp_dir("rubin-node-bin-peers-last-wins");
+        seed_block_store(&dir);
+        let args: Vec<String> = [
+            "--datadir", &dir.display().to_string(),
+            "--peers", "127.0.0.1:29114,127.0.0.1:29115",
+            "--peer", "127.0.0.1:29112",
+            "--peers", "127.0.0.1:29117",
+            "--peer", "127.0.0.1:29113",
+            "--max-peers", "8",
+            "--dry-run",
+        ]
+        .iter()
+        .map(|arg| (*arg).to_string())
+        .collect();
+
+        assert_eq!(
+            parse_args(&args).expect("parse").peers,
+            expected,
+            "ordinary parsing must keep only the final --peers CSV"
+        );
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run(&args, &mut stdout, &mut stderr);
+        assert_eq!(code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
+        let json: Value = parse_effective_config_json(&stdout);
+        assert_eq!(
+            json["peers"],
+            serde_json::json!(expected),
+            "the dry-run report must keep only the final --peers CSV"
         );
 
         fs::remove_dir_all(&dir).expect("cleanup");
@@ -3287,6 +3795,15 @@ mod tests {
     fn seed_block_store(data_dir: &std::path::Path) {
         fs::create_dir_all(data_dir).expect("mkdir datadir");
         BlockStore::create(block_store_path(data_dir)).expect("create block store");
+    }
+
+    /// Canonical tip an already-created store holds on disk, for tests that
+    /// must not hard-code the local mining bootstrap's canonical height.
+    fn on_disk_store_tip(data_dir: &std::path::Path) -> Option<(u64, [u8; 32])> {
+        BlockStore::open(block_store_path(data_dir))
+            .expect("open block store")
+            .tip()
+            .expect("read block store tip")
     }
 
     fn cli(args: &[&str]) -> (i32, String) {

--- a/scripts/test_node_dry_run_parity.sh
+++ b/scripts/test_node_dry_run_parity.sh
@@ -1,0 +1,688 @@
+#!/usr/bin/env bash
+#
+# RUB-1083: Go/Rust `rubin-node --dry-run` parity and zero-write harness.
+#
+# For every storage shape and every flag row the RUB-1083 contract lists it
+# snapshots the datadir exactly, runs the Go binary and then the Rust binary,
+# requires each client's post-run snapshot to equal the pre-run one, and
+# requires exit 0, empty stderr and an identical finite cross-client projection
+# of stdout on both.
+#
+# `flag_rows` is the contract's finite list of COMMON dry-run rows, not the whole
+# legal dry-run surface: Go additionally accepts `--log-level`,
+# `--mempool-max-txs`, `--mempool-max-bytes` and `--featurebits-deployments`,
+# which Rust rejects, so those are outside cross-client comparison entirely.
+#
+# Both binaries are built from the current checkout; a preinstalled or
+# PATH-resolved rubin-node is never used. Set KEEP_TMP=1 to preserve
+# artifacts on success (they are always preserved on failure).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+
+# Only the tools this script invokes in its OWN PATH are precondition-checked.
+# `go` and `cargo` are deliberately absent: they run through `dev-env.sh`, whose
+# job is repairing a minimal PATH, so checking them here would reject an
+# environment the build then handles fine.
+for tool in python3 diff cmp; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    printf 'missing required tool: %s\n' "${tool}" >&2
+    exit 1
+  }
+done
+
+# shellcheck source=scripts/devnet-process-common.sh
+source "${REPO_ROOT}/scripts/devnet-process-common.sh"
+rubin_process_init "rubin-dry-run-parity"
+ART="${RUBIN_PROCESS_ARTIFACT_ROOT}"
+
+# Set only while a row runs against a mode-0500 datadir. ANY exit in that
+# window — fail(), an unexpected `set -e` abort, Ctrl-C — must restore 0700 or
+# the preserved artifact tree keeps a directory the operator cannot remove, so
+# the restore hangs off the EXIT trap rather than off fail(). Overwriting the
+# helper's EXIT trap and calling `rubin_process_cleanup` with the original
+# status is the pattern in `devnet-go-da-relay.sh:38-45`.
+RESTORE_MODE_DIR=""
+
+dry_run_parity_exit_trap() {
+  local status=$? cleanup_status=0
+  [[ -z "${RESTORE_MODE_DIR}" ]] || chmod 0700 "${RESTORE_MODE_DIR}" 2>/dev/null || true
+  rubin_process_cleanup "${status}" || cleanup_status=$?
+  [[ "${status}" == "0" ]] || exit "${status}"
+  exit "${cleanup_status}"
+}
+trap dry_run_parity_exit_trap EXIT
+# A bare SIGINT/SIGTERM kills the shell without running the EXIT trap; routing
+# them through `exit` runs it with the conventional 128+signal status.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Rows the contract allows to be skipped (uid 0, no symlink support). The final
+# summary must name them rather than claim every row held.
+SKIPPED_ROWS=()
+
+SNAPSHOT_PY="${ART}/snapshot_datadir.py"
+PROJECT_PY="${ART}/project_dry_run.py"
+
+cat >"${SNAPSHOT_PY}" <<'PY'
+"""Exact filesystem snapshot of one datadir, as defined by the RUB-1083 contract.
+
+Sorted recursive lstat inventory: relative path, entry kind, regular-file
+SHA-256, symlink target, size, permission bits, device/inode, link count and
+nanosecond mtime. atime and ctime are excluded because a pure read moves them.
+"""
+import hashlib
+import os
+import stat
+import sys
+
+root = os.path.abspath(sys.argv[1])
+
+def digest(path, mode):
+    # The mode-000 tip-header row is unreadable as-is, so its read is bracketed
+    # by a temporary +r and an unconditional restore of the ORIGINAL mode, which
+    # is also the mode row() records. Safe ONLY because this snapshot excludes
+    # ctime: chmod moves ctime, never mtime. Do not "simplify" the restore away —
+    # a permanent relaxation would mutate the very state being observed. The
+    # relaxing chmod stays INSIDE the try so no signal can land between it and
+    # the restoring finally; the restore is idempotent, so a relax that itself
+    # fails only re-applies the mode already on disk and still propagates.
+    relax = not mode & stat.S_IRUSR
+    try:
+        if relax:
+            os.chmod(path, mode | stat.S_IRUSR)
+        sha = hashlib.sha256()
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                sha.update(chunk)
+        return sha.hexdigest()
+    finally:
+        if relax:
+            os.chmod(path, mode)
+
+
+def row(path):
+    st = os.lstat(path)
+    # filemode()[0] is the type character: d/-/l/p/s/b/c, exact and exhaustive.
+    kind = stat.filemode(st.st_mode)[0]
+    if kind == "-":
+        content = digest(path, stat.S_IMODE(st.st_mode))
+    elif kind == "l":
+        content = "link:" + os.readlink(path)
+    else:
+        content = "-"
+    return "\t".join(
+        [
+            os.path.relpath(path, root),
+            kind,
+            content,
+            str(st.st_size),
+            oct(stat.S_IMODE(st.st_mode)),
+            str(st.st_dev),
+            str(st.st_ino),
+            str(st.st_nlink),
+            str(st.st_mtime_ns),
+        ]
+    )
+
+
+def reraise(error):
+    # Propagate the walk error. Silently dropping an unreadable subtree removes
+    # it from the before AND after snapshot alike, so the diff passes over
+    # whatever changed inside it. Mirrors the walkErr return in
+    # `clients/go/cmd/rubin-node/main_test.go:2774-2777`.
+    raise error
+
+
+rows = [row(root)]
+for dirpath, dirnames, filenames in os.walk(root, onerror=reraise, followlinks=False):
+    for name in dirnames + filenames:
+        rows.append(row(os.path.join(dirpath, name)))
+rows.sort()
+sys.stdout.write("\n".join(rows) + "\n")
+PY
+
+cat >"${PROJECT_PY}" <<'PY'
+"""Finite cross-client projection of `rubin-node --dry-run` stdout (RUB-1083).
+
+Emits only the fields the contract compares across clients. Go-only and
+Rust-only JSON fields are dropped. Absent and null stay distinct tokens rather
+than being normalized, except for `rpc_bind_addr` and `mine_address`, where
+absent, null and "" are one unset value.
+
+`ibd` is compared cross-client and must be `true` on every listed row. Neither
+client hydrates a tip timestamp on the dry-run path — Go's `NewSyncEngine` never
+reads the tip header and Rust's dry-run reporting engine is constructed with no
+blockstore — so both sit at timestamp zero and `is_in_ibd` is structurally true.
+Nothing here may depend on the fixture's age; `ibd=false` is a real regression,
+not a stale-fixture artifact, so it fails here rather than being tolerated.
+"""
+import json
+import re
+import sys
+
+BOOL = re.compile(r"^(true|false)$")
+TRUE = re.compile(r"^true$")
+UINT = re.compile(r"^(0|[1-9][0-9]*)$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def die(message):
+    sys.stderr.write("projection error: {}\n".format(message))
+    raise SystemExit(1)
+
+
+def parse_kv(line, prefix, keys):
+    body = line[len(prefix):]
+    tokens = body.split(" ")
+    if len(tokens) != len(keys):
+        die("{!r}: expected {} fields, got {}".format(line, len(keys), len(tokens)))
+    values = {}
+    for token, key in zip(tokens, keys):
+        name, sep, value = token.partition("=")
+        if sep != "=" or name != key:
+            die("{!r}: expected key {!r}, got token {!r}".format(line, key, token))
+        values[key] = value
+    return values
+
+
+def require(line, key, value, pattern, expectation):
+    if not pattern.match(value):
+        die("{!r}: {} must be {}, got {!r}".format(line, key, expectation, value))
+
+
+def json_string(cfg, key):
+    if key not in cfg:
+        return "<absent>"
+    value = cfg[key]
+    if value is None:
+        return "<null>"
+    if not isinstance(value, str):
+        die("{} must be a JSON string, got {!r}".format(key, value))
+    return value
+
+
+def json_unset_or_string(cfg, key):
+    value = cfg.get(key)
+    if value is None or value == "":
+        return "<unset>"
+    if not isinstance(value, str):
+        die("{} must be a JSON string, got {!r}".format(key, value))
+    return value
+
+
+with open(sys.argv[1], "rb") as handle:
+    raw = handle.read().decode("utf-8")
+
+start = raw.find("{")
+if start < 0:
+    die("no effective-config JSON object in stdout")
+cfg, end = json.JSONDecoder().raw_decode(raw, start)
+if not isinstance(cfg, dict):
+    die("effective config is not a JSON object")
+
+lines = [line for line in raw[end:].splitlines() if line.strip()]
+prefixes = ("chainstate: ", "blockstore: ", "sync: ", "p2p: ")
+if len(lines) != len(prefixes):
+    die("expected exactly {} banner lines after the JSON, got {}: {!r}".format(
+        len(prefixes), len(lines), lines))
+for line, prefix in zip(lines, prefixes):
+    if not line.startswith(prefix):
+        die("expected a line starting with {!r}, got {!r}".format(prefix, line))
+chainstate_line, blockstore_line, sync_line, p2p_line = lines
+
+chainstate_keys = ["has_tip", "height", "utxos", "already_generated"]
+if " tip=" in chainstate_line:
+    chainstate_keys.append("tip")
+chainstate = parse_kv(chainstate_line, "chainstate: ", chainstate_keys)
+require(chainstate_line, "has_tip", chainstate["has_tip"], BOOL, "a bool token")
+for key in ("height", "utxos", "already_generated"):
+    require(chainstate_line, key, chainstate[key], UINT, "a decimal uint")
+if "tip" in chainstate:
+    require(chainstate_line, "tip", chainstate["tip"], HEX64, "64 lowercase hex")
+
+if blockstore_line == "blockstore: empty":
+    blockstore = None
+else:
+    blockstore = parse_kv(blockstore_line, "blockstore: ", ["tip_height", "tip_hash"])
+    require(blockstore_line, "tip_height", blockstore["tip_height"], UINT, "a decimal uint")
+    require(blockstore_line, "tip_hash", blockstore["tip_hash"], HEX64, "64 lowercase hex")
+
+# Frozen Go gating rule: the chainstate `tip=` field is present exactly when the
+# canonical index has a tip, never when the chainstate merely claims one.
+if ("tip" in chainstate) != (blockstore is not None):
+    die("chainstate tip= presence must follow the blockstore tip: {!r} / {!r}".format(
+        chainstate_line, blockstore_line))
+
+sync = parse_kv(sync_line, "sync: ", ["header_request_has_from", "header_request_limit", "ibd"])
+require(sync_line, "header_request_has_from", sync["header_request_has_from"], BOOL, "a bool")
+require(sync_line, "header_request_limit", sync["header_request_limit"], UINT, "a decimal uint")
+require(sync_line, "ibd", sync["ibd"], TRUE, "true on every listed dry-run row")
+
+p2p = parse_kv(p2p_line, "p2p: ", ["peer_slots", "connected"])
+require(p2p_line, "peer_slots", p2p["peer_slots"], UINT, "a decimal uint")
+require(p2p_line, "connected", p2p["connected"], UINT, "a decimal uint")
+
+peers = cfg.get("peers")
+if not isinstance(peers, list) or any(not isinstance(peer, str) for peer in peers):
+    die("peers must be a JSON array of strings, got {!r}".format(peers))
+max_peers = cfg.get("max_peers")
+if not isinstance(max_peers, int) or isinstance(max_peers, bool):
+    die("max_peers must be a JSON integer, got {!r}".format(max_peers))
+
+out = [
+    ("json.network", json_string(cfg, "network")),
+    ("json.data_dir", json_string(cfg, "data_dir")),
+    ("json.chain_id_hex", json_string(cfg, "chain_id_hex")),
+    ("json.bind_addr", json_string(cfg, "bind_addr")),
+    ("json.peers", json.dumps(peers)),
+    ("json.max_peers", str(max_peers)),
+    ("json.rpc_bind_addr", json_unset_or_string(cfg, "rpc_bind_addr")),
+    ("json.mine_address", json_unset_or_string(cfg, "mine_address")),
+    ("chainstate.has_tip", chainstate["has_tip"]),
+    ("chainstate.height", chainstate["height"]),
+    ("chainstate.utxos", chainstate["utxos"]),
+    ("chainstate.already_generated", chainstate["already_generated"]),
+    ("chainstate.tip", chainstate.get("tip", "<absent>")),
+    ("blockstore.tip_height", "<empty>" if blockstore is None else blockstore["tip_height"]),
+    ("blockstore.tip_hash", "<empty>" if blockstore is None else blockstore["tip_hash"]),
+    ("sync.header_request_has_from", sync["header_request_has_from"]),
+    ("sync.header_request_limit", sync["header_request_limit"]),
+    ("sync.ibd", sync["ibd"]),
+    ("p2p.peer_slots", p2p["peer_slots"]),
+    ("p2p.connected", p2p["connected"]),
+]
+sys.stdout.write("".join("{}={}\n".format(key, value) for key, value in out))
+PY
+
+GO_BIN="${ART}/rubin-node-go"
+RUST_BIN="${ART}/rubin-node-rust"
+
+echo "Building the Go node from the current checkout"
+"${DEV_ENV}" -- go -C "${REPO_ROOT}/clients/go" build -o "${GO_BIN}" ./cmd/rubin-node
+echo "Building the Rust node from the current checkout"
+# The binary path comes from cargo's own machine-readable artifact event, not a
+# guessed `target/debug/` layout: under `CARGO_TARGET_DIR`, `build.target-dir`
+# or a configured target triple the guess either fails outright or — the
+# dangerous branch — copies a stale binary from an earlier build. Same pattern
+# as `scripts/devnet-rust-binary-soak.sh:258-370`.
+CARGO_BUILD_LOG="${ART}/cargo-build.jsonl"
+"${DEV_ENV}" -- cargo build --manifest-path "${REPO_ROOT}/clients/rust/Cargo.toml" \
+  -p rubin-node --message-format=json-render-diagnostics >"${CARGO_BUILD_LOG}"
+# Fail-closed: cargo routes JSON events to stdout and rendered diagnostics to
+# stderr, so a non-JSON line is contamination, and zero matching
+# compiler-artifact events means cargo never linked the binary we are about to
+# run. Both exit non-zero rather than falling back to a path guess.
+CARGO_RUST_BIN="$(python3 - "${CARGO_BUILD_LOG}" <<'PY'
+import json
+import sys
+
+selected = None
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for raw in handle:
+        line = raw.strip()
+        if not line:
+            continue
+        if not line.startswith("{"):
+            raise SystemExit("cargo log contamination: {!r}".format(line[:160]))
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SystemExit("cargo log parse error: {}: {!r}".format(exc, line[:160]))
+        target = event.get("target") or {}
+        if (
+            event.get("reason") == "compiler-artifact"
+            and target.get("name") == "rubin-node"
+            and "bin" in (target.get("kind") or [])
+            and event.get("executable")
+        ):
+            # Last match wins: a relink emits a later event than any earlier one.
+            selected = event["executable"]
+if selected is None:
+    raise SystemExit("no rubin-node bin artifact in the cargo build log")
+print(selected)
+PY
+)" || fail "cargo did not report a rubin-node executable (raw log: ${CARGO_BUILD_LOG})"
+[[ -x "${CARGO_RUST_BIN}" ]] || fail "cargo-reported executable is not executable: ${CARGO_RUST_BIN}"
+cp -- "${CARGO_RUST_BIN}" "${RUST_BIN}"
+
+artifact() { printf '%s/%s.%s' "${ART}" "$1" "$2"; }
+
+snapshot() { python3 "${SNAPSHOT_PY}" "$1"; }
+
+# compare_row <label> <datadir> <argv...>
+#
+# Runs both clients with the same argv, proves neither touched <datadir>, then
+# requires the contract's disposition for every listed row — exit 0 with empty
+# stderr on BOTH clients — and an identical finite projection.
+#
+# Every listed row is an accepted (exit 0, empty stderr) row, so that assertion
+# is unconditional: a row where both clients failed identically must never
+# report PASS with the projection uncompared. There is deliberately no reject
+# row — rejects diverge on stderr wording by design, so no reject row could pass
+# byte-identical stderr, and one would need exit-code plus normalized-shape
+# comparison instead.
+compare_row() {
+  local label="$1" datadir="$2"
+  shift 2
+  local -a args=("$@")
+  local impl bin rc before after
+
+  # A row whose argv named some OTHER datadir would snapshot an untouched tree,
+  # diff clean and print PASS while the clients wrote to the real target.
+  local seen=0 declared="" i
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[i]}" in
+      --datadir) seen=$((seen + 1)) declared="${args[i + 1]-}" ;;
+      --datadir=*) seen=$((seen + 1)) declared="${args[i]#--datadir=}" ;;
+    esac
+  done
+  [[ "${seen}" == "1" && "${declared}" == "${datadir}" ]] ||
+    fail "${label}: argv must name --datadir exactly once as ${datadir}, got ${seen} occurrence(s) naming ${declared:-<none>}"
+
+  for impl in go rust; do
+    case "${impl}" in
+      go) bin="${GO_BIN}" ;;
+      *) bin="${RUST_BIN}" ;;
+    esac
+    before="$(artifact "${label}" "${impl}.snapshot.before")"
+    after="$(artifact "${label}" "${impl}.snapshot.after")"
+    snapshot "${datadir}" >"${before}"
+    rc=0
+    "${bin}" "${args[@]}" \
+      >"$(artifact "${label}" "${impl}.stdout")" \
+      2>"$(artifact "${label}" "${impl}.stderr")" || rc=$?
+    snapshot "${datadir}" >"${after}"
+    diff -u "${before}" "${after}" >"$(artifact "${label}" "${impl}.snapshot.diff")" ||
+      fail "${label}: ${impl} --dry-run mutated ${datadir} (see $(artifact "${label}" "${impl}.snapshot.diff"))"
+    printf '%s\n' "${rc}" >"$(artifact "${label}" "${impl}.exit")"
+  done
+
+  local go_rc rust_rc
+  go_rc="$(cat "$(artifact "${label}" "go.exit")")"
+  rust_rc="$(cat "$(artifact "${label}" "rust.exit")")"
+  [[ "${go_rc}" == "${rust_rc}" ]] ||
+    fail "${label}: exit code mismatch go=${go_rc} rust=${rust_rc}"
+  cmp -s "$(artifact "${label}" "go.stderr")" "$(artifact "${label}" "rust.stderr")" || {
+    diff -u "$(artifact "${label}" "go.stderr")" "$(artifact "${label}" "rust.stderr")" >&2 || true
+    fail "${label}: stderr bytes differ"
+  }
+  [[ "${go_rc}" == "0" ]] ||
+    fail "${label}: every listed row must exit 0 on both clients, got ${go_rc}"
+  # Byte-identity above already ties the two together, so one emptiness check
+  # covers both clients.
+  [[ ! -s "$(artifact "${label}" "go.stderr")" ]] || {
+    cat "$(artifact "${label}" "go.stderr")" >&2
+    fail "${label}: every listed row must leave stderr empty"
+  }
+
+  for impl in go rust; do
+    python3 "${PROJECT_PY}" "$(artifact "${label}" "${impl}.stdout")" \
+      >"$(artifact "${label}" "${impl}.projection")" ||
+      fail "${label}: ${impl} stdout does not match the frozen dry-run layout"
+  done
+  diff -u "$(artifact "${label}" "go.projection")" "$(artifact "${label}" "rust.projection")" ||
+    fail "${label}: cross-client projection mismatch"
+
+  printf 'PASS  %-32s exit=%s\n' "${label}" "${go_rc}"
+}
+
+MINE_ADDRESS="$(printf '1%.0s' {1..64})"
+GENESIS_FILE="${ART}/genesis.json"
+printf '%s\n' '{"chain_id_hex":"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103","genesis_hash_hex":"0x8d48b863805b96e5fcb79ee9652cd6257ae352b2f52088af921212039f9e8aff"}' >"${GENESIS_FILE}"
+chmod 0444 "${GENESIS_FILE}"
+
+HEALTHY_DIR="${ART}/healthy"
+BASE_DIR="${ART}/base-height-1"
+echo "Preparing the healthy initialized store"
+"${GO_BIN}" --create-store --datadir "${HEALTHY_DIR}" --mine-address "${MINE_ADDRESS}" \
+  --mine-blocks 2 --mine-exit >"${ART}/healthy.mine.log" 2>&1
+"${GO_BIN}" --create-store --datadir "${BASE_DIR}" --mine-address "${MINE_ADDRESS}" \
+  --mine-blocks 1 --mine-exit >"${ART}/base.mine.log" 2>&1
+
+# The encoded empty/no-tip chainstate has to come from the client's own encoder,
+# not from a hand-written fixture: start a real node on a freshly created empty
+# store through the process lifecycle helpers, wait for its readiness evidence,
+# stop it, and take the snapshot it saved.
+echo "Capturing the encoded empty/no-tip chainstate"
+EMPTY_DIR="${ART}/empty-capture"
+rubin_process_start "empty-capture.log" "${GO_BIN}" --create-store --datadir "${EMPTY_DIR}" \
+  --bind 127.0.0.1:0
+EMPTY_PID="${RUBIN_PROCESS_LAST_PID}"
+rubin_process_wait_for_log "empty-capture.log" "rubin-node skeleton running" 60 "${EMPTY_PID}"
+rubin_process_stop_pid "${EMPTY_PID}"
+EMPTY_CHAINSTATE="${EMPTY_DIR}/chainstate.json"
+[[ -f "${EMPTY_CHAINSTATE}" ]] || fail "empty-chainstate capture produced no chainstate file"
+"${GO_BIN}" --datadir "${EMPTY_DIR}" --dry-run >"${ART}/empty-capture.verify" 2>&1
+grep -F -q -x "chainstate: has_tip=false height=0 utxos=0 already_generated=0" \
+  "${ART}/empty-capture.verify" ||
+  fail "empty-chainstate capture is not the encoded no-tip state"
+grep -F -q -x "blockstore: empty" "${ART}/empty-capture.verify" ||
+  fail "empty-chainstate capture store is not empty"
+
+TIP_HASH="$(python3 - "${BASE_DIR}/blockstore/index.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    canonical = json.load(handle)["canonical"]
+if not canonical:
+    raise SystemExit("canonical index is empty")
+print(canonical[-1])
+PY
+)"
+[[ "${TIP_HASH}" =~ ^[0-9a-f]{64}$ ]] || fail "unexpected canonical tip hash: ${TIP_HASH}"
+
+echo "Preparing the storage shapes"
+ABSENT_DIR="${ART}/absent-chainstate"
+cp -R "${BASE_DIR}" "${ABSENT_DIR}"
+rm -- "${ABSENT_DIR}/chainstate.json"
+
+STALE_DIR="${ART}/stale-chainstate"
+cp -R "${BASE_DIR}" "${STALE_DIR}"
+cp -- "${EMPTY_CHAINSTATE}" "${STALE_DIR}/chainstate.json"
+
+NO_UNDO_DIR="${ART}/tip-undo-absent"
+cp -R "${BASE_DIR}" "${NO_UNDO_DIR}"
+rm -- "${NO_UNDO_DIR}/blockstore/undo/${TIP_HASH}.json"
+
+NO_BLOB_DIR="${ART}/tip-block-blob-absent"
+cp -R "${BASE_DIR}" "${NO_BLOB_DIR}"
+rm -- "${NO_BLOB_DIR}/blockstore/blocks/${TIP_HASH}.bin"
+[[ -f "${NO_BLOB_DIR}/blockstore/headers/${TIP_HASH}.bin" ]] ||
+  fail "block-blob-absent shape must keep the tip header"
+[[ -f "${NO_BLOB_DIR}/blockstore/undo/${TIP_HASH}.json" ]] ||
+  fail "block-blob-absent shape must keep the tip undo entry"
+
+# One datadir per tip-header shape: the canonical index and the chainstate name
+# the same tip and its block and undo entries stay present, so only the header
+# path differs. Neither client reads that header on the dry-run path, so every
+# shape is an accepted row.
+prepare_header_shape() {
+  local shape="$1" dir="${ART}/tip-header-$1" header
+  cp -R "${BASE_DIR}" "${dir}"
+  header="${dir}/blockstore/headers/${TIP_HASH}.bin"
+  case "${shape}" in
+    absent) rm -- "${header}" ;;
+    dangling-symlink)
+      rm -- "${header}"
+      ln -s "${dir}/blockstore/headers/no-such-header.bin" "${header}"
+      ;;
+    zero-length) : >"${header}" ;;
+    malformed) printf 'not a block header' >"${header}" ;;
+    mode-000) chmod 0000 "${header}" ;;
+    directory)
+      rm -- "${header}"
+      mkdir -- "${header}"
+      ;;
+    *) fail "unknown tip-header shape: ${shape}" ;;
+  esac
+  [[ -e "${dir}/blockstore/blocks/${TIP_HASH}.bin" ]] ||
+    fail "${shape}: the shape must keep the tip block blob"
+  [[ -e "${dir}/blockstore/undo/${TIP_HASH}.json" ]] ||
+    fail "${shape}: the shape must keep the tip undo entry"
+}
+
+# Probed once up front rather than from a failure inside the loop, so a broken
+# `cp` can never be misreported as an unsupported-platform skip.
+SYMLINK_SUPPORTED=1
+ln -s /nonexistent "${ART}/symlink-probe" 2>/dev/null || SYMLINK_SUPPORTED=0
+[[ "${SYMLINK_SUPPORTED}" == "0" ]] || rm -- "${ART}/symlink-probe"
+
+HARDLINK_DIR="${ART}/hardlinked-chainstate"
+cp -R "${BASE_DIR}" "${HARDLINK_DIR}"
+HARDLINK_WITNESS_DIR="${ART}/hardlink-witness"
+mkdir -- "${HARDLINK_WITNESS_DIR}"
+ln -- "${HARDLINK_DIR}/chainstate.json" "${HARDLINK_WITNESS_DIR}/chainstate.link"
+
+RO_DIR="${ART}/datadir-mode-0500"
+cp -R "${BASE_DIR}" "${RO_DIR}"
+
+LIVE_DIR="${ART}/live-node-datadir"
+cp -R "${BASE_DIR}" "${LIVE_DIR}"
+
+echo
+echo "Storage/permission/hardlink/live-node shapes (F0_BASE on each)"
+for attempt in 1 2 3; do
+  compare_row "healthy-run-${attempt}" "${HEALTHY_DIR}" --datadir "${HEALTHY_DIR}" --dry-run
+done
+compare_row "absent-chainstate" "${ABSENT_DIR}" --datadir "${ABSENT_DIR}" --dry-run
+compare_row "stale-chainstate" "${STALE_DIR}" --datadir "${STALE_DIR}" --dry-run
+compare_row "tip-undo-absent" "${NO_UNDO_DIR}" --datadir "${NO_UNDO_DIR}" --dry-run
+compare_row "tip-block-blob-absent" "${NO_BLOB_DIR}" --datadir "${NO_BLOB_DIR}" --dry-run
+
+# The rows the contract pins field-by-field: chainstate and the canonical index
+# both name a tip, and only the shape at its header path varies. Rust builds the
+# dry-run reporting engine with no blockstore and therefore never reads that
+# header, matching Go, so the values below must hold on BOTH clients for all six.
+for shape in absent dangling-symlink zero-length malformed mode-000 directory; do
+  HEADER_LABEL="tip-header-${shape}"
+  HEADER_DIR="${ART}/${HEADER_LABEL}"
+  if [[ "${shape}" == "dangling-symlink" && "${SYMLINK_SUPPORTED}" == "0" ]]; then
+    printf 'SKIP  %-32s reason=symlink_unsupported\n' "${HEADER_LABEL}"
+    SKIPPED_ROWS+=("${HEADER_LABEL}")
+    continue
+  fi
+  # A mode-000 file does not block uid 0, so as root the row would prove nothing.
+  if [[ "${shape}" == "mode-000" && "$(id -u)" == "0" ]]; then
+    printf 'SKIP  %-32s reason=euid_is_root\n' "${HEADER_LABEL}"
+    SKIPPED_ROWS+=("${HEADER_LABEL}")
+    continue
+  fi
+  prepare_header_shape "${shape}"
+  compare_row "${HEADER_LABEL}" "${HEADER_DIR}" --datadir "${HEADER_DIR}" --dry-run
+  for impl in go rust; do
+    for expected in \
+      "chainstate.tip=${TIP_HASH}" \
+      "blockstore.tip_hash=${TIP_HASH}" \
+      "sync.header_request_has_from=true" \
+      "sync.header_request_limit=512" \
+      "sync.ibd=true"; do
+      grep -F -q -x "${expected}" "$(artifact "${HEADER_LABEL}" "${impl}.projection")" ||
+        fail "${HEADER_LABEL}: ${impl} projection is missing ${expected}"
+    done
+  done
+  [[ -e "${HEADER_DIR}/blockstore/blocks/${TIP_HASH}.bin" ]] ||
+    fail "${HEADER_LABEL}: the tip block blob must survive the row"
+  printf 'PASS  %-32s\n' "${HEADER_LABEL}-fields"
+done
+
+WITNESS_BEFORE="${ART}/hardlink-witness.before"
+WITNESS_AFTER="${ART}/hardlink-witness.after"
+snapshot "${HARDLINK_WITNESS_DIR}" >"${WITNESS_BEFORE}"
+compare_row "hardlinked-chainstate" "${HARDLINK_DIR}" --datadir "${HARDLINK_DIR}" --dry-run
+snapshot "${HARDLINK_WITNESS_DIR}" >"${WITNESS_AFTER}"
+diff -u "${WITNESS_BEFORE}" "${WITNESS_AFTER}" ||
+  fail "hardlinked chainstate lost its bytes, inode or link count"
+
+if [[ "$(id -u)" == "0" ]]; then
+  printf 'SKIP  %-32s reason=euid_is_root\n' "datadir-mode-0500"
+  SKIPPED_ROWS+=("datadir-mode-0500")
+else
+  RESTORE_MODE_DIR="${RO_DIR}"
+  chmod 0500 "${RO_DIR}"
+  compare_row "datadir-mode-0500" "${RO_DIR}" --datadir "${RO_DIR}" --dry-run
+  chmod 0700 "${RO_DIR}"
+  RESTORE_MODE_DIR=""
+fi
+
+echo "Starting a live node on a prepared datadir"
+rubin_process_start "live-node.log" "${GO_BIN}" --datadir "${LIVE_DIR}" --bind 127.0.0.1:0
+LIVE_PID="${RUBIN_PROCESS_LAST_PID}"
+rubin_process_wait_for_log "live-node.log" "rubin-node skeleton running" 60 "${LIVE_PID}"
+compare_row "live-node-holds-datadir" "${LIVE_DIR}" --datadir "${LIVE_DIR}" --dry-run
+rubin_process_is_alive "${LIVE_PID}" ||
+  fail "live node exited during the observation window; the row proves nothing"
+rubin_process_stop_pid "${LIVE_PID}"
+
+echo
+echo "Flag rows on the healthy initialized store"
+# F0_BASE on the healthy store is argv-identical to healthy-run-1..3 above and
+# is not repeated here; the contract lists it in both places because it is also
+# the row driven across every storage shape.
+compare_row "f1-network-genesis" "${HEALTHY_DIR}" \
+  --network devnet --genesis-file "${GENESIS_FILE}" --datadir "${HEALTHY_DIR}" --dry-run
+compare_row "f2-bind" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --bind 127.0.0.1:29111 --dry-run
+compare_row "f3-peers-csv-first" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --peers 127.0.0.1:29114,127.0.0.1:29115 \
+  --peer 127.0.0.1:29112 --peer 127.0.0.1:29113 --max-peers 8 --dry-run
+compare_row "f3-peers-repeat-first" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --peer 127.0.0.1:29112 --peer 127.0.0.1:29113 \
+  --peers 127.0.0.1:29114,127.0.0.1:29115 --max-peers 8 --dry-run
+compare_row "f3-peers-last-wins" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --peers 127.0.0.1:29114,127.0.0.1:29115 \
+  --peer 127.0.0.1:29112 --peers 127.0.0.1:29117 --peer 127.0.0.1:29113 \
+  --max-peers 8 --dry-run
+compare_row "f4-rpc" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --rpc-bind 127.0.0.1:29116 --dry-run
+# f5/f6 contribute no compared bytes for the flags they name: `mine_blocks`,
+# `mine_exit`, `pv_mode` and `pv_shadow_max` are all client-only JSON fields,
+# excluded from the projection. They prove the flags stay accepted and
+# zero-write, not that their values agree.
+compare_row "f5-miner" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --mine-address "${MINE_ADDRESS}" --mine-blocks 2 --mine-exit --dry-run
+compare_row "f6-pv" "${HEALTHY_DIR}" \
+  --datadir "${HEALTHY_DIR}" --pv-mode shadow --pv-shadow-max 7 --dry-run
+compare_row "f7-all" "${HEALTHY_DIR}" \
+  --network devnet --genesis-file "${GENESIS_FILE}" --datadir "${HEALTHY_DIR}" \
+  --bind 127.0.0.1:29111 --peers 127.0.0.1:29114,127.0.0.1:29115 \
+  --peer 127.0.0.1:29112 --peer 127.0.0.1:29113 --max-peers 8 --rpc-bind 127.0.0.1:29116 \
+  --mine-address "${MINE_ADDRESS}" --mine-blocks 2 --mine-exit --pv-mode shadow \
+  --pv-shadow-max 7 --dry-run
+
+# Both argv permutations must yield the same ordered peer list on both clients:
+# every `--peers` CSV entry precedes every repeated `--peer` entry.
+for impl in go rust; do
+  diff -u "$(artifact "f3-peers-csv-first" "${impl}.projection")" \
+    "$(artifact "f3-peers-repeat-first" "${impl}.projection")" ||
+    fail "${impl}: peer argv permutation changed the projection"
+done
+printf 'PASS  %-32s\n' "peer-argv-permutation"
+
+# `F3_PEERS_LAST_WINS`: Go's `--peers` is a `flag.String`
+# (`clients/go/cmd/rubin-node/main.go:292`), so a repeated occurrence overwrites
+# and only the final CSV reaches `append([]string{*peerCSV}, peers...)`.
+# compare_row's cross-client diff reddens if exactly one client accumulated, but
+# not if both accumulate alike, so pin the exact ordered list per client.
+PEERS_LAST_WINS_EXPECTED='json.peers=["127.0.0.1:29117", "127.0.0.1:29112", "127.0.0.1:29113"]'
+for impl in go rust; do
+  grep -Fxq -- "${PEERS_LAST_WINS_EXPECTED}" \
+    "$(artifact "f3-peers-last-wins" "${impl}.projection")" ||
+    fail "${impl}: a repeated --peers must keep only the final CSV; expected ${PEERS_LAST_WINS_EXPECTED}"
+done
+printf 'PASS  %-32s\n' "peers-last-occurrence-wins"
+
+echo
+if ((${#SKIPPED_ROWS[@]} > 0)); then
+  printf 'PASS: Go/Rust --dry-run parity and zero-write hold on every RUB-1083 row except %d allowed skip(s): %s\n' \
+    "${#SKIPPED_ROWS[@]}" "${SKIPPED_ROWS[*]}"
+else
+  echo "PASS: Go/Rust --dry-run parity and zero-write hold on every RUB-1083 row"
+fi


### PR DESCRIPTION
## Issue
- Linear: RUB-1083
- GitHub Issue mirror (non-authoritative): #2763

Refs: Q-CLI-DRY-RUN-READ-ONLY-01-RUST

## Summary
The Rust node reached `reconcile_chain_state_with_block_store` and `chain_state.save` before its `--dry-run` return, so every invocation rewrote the chainstate snapshot through a temp-and-rename and could truncate the canonical index on a datadir it was asked only to report. Both steps are now skipped under the flag. The dry-run reporting engine is additionally constructed with no blockstore, so the canonical tip header is never probed, opened or parsed and every header shape reports instead of failing — matching the merged Go client, whose `NewSyncEngine` never reads that header either.

Two operator-visible consequences. `--dry-run` now emits the `chainstate:` and `blockstore:` banners in the Go format, under that flag only; ordinary startup is unchanged and still emits neither. Comma-separated `--peers` entries now precede repeated `--peer` entries in both dry-run and ordinary parsing, matching Go's fixed collection order. `sync: ibd` is constant `true` under the flag on both clients, because neither hydrates a tip timestamp on this path.

`scripts/test_node_dry_run_parity.sh` builds both binaries from the checkout and compares exit code, stderr bytes and a finite projection of the report across every listed store, tip-header and flag shape, snapshotting each datadir before and after each invocation.

## Invariant
A Rust `--dry-run` invocation prints the effective configuration and exits without creating, changing, renaming, truncating, linking or removing any datadir entry, and matches the merged Go client on exit code, stderr bytes and the finite projected report for every listed store, header and flag shape.

## Scope
- Changed files: 3
- Surfaces: clients/go, clients/rust, tooling
- Non-scope: no preflight semantics; no in-memory repair used to make the report look healthy; no change to the `SyncEngine` constructor, `load_persisted_tip_timestamp` or any `sync.rs` behavior; no new flag; no lock implementation; no migration; no change to `--legacy-exposure-scan`; no Go executable change; and no ordinary-startup change beyond the frozen peer collection precedence. The Go footprint is the deletion of one stale comment paragraph, with no executable token touched.
- Consensus rules unchanged: YES — the change gates two node-local startup steps behind an existing CLI flag and alters no validation path; accept/reject outcomes, public error codes and their ordering are untouched
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks: `cargo fmt --check` — PASS; `cargo clippy -p rubin-node --all-targets -- -D warnings` — PASS; `cargo test -p rubin-node -- --test-threads=1` — PASS; `cargo test --workspace -- --test-threads=1` — PASS; `cargo nextest run --workspace --all-targets` — PASS; `cargo test --workspace --doc` — PASS; `go build ./...` — PASS; `go vet ./cmd/rubin-node` — PASS; `go test ./cmd/rubin-node -count=1` — PASS; `go test -race -timeout=20m -shuffle=on -count=1 ./...` — PASS; `bash -n scripts/test_node_dry_run_parity.sh` — PASS; `shellcheck -x scripts/test_node_dry_run_parity.sh` — PASS; `scripts/dev-env.sh -- bash scripts/test_node_dry_run_parity.sh` — PASS; `git diff --check` — PASS

## Follow-ups / Waivers
- RUB-1078
