### PR TITLE
RUB-1078: enforce a cross-client datadir writer lock

### DIFF
--- a/clients/go/cmd/rubin-node/datadir_lock.go
+++ b/clients/go/cmd/rubin-node/datadir_lock.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/internal/filelock"
+)
+
+func acquireDatadirLock(normalizedDataDir string, stderr io.Writer) (*filelock.Handle, int) {
+	lockPath := filepath.Join(normalizedDataDir, ".rubin.lock")
+	lock, result, err := filelock.Acquire(lockPath)
+	if err == nil {
+		return lock, 0
+	}
+	if result == filelock.ResultContended {
+		_, _ = fmt.Fprintf(stderr, "datadir is already in use by another rubin-node: %s\n", normalizedDataDir)
+		return nil, 2
+	}
+	_, _ = fmt.Fprintf(stderr, "cannot open datadir lock %s: %v\n", lockPath, err)
+	return nil, 2
+}

--- a/clients/go/cmd/rubin-node/datadir_lock_test.go
+++ b/clients/go/cmd/rubin-node/datadir_lock_test.go
@@ -120,6 +120,51 @@ func TestRunStrictOpenMissingDatadirDoesNotCreateLock(t *testing.T) {
 	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
 		t.Fatalf("strict open created datadir or lock: %v", err)
 	}
+
+	t.Run("existing_root_returns_nil", func(t *testing.T) {
+		dataDir := filepath.Join(t.TempDir(), "missing")
+		rootPath := t.TempDir()
+		if err := missingBlockStoreOpenError(dataDir, rootPath); err != nil {
+			t.Fatalf("missingBlockStoreOpenError=%v, want nil", err)
+		}
+		if _, err := os.Lstat(dataDir); !os.IsNotExist(err) {
+			t.Fatalf("missingBlockStoreOpenError mutated datadir: %v", err)
+		}
+	})
+}
+
+func TestCreateOrOpenBlockStoreReportsMkdirFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can create a child beneath a non-writable parent")
+	}
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatalf("chmod parent: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(parent, 0o700); err != nil {
+			t.Errorf("restore parent permissions: %v", err)
+		}
+	})
+	dataDir := filepath.Join(parent, "data")
+	var stderr bytes.Buffer
+	store, lock, code := createOrOpenBlockStore(dataDir, node.ChainStatePath(dataDir), true, false, &stderr)
+	if store != nil || lock != nil || code != 2 {
+		t.Fatalf("store=%v lock=%v code=%d, want nil nil 2", store, lock, code)
+	}
+	if got := stderr.String(); !strings.HasPrefix(got, "datadir create failed: ") {
+		t.Fatalf("stderr=%q, want datadir create failure prefix", got)
+	}
+	for _, path := range []string{
+		dataDir,
+		node.BlockStorePath(dataDir),
+		node.ChainStatePath(dataDir),
+		filepath.Join(dataDir, ".rubin.lock"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("artifact %s exists after mkdir failure: %v", path, err)
+		}
+	}
 }
 
 func TestCreateOrOpenBlockStoreReturnsLockOnlyForMutatingStrictOpen(t *testing.T) {

--- a/clients/go/cmd/rubin-node/datadir_lock_test.go
+++ b/clients/go/cmd/rubin-node/datadir_lock_test.go
@@ -1,0 +1,233 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/internal/filelock"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+func TestAcquireDatadirLockReportsContentionAndReleases(t *testing.T) {
+	dir := t.TempDir()
+	holder, code := acquireDatadirLock(dir, &bytes.Buffer{})
+	if code != 0 || holder == nil {
+		t.Fatalf("first acquire code=%d holder=%v", code, holder)
+	}
+
+	var stderr bytes.Buffer
+	challenger, code := acquireDatadirLock(dir, &stderr)
+	if code != 2 || challenger != nil {
+		t.Fatalf("second acquire code=%d holder=%v", code, challenger)
+	}
+	if want := "datadir is already in use by another rubin-node: " + dir; !strings.Contains(stderr.String(), want) {
+		t.Fatalf("stderr=%q, want %q", stderr.String(), want)
+	}
+	if err := holder.Release(); err != nil {
+		t.Fatalf("release holder: %v", err)
+	}
+
+	reused, code := acquireDatadirLock(dir, &bytes.Buffer{})
+	if code != 0 || reused == nil {
+		t.Fatalf("reused acquire code=%d holder=%v", code, reused)
+	}
+	if err := reused.Release(); err != nil {
+		t.Fatalf("release reused holder: %v", err)
+	}
+}
+
+func TestRunMutatingStartupRejectsDatadirLockBeforeBlockStore(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*testing.T, string)
+		want  string
+	}{
+		{
+			name: "contended",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				holder, result, err := filelock.Acquire(filepath.Join(dir, ".rubin.lock"))
+				if err != nil || result != "" {
+					t.Fatalf("Acquire result=%q err=%v", result, err)
+				}
+				t.Cleanup(func() { _ = holder.Release() })
+			},
+			want: "datadir is already in use by another rubin-node:",
+		},
+		{
+			name: "invalid",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, ".rubin.lock"), []byte("not empty"), 0o600); err != nil {
+					t.Fatalf("write lock: %v", err)
+				}
+			},
+			want: "cannot open datadir lock",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			code, stderr := runCLI("--datadir", dir)
+			if code != 2 || !strings.Contains(stderr, tc.want) {
+				t.Fatalf("exit=%d stderr=%q, want %q", code, stderr, tc.want)
+			}
+			if _, err := os.Lstat(node.BlockStorePath(dir)); !os.IsNotExist(err) {
+				t.Fatalf("blockstore must not be opened or created before lock rejection: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunCreateStoreRejectsHeldLockBeforeStoreCreation(t *testing.T) {
+	dir := t.TempDir()
+	holder, result, err := filelock.Acquire(filepath.Join(dir, ".rubin.lock"))
+	if err != nil || result != "" {
+		t.Fatalf("Acquire result=%q err=%v", result, err)
+	}
+	t.Cleanup(func() { _ = holder.Release() })
+
+	code, stderr := runCLI("--datadir", dir, "--create-store")
+	if code != 2 || !strings.Contains(stderr, "datadir is already in use by another rubin-node:") {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	for _, path := range []string{node.BlockStorePath(dir), node.ChainStatePath(dir)} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("store artifact %s exists after lock rejection: %v", path, err)
+		}
+	}
+}
+
+func TestRunStrictOpenMissingDatadirDoesNotCreateLock(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	rootPath := node.BlockStorePath(dir)
+	_, statErr := os.Stat(rootPath)
+	if statErr == nil {
+		t.Fatalf("missing root unexpectedly exists: %s", rootPath)
+	}
+	code, stderr := runCLI("--datadir", dir)
+	want := fmt.Sprintf("blockstore open failed: blockstore directory %s: %v\n", rootPath, statErr)
+	if code != 2 || stderr != want {
+		t.Fatalf("exit=%d stderr=%q, want %q", code, stderr, want)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Fatalf("strict open created datadir or lock: %v", err)
+	}
+}
+
+func TestCreateOrOpenBlockStoreReturnsLockOnlyForMutatingStrictOpen(t *testing.T) {
+	dir := preparedDatadir(t)
+	chainStatePath := node.ChainStatePath(dir)
+
+	t.Run("mutating", func(t *testing.T) {
+		store, lock, code := createOrOpenBlockStore(dir, chainStatePath, false, false, &bytes.Buffer{})
+		if code != 0 || store == nil || lock == nil {
+			t.Fatalf("store=%v lock=%v code=%d, want store and held lock", store, lock, code)
+		}
+		defer func() {
+			if err := lock.Release(); err != nil {
+				t.Errorf("release mutating lock: %v", err)
+			}
+		}()
+
+		challenger, result, err := filelock.Acquire(filepath.Join(dir, ".rubin.lock"))
+		if err == nil || challenger != nil || result != filelock.ResultContended {
+			if challenger != nil {
+				_ = challenger.Release()
+			}
+			t.Fatalf("strict-open lock result=%q handle=%v err=%v, want contention", result, challenger, err)
+		}
+	})
+
+	t.Run("dry_run", func(t *testing.T) {
+		store, lock, code := createOrOpenBlockStore(dir, chainStatePath, false, true, &bytes.Buffer{})
+		if code != 0 || store == nil || lock != nil {
+			t.Fatalf("store=%v lock=%v code=%d, want store and nil lock", store, lock, code)
+		}
+		probe, result, err := filelock.Acquire(filepath.Join(dir, ".rubin.lock"))
+		if err != nil || result != "" || probe == nil {
+			t.Fatalf("dry-run must not hold lock: result=%q handle=%v err=%v", result, probe, err)
+		}
+		if err := probe.Release(); err != nil {
+			t.Fatalf("release dry-run probe: %v", err)
+		}
+	})
+}
+
+func TestRunCreateStoreCreatesReusableZeroByteLock(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	if code, stderr := runCLI("--datadir", dir, "--create-store", "--mine-blocks", "1", "--mine-exit"); code != 0 {
+		t.Fatalf("create exit=%d stderr=%q", code, stderr)
+	}
+	lockPath := filepath.Join(dir, ".rubin.lock")
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatalf("stat lock: %v", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != 0 {
+		t.Fatalf("lock info = mode %v size %d, want regular zero-byte file", info.Mode(), info.Size())
+	}
+	handle, result, err := filelock.Acquire(lockPath)
+	if err != nil || result != "" {
+		t.Fatalf("reacquire result=%q err=%v", result, err)
+	}
+	if err := handle.Release(); err != nil {
+		t.Fatalf("release reacquired lock: %v", err)
+	}
+}
+
+func TestRunReadOnlyModesIgnoreDatadirLock(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "contended",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				holder, result, err := filelock.Acquire(filepath.Join(dir, ".rubin.lock"))
+				if err != nil || result != "" {
+					t.Fatalf("Acquire result=%q err=%v", result, err)
+				}
+				t.Cleanup(func() { _ = holder.Release() })
+			},
+		},
+		{
+			name: "invalid",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				path := filepath.Join(dir, ".rubin.lock")
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove valid lock: %v", err)
+				}
+				if err := os.WriteFile(path, []byte("not empty"), 0o600); err != nil {
+					t.Fatalf("write invalid lock: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := preparedDatadir(t)
+			tc.setup(t, dir)
+			before := datadirSnapshot(t, dir)
+			for _, args := range [][]string{
+				{"--dry-run", "--datadir", dir},
+				{"--legacy-exposure-scan", "--legacy-suite-id", "1", "--datadir", dir},
+			} {
+				var stdout, stderr bytes.Buffer
+				if code := run(args, &stdout, &stderr); code != 0 {
+					t.Fatalf("%v: exit=%d stderr=%q", args, code, stderr.String())
+				}
+			}
+			assertNoFilesystemWrite(t, before, datadirSnapshot(t, dir))
+		})
+	}
+}

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/internal/filelock"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node/p2p"
 )
@@ -231,34 +232,85 @@ func loadLegacyExposureScanChainState(path string) (*node.ChainState, error) {
 }
 
 // createOrOpenBlockStore selects the explicit create path or the strict
-// open-existing path. In create mode the CLI owns the preconditions: the
-// blockstore root must be absent (its error wins) and the chainstate must be
-// absent, both checked before the datadir or any store artifact is created.
-func createOrOpenBlockStore(dataDir, chainStatePath string, createStore bool, stderr io.Writer) (*node.BlockStore, int) {
+// open-existing path. Mutating paths return their held datadir lock; dry-run
+// preserves the strict open without acquiring or creating that lock.
+func createOrOpenBlockStore(dataDir, chainStatePath string, createStore, dryRun bool, stderr io.Writer) (*node.BlockStore, *filelock.Handle, int) {
 	rootPath := node.BlockStorePath(dataDir)
 	if !createStore {
-		blockStore, err := node.OpenBlockStore(rootPath)
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "blockstore open failed: %v\n", err)
-			return nil, 2
+		if dryRun {
+			blockStore, exit := openBlockStore(rootPath, stderr)
+			return blockStore, nil, exit
 		}
-		return blockStore, 0
+		if err := missingBlockStoreOpenError(dataDir, rootPath); err != nil {
+			_, _ = fmt.Fprintf(stderr, "blockstore open failed: %v\n", err)
+			return nil, nil, 2
+		}
+		lock, lockExit := acquireDatadirLock(dataDir, stderr)
+		if lockExit != 0 {
+			return nil, nil, lockExit
+		}
+		blockStore, exit := openBlockStore(rootPath, stderr)
+		if exit != 0 {
+			_ = lock.Release()
+			return nil, nil, exit
+		}
+		return blockStore, lock, 0
 	}
 	if err := requireAbsentPath("blockstore root", rootPath); err != nil {
 		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
-		return nil, 2
+		return nil, nil, 2
 	}
 	if err := requireAbsentPath("chainstate", chainStatePath); err != nil {
 		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
-		return nil, 2
+		return nil, nil, 2
 	}
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		_, _ = fmt.Fprintf(stderr, "datadir create failed: %v\n", err)
-		return nil, 2
+		return nil, nil, 2
+	}
+	lock, lockExit := acquireDatadirLock(dataDir, stderr)
+	if lockExit != 0 {
+		return nil, nil, lockExit
+	}
+	if err := requireAbsentPath("blockstore root", rootPath); err != nil {
+		_ = lock.Release()
+		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, nil, 2
+	}
+	if err := requireAbsentPath("chainstate", chainStatePath); err != nil {
+		_ = lock.Release()
+		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, nil, 2
 	}
 	blockStore, err := node.CreateBlockStore(rootPath)
 	if err != nil {
+		_ = lock.Release()
 		_, _ = fmt.Fprintf(stderr, "blockstore create failed: %v\n", err)
+		return nil, nil, 2
+	}
+	return blockStore, lock, 0
+}
+
+// missingBlockStoreOpenError preserves the strict-open rejection for an
+// initially absent datadir without entering BlockStore open before a mutating
+// caller owns the datadir lock. The second, root-level probe closes the only
+// relevant race: if a concurrent create has made the root appear, the caller
+// continues to acquire the lock and opens the store under it. If it remains
+// absent, format the same root Stat error that BlockStore open would report.
+func missingBlockStoreOpenError(dataDir, rootPath string) error {
+	if _, err := os.Lstat(dataDir); !errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if _, err := os.Stat(rootPath); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("blockstore directory %s: %w", rootPath, err)
+	}
+	return nil
+}
+
+func openBlockStore(rootPath string, stderr io.Writer) (*node.BlockStore, int) {
+	blockStore, err := node.OpenBlockStore(rootPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "blockstore open failed: %v\n", err)
 		return nil, 2
 	}
 	return blockStore, 0
@@ -406,9 +458,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Storage lifecycle runs BEFORE the chainstate load: an uninitialized or
 	// half-initialized store must reject before anything reads or writes
 	// chainstate. Ordinary startup performs no mkdir at all.
-	blockStore, storeExit := createOrOpenBlockStore(cfg.DataDir, chainStatePath, *createStore, stderr)
+	blockStore, datadirLock, storeExit := createOrOpenBlockStore(cfg.DataDir, chainStatePath, *createStore, *dryRun, stderr)
 	if storeExit != 0 {
 		return storeExit
+	}
+	if datadirLock != nil {
+		defer func() { _ = datadirLock.Release() }()
 	}
 	chainState, err := node.LoadChainState(chainStatePath)
 	if err != nil {

--- a/clients/go/cmd/rubin-node/main_unix_test.go
+++ b/clients/go/cmd/rubin-node/main_unix_test.go
@@ -41,6 +41,14 @@ func TestRunStartupFailsWhenChainstateSaveFails(t *testing.T) {
 	if _, err := engine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
 		t.Fatalf("ApplyBlock(genesis): %v", err)
 	}
+	var lockStderr bytes.Buffer
+	lock, lockExit := acquireDatadirLock(dir, &lockStderr)
+	if lockExit != 0 || lock == nil {
+		t.Fatalf("create datadir lock: exit=%d stderr=%q", lockExit, lockStderr.String())
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("release datadir lock: %v", err)
+	}
 
 	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatalf("Chmod(readonly datadir): %v", err)

--- a/clients/go/internal/filelock/filelock.go
+++ b/clients/go/internal/filelock/filelock.go
@@ -1,0 +1,28 @@
+// Package filelock holds a process-scoped advisory lock on one regular file.
+package filelock
+
+// Result classifies a failed acquisition without exposing host-specific errno
+// values to callers.
+type Result string
+
+const (
+	ResultContended           Result = "contended"
+	ResultInvalidOrUnopenable Result = "invalid_or_unopenable"
+	ResultUnsupportedHost     Result = "unsupported_host"
+)
+
+// Handle owns an acquired lock until Release.
+type Handle struct {
+	fd int
+}
+
+// Release relinquishes the held lock. Releasing an already released handle is
+// a no-op.
+func (h *Handle) Release() error {
+	if h == nil || h.fd < 0 {
+		return nil
+	}
+	fd := h.fd
+	h.fd = -1
+	return release(fd)
+}

--- a/clients/go/internal/filelock/filelock_test.go
+++ b/clients/go/internal/filelock/filelock_test.go
@@ -1,0 +1,243 @@
+//go:build darwin || linux
+
+package filelock
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestAcquireContendsUntilRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock")
+	holder, result, err := Acquire(path)
+	if err != nil || result != "" {
+		t.Fatalf("first Acquire result=%q err=%v", result, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat lock: %v", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != 0 {
+		t.Fatalf("lock info = mode %v size %d, want regular zero-byte file", info.Mode(), info.Size())
+	}
+
+	challenger, result, err := Acquire(path)
+	if challenger != nil || result != ResultContended || err == nil {
+		t.Fatalf("second Acquire handle=%v result=%q err=%v", challenger, result, err)
+	}
+	if err := holder.Release(); err != nil {
+		t.Fatalf("release holder: %v", err)
+	}
+
+	reused, result, err := Acquire(path)
+	if err != nil || result != "" {
+		t.Fatalf("reused Acquire result=%q err=%v", result, err)
+	}
+	if err := reused.Release(); err != nil {
+		t.Fatalf("release reused handle: %v", err)
+	}
+}
+
+func TestAcquireRejectsUnsafeLeaves(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				target := path + ".target"
+				if err := os.WriteFile(target, nil, 0o600); err != nil {
+					t.Fatalf("write target: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+			},
+		},
+		{
+			name: "dangling_symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Symlink(path+".missing", path); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+			},
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+			},
+		},
+		{
+			name: "fifo",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := syscall.Mkfifo(path, 0o600); err != nil {
+					t.Fatalf("mkfifo: %v", err)
+				}
+			},
+		},
+		{
+			name: "nonzero_file",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("not empty"), 0o600); err != nil {
+					t.Fatalf("write lock: %v", err)
+				}
+			},
+		},
+		{
+			name: "hardlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				source := path + ".source"
+				if err := os.WriteFile(source, nil, 0o600); err != nil {
+					t.Fatalf("write source: %v", err)
+				}
+				if err := os.Link(source, path); err != nil {
+					t.Fatalf("link: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "lock")
+			tc.setup(t, path)
+			handle, result, err := Acquire(path)
+			if handle != nil || result != ResultInvalidOrUnopenable || err == nil {
+				t.Fatalf("Acquire handle=%v result=%q err=%v", handle, result, err)
+			}
+		})
+	}
+}
+
+func TestAcquireRejectsUnreadableLeaf(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can bypass lock-file permissions")
+	}
+	path := filepath.Join(t.TempDir(), "lock")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatalf("chmod lock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	handle, result, err := Acquire(path)
+	if handle != nil || result != ResultInvalidOrUnopenable || err == nil {
+		t.Fatalf("Acquire handle=%v result=%q err=%v", handle, result, err)
+	}
+}
+
+// TestFileLockExternalProtocol is a test-binary-only protocol for the
+// cross-client harness. Run a binary made by `go test -c` with
+// RUBIN_FILELOCK_PROTOCOL_MODE=holder or challenger and -test.run set to this
+// exact test. Every supplied path is absolute. The holder needs LOCK_PATH,
+// READY_PATH, and RELEASE_PATH; the challenger needs LOCK_PATH and RESULT_PATH.
+func TestFileLockExternalProtocol(t *testing.T) {
+	mode := os.Getenv("RUBIN_FILELOCK_PROTOCOL_MODE")
+	if mode == "" {
+		t.Skip("external filelock protocol is not requested")
+	}
+	lockPath := protocolAbsolutePath(t, "RUBIN_FILELOCK_PROTOCOL_LOCK_PATH")
+	switch mode {
+	case "holder":
+		readyPath := protocolAbsolutePath(t, "RUBIN_FILELOCK_PROTOCOL_READY_PATH")
+		if protocolPathInside(filepath.Dir(lockPath), readyPath) {
+			t.Fatalf("ready marker must be outside locked parent: %s", readyPath)
+		}
+		releasePath := protocolAbsolutePath(t, "RUBIN_FILELOCK_PROTOCOL_RELEASE_PATH")
+		runProtocolHolder(t, lockPath, readyPath, releasePath)
+	case "challenger":
+		resultPath := protocolAbsolutePath(t, "RUBIN_FILELOCK_PROTOCOL_RESULT_PATH")
+		runProtocolChallenger(t, lockPath, resultPath)
+	default:
+		t.Fatalf("unknown RUBIN_FILELOCK_PROTOCOL_MODE %q", mode)
+	}
+}
+
+func runProtocolHolder(t *testing.T, lockPath, readyPath, releasePath string) {
+	t.Helper()
+	handle, result, err := Acquire(lockPath)
+	if err != nil || result != "" {
+		t.Fatalf("holder Acquire result=%q err=%v", result, err)
+	}
+	defer func() {
+		if err := handle.Release(); err != nil {
+			t.Errorf("holder release: %v", err)
+		}
+	}()
+	if err := os.WriteFile(readyPath, []byte("ready\n"), 0o600); err != nil {
+		t.Fatalf("write ready marker: %v", err)
+	}
+	waitForProtocolMarker(t, releasePath)
+}
+
+func runProtocolChallenger(t *testing.T, lockPath, resultPath string) {
+	t.Helper()
+	handle, result, err := Acquire(lockPath)
+	outcome := "acquired"
+	if err != nil {
+		switch result {
+		case ResultContended:
+			outcome = string(ResultContended)
+		case ResultInvalidOrUnopenable:
+			outcome = string(ResultInvalidOrUnopenable)
+		default:
+			t.Fatalf("challenger Acquire result=%q err=%v", result, err)
+		}
+	} else if err := handle.Release(); err != nil {
+		t.Fatalf("challenger release: %v", err)
+	}
+	if err := os.WriteFile(resultPath, []byte(outcome+"\n"), 0o600); err != nil {
+		t.Fatalf("write result marker: %v", err)
+	}
+}
+
+func protocolAbsolutePath(t *testing.T, name string) string {
+	t.Helper()
+	path := os.Getenv(name)
+	if !filepath.IsAbs(path) {
+		t.Fatalf("%s must be an absolute path", name)
+	}
+	return filepath.Clean(path)
+}
+
+func protocolPathInside(parent, path string) bool {
+	rel, err := filepath.Rel(parent, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func waitForProtocolMarker(t *testing.T, path string) {
+	t.Helper()
+	timeout := time.NewTimer(10 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer timeout.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatalf("timeout waiting for release marker %s", path)
+		case <-ticker.C:
+			_, err := os.Stat(path)
+			if err == nil {
+				return
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("stat release marker %s: %v", path, err)
+			}
+		}
+	}
+}

--- a/clients/go/internal/filelock/filelock_test.go
+++ b/clients/go/internal/filelock/filelock_test.go
@@ -43,6 +43,29 @@ func TestAcquireContendsUntilRelease(t *testing.T) {
 	}
 }
 
+func TestReleaseAllowsNilAndReleasedHandles(t *testing.T) {
+	var nilHandle *Handle
+	if err := nilHandle.Release(); err != nil {
+		t.Fatalf("release nil handle: %v", err)
+	}
+	handle, result, err := Acquire(filepath.Join(t.TempDir(), "lock"))
+	if err != nil || result != "" {
+		t.Fatalf("Acquire result=%q err=%v", result, err)
+	}
+	if err := handle.Release(); err != nil {
+		t.Fatalf("release handle: %v", err)
+	}
+	if err := handle.Release(); err != nil {
+		t.Fatalf("release released handle: %v", err)
+	}
+}
+
+func TestValidateReportsFstatFailure(t *testing.T) {
+	if err := validate(-1); !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("validate(-1) error=%v, want EBADF", err)
+	}
+}
+
 func TestAcquireRejectsUnsafeLeaves(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/clients/go/internal/filelock/filelock_unix.go
+++ b/clients/go/internal/filelock/filelock_unix.go
@@ -1,0 +1,51 @@
+//go:build darwin || linux
+
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// Acquire opens path once and holds an exclusive advisory lock on its exact
+// regular-file inode. Callers own a non-nil Handle until Release.
+func Acquire(path string) (*Handle, Result, error) {
+	fd, err := syscall.Open(path, syscall.O_RDWR|syscall.O_CREAT|syscall.O_CLOEXEC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0o600)
+	if err != nil {
+		return nil, ResultInvalidOrUnopenable, err
+	}
+	if err := validate(fd); err != nil {
+		_ = syscall.Close(fd)
+		return nil, ResultInvalidOrUnopenable, err
+	}
+	if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = syscall.Close(fd)
+		if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ResultContended, err
+		}
+		return nil, ResultInvalidOrUnopenable, err
+	}
+	return &Handle{fd: fd}, "", nil
+}
+
+func validate(fd int) error {
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(fd, &stat); err != nil {
+		return err
+	}
+	if stat.Mode&syscall.S_IFMT != syscall.S_IFREG {
+		return errors.New("datadir lock must be a regular file")
+	}
+	if stat.Size != 0 {
+		return fmt.Errorf("datadir lock must be empty, got size %d", stat.Size)
+	}
+	if stat.Nlink != 1 {
+		return fmt.Errorf("datadir lock must have one link, got %d", stat.Nlink)
+	}
+	return nil
+}
+
+func release(fd int) error {
+	return syscall.Close(fd)
+}

--- a/clients/go/internal/filelock/filelock_unsupported.go
+++ b/clients/go/internal/filelock/filelock_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !darwin && !linux
+
+package filelock
+
+import "errors"
+
+// Acquire is unavailable on hosts without the required final-component-safe
+// open and advisory-lock syscalls.
+func Acquire(_ string) (*Handle, Result, error) {
+	return nil, ResultUnsupportedHost, errors.New("datadir writer lock is unsupported on this host")
+}
+
+func release(_ int) error {
+	return nil
+}

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "hex",
+ "libc",
  "num-bigint",
  "rubin-consensus",
  "serde",

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -13,6 +13,9 @@ sha3 = "0.10"
 
 rubin-consensus = { path = "../rubin-consensus" }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+libc = "0.2"
+
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"
 

--- a/clients/rust/crates/rubin-node/src/datadir_lock.rs
+++ b/clients/rust/crates/rubin-node/src/datadir_lock.rs
@@ -1,0 +1,39 @@
+use std::io::Write;
+use std::path::Path;
+
+use crate::file_lock::{self, HeldFileLock, LockClass};
+
+pub(crate) struct HeldDatadirLock(HeldFileLock);
+
+impl HeldDatadirLock {
+    pub(crate) fn release(self) {
+        self.0.release();
+    }
+}
+
+pub(crate) fn acquire(
+    normalized_data_dir: &Path,
+    stderr: &mut dyn Write,
+) -> Result<HeldDatadirLock, i32> {
+    let lock_path = normalized_data_dir.join(".rubin.lock");
+    match file_lock::acquire(&lock_path) {
+        Ok(lock) => Ok(HeldDatadirLock(lock)),
+        Err(error) if error.class() == LockClass::Contended => {
+            let _ = writeln!(
+                stderr,
+                "datadir is already in use by another rubin-node: {}",
+                normalized_data_dir.display()
+            );
+            Err(2)
+        }
+        Err(error) => {
+            let _ = writeln!(
+                stderr,
+                "cannot open datadir lock {}: {}",
+                lock_path.display(),
+                error.cause()
+            );
+            Err(2)
+        }
+    }
+}

--- a/clients/rust/crates/rubin-node/src/file_lock.rs
+++ b/clients/rust/crates/rubin-node/src/file_lock.rs
@@ -115,9 +115,7 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
-
     type LeafSetup = fn(&Path);
-
     fn temp_dir(name: &str) -> PathBuf {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -132,7 +130,6 @@ mod tests {
             .unwrap_or_else(|err| panic!("create temp dir {}: {err}", path.display()));
         path
     }
-
     fn assert_invalid(path: &Path) {
         match acquire(path) {
             Ok(lock) => {
@@ -142,7 +139,6 @@ mod tests {
             Err(error) => assert_eq!(error.class(), LockClass::InvalidOrUnopenable),
         }
     }
-
     #[test]
     fn acquire_contends_until_release_and_leaves_empty_file() {
         let dir = temp_dir("contended");
@@ -199,10 +195,34 @@ mod tests {
         }
     }
 
-    // Test-binary-only protocol for an executable built by `cargo test --no-run`.
-    // Set RUBIN_FILE_LOCK_PROTOCOL_MODE to holder or challenger and execute only
-    // this test. The holder needs LOCK_PATH, READY_PATH, and RELEASE_PATH; the
-    // challenger needs LOCK_PATH and RESULT_PATH. Every supplied path is absolute.
+    #[test]
+    fn protocol_helpers_cover_immediate_release_and_outcomes() {
+        let dir = temp_dir("protocol-helpers");
+        let lock = dir.join("lock");
+        let ready = dir.join("ready");
+        let release = dir.join("release");
+        fs::write(&release, b"release\n").expect("release marker");
+        protocol_holder(&lock, &ready, &release);
+        assert_eq!(fs::read(&ready).expect("ready marker"), b"ready\n");
+
+        let result = dir.join("result");
+        protocol_challenger(&lock, &result);
+        assert_eq!(fs::read(&result).expect("acquired result"), b"acquired\n");
+
+        let holder = acquire(&lock).unwrap_or_else(|err| panic!("hold lock: {}", err.cause()));
+        protocol_challenger(&lock, &result);
+        assert_eq!(fs::read(&result).expect("contended result"), b"contended\n");
+        holder.release();
+
+        fs::write(&lock, b"x").expect("invalid leaf");
+        protocol_challenger(&lock, &result);
+        assert_eq!(
+            fs::read(&result).expect("invalid result"),
+            b"invalid_or_unopenable\n"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
     #[test]
     fn external_file_lock_protocol() {
         let Ok(mode) = env::var("RUBIN_FILE_LOCK_PROTOCOL_MODE") else {

--- a/clients/rust/crates/rubin-node/src/file_lock.rs
+++ b/clients/rust/crates/rubin-node/src/file_lock.rs
@@ -1,0 +1,280 @@
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LockClass {
+    Contended,
+    InvalidOrUnopenable,
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    UnsupportedHost,
+}
+
+pub(crate) struct HeldFileLock {
+    file: File,
+}
+
+impl HeldFileLock {
+    pub(crate) fn release(self) {
+        drop(self.file);
+    }
+}
+
+pub(crate) struct LockError {
+    class: LockClass,
+    cause: io::Error,
+}
+
+impl LockError {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn invalid(cause: io::Error) -> Self {
+        Self {
+            class: LockClass::InvalidOrUnopenable,
+            cause,
+        }
+    }
+
+    pub(crate) fn class(&self) -> LockClass {
+        self.class
+    }
+
+    pub(crate) fn cause(&self) -> &io::Error {
+        &self.cause
+    }
+}
+
+pub(crate) fn acquire(path: &Path) -> Result<HeldFileLock, LockError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        acquire_supported_host(path)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = path;
+        Err(LockError {
+            class: LockClass::UnsupportedHost,
+            cause: io::Error::new(
+                io::ErrorKind::Unsupported,
+                "datadir writer lock is unsupported on this host",
+            ),
+        })
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn acquire_supported_host(path: &Path) -> Result<HeldFileLock, LockError> {
+    use std::fs::{OpenOptions, TryLockError};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(LockError::invalid)?;
+    let metadata = file.metadata().map_err(LockError::invalid)?;
+    if !metadata.file_type().is_file() {
+        return Err(LockError::invalid(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "datadir lock must be a regular file",
+        )));
+    }
+    if metadata.len() != 0 {
+        return Err(LockError::invalid(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("datadir lock must be empty, got size {}", metadata.len()),
+        )));
+    }
+    if metadata.nlink() != 1 {
+        return Err(LockError::invalid(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("datadir lock must have one link, got {}", metadata.nlink()),
+        )));
+    }
+    match file.try_lock() {
+        Ok(()) => Ok(HeldFileLock { file }),
+        Err(TryLockError::WouldBlock) => Err(LockError {
+            class: LockClass::Contended,
+            cause: io::Error::from(io::ErrorKind::WouldBlock),
+        }),
+        Err(TryLockError::Error(error)) => Err(LockError::invalid(error)),
+    }
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+mod tests {
+    use super::{acquire, LockClass};
+    use std::env;
+    use std::fs;
+    use std::io;
+    use std::os::unix::fs::symlink;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
+
+    type LeafSetup = fn(&Path);
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = env::temp_dir().join(format!(
+            "rubin-node-file-lock-{name}-{}-{nonce}-{}",
+            std::process::id(),
+            NEXT_TEMP_DIR.fetch_add(1, Ordering::Relaxed),
+        ));
+        fs::create_dir(&path)
+            .unwrap_or_else(|err| panic!("create temp dir {}: {err}", path.display()));
+        path
+    }
+
+    fn assert_invalid(path: &Path) {
+        match acquire(path) {
+            Ok(lock) => {
+                lock.release();
+                panic!("unexpectedly acquired {}", path.display());
+            }
+            Err(error) => assert_eq!(error.class(), LockClass::InvalidOrUnopenable),
+        }
+    }
+
+    #[test]
+    fn acquire_contends_until_release_and_leaves_empty_file() {
+        let dir = temp_dir("contended");
+        let path = dir.join("lock");
+        let holder = acquire(&path).unwrap_or_else(|err| panic!("first acquire: {}", err.cause()));
+        let metadata = fs::metadata(&path).unwrap_or_else(|err| panic!("metadata: {err}"));
+        assert!(metadata.file_type().is_file());
+        assert_eq!(metadata.len(), 0);
+
+        match acquire(&path) {
+            Err(error) => assert_eq!(error.class(), LockClass::Contended),
+            Ok(lock) => {
+                lock.release();
+                panic!("second acquire unexpectedly succeeded");
+            }
+        }
+        holder.release();
+        acquire(&path)
+            .unwrap_or_else(|err| panic!("reacquire after release: {}", err.cause()))
+            .release();
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn acquire_rejects_unsafe_leaf_shapes() {
+        let cases: [(&str, LeafSetup); 5] = [
+            ("symlink", |path| {
+                let target = path.with_extension("target");
+                fs::write(&target, []).unwrap_or_else(|err| panic!("write target: {err}"));
+                symlink(target, path).unwrap_or_else(|err| panic!("symlink: {err}"));
+            }),
+            ("dangling_symlink", |path| {
+                symlink(path.with_extension("missing"), path)
+                    .unwrap_or_else(|err| panic!("dangling symlink: {err}"));
+            }),
+            ("directory", |path| {
+                fs::create_dir(path).unwrap_or_else(|err| panic!("mkdir: {err}"));
+            }),
+            ("nonempty_file", |path| {
+                fs::write(path, b"not empty").unwrap_or_else(|err| panic!("write lock: {err}"));
+            }),
+            ("hardlink", |path| {
+                let source = path.with_extension("source");
+                fs::write(&source, []).unwrap_or_else(|err| panic!("write source: {err}"));
+                fs::hard_link(source, path).unwrap_or_else(|err| panic!("hard link: {err}"));
+            }),
+        ];
+        for (name, setup) in cases {
+            let dir = temp_dir(name);
+            let path = dir.join("lock");
+            setup(&path);
+            assert_invalid(&path);
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    // Test-binary-only protocol for an executable built by `cargo test --no-run`.
+    // Set RUBIN_FILE_LOCK_PROTOCOL_MODE to holder or challenger and execute only
+    // this test. The holder needs LOCK_PATH, READY_PATH, and RELEASE_PATH; the
+    // challenger needs LOCK_PATH and RESULT_PATH. Every supplied path is absolute.
+    #[test]
+    fn external_file_lock_protocol() {
+        let Ok(mode) = env::var("RUBIN_FILE_LOCK_PROTOCOL_MODE") else {
+            return;
+        };
+        let lock_path = protocol_absolute_path("RUBIN_FILE_LOCK_PROTOCOL_LOCK_PATH");
+        match mode.as_str() {
+            "holder" => {
+                let ready_path = protocol_absolute_path("RUBIN_FILE_LOCK_PROTOCOL_READY_PATH");
+                let lock_parent = lock_path
+                    .parent()
+                    .unwrap_or_else(|| panic!("lock path has no parent"));
+                assert!(
+                    !ready_path.starts_with(lock_parent),
+                    "ready marker must be outside locked parent: {}",
+                    ready_path.display()
+                );
+                let release_path = protocol_absolute_path("RUBIN_FILE_LOCK_PROTOCOL_RELEASE_PATH");
+                protocol_holder(&lock_path, &ready_path, &release_path);
+            }
+            "challenger" => {
+                let result_path = protocol_absolute_path("RUBIN_FILE_LOCK_PROTOCOL_RESULT_PATH");
+                protocol_challenger(&lock_path, &result_path);
+            }
+            _ => panic!("unknown RUBIN_FILE_LOCK_PROTOCOL_MODE {mode}"),
+        }
+    }
+
+    fn protocol_absolute_path(name: &str) -> PathBuf {
+        let path = PathBuf::from(env::var(name).unwrap_or_else(|_| panic!("{name} must be set")));
+        assert!(path.is_absolute(), "{name} must be absolute");
+        path
+    }
+
+    fn protocol_holder(lock_path: &Path, ready_path: &Path, release_path: &Path) {
+        let lock =
+            acquire(lock_path).unwrap_or_else(|err| panic!("holder acquire: {}", err.cause()));
+        fs::write(ready_path, b"ready\n").unwrap_or_else(|err| panic!("write ready marker: {err}"));
+        wait_for_marker(release_path).unwrap_or_else(|err| panic!("wait release marker: {err}"));
+        lock.release();
+    }
+
+    fn protocol_challenger(lock_path: &Path, result_path: &Path) {
+        let outcome = match acquire(lock_path) {
+            Ok(lock) => {
+                lock.release();
+                "acquired"
+            }
+            Err(error) => match error.class() {
+                LockClass::Contended => "contended",
+                LockClass::InvalidOrUnopenable => "invalid_or_unopenable",
+            },
+        };
+        fs::write(result_path, format!("{outcome}\n"))
+            .unwrap_or_else(|err| panic!("write result marker: {err}"));
+    }
+
+    fn wait_for_marker(path: &Path) -> io::Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match fs::metadata(path) {
+                Ok(_) => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("timeout waiting for {}", path.display()),
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -4109,6 +4109,24 @@ mod tests {
         assert!(!chain_state_path(&create).exists());
         holder.release();
         let _ = fs::remove_dir_all(&create);
+
+        let invalid = unique_temp_dir("rubin-node-lock-invalid");
+        fs::create_dir_all(&invalid).expect("mkdir invalid datadir");
+        let invalid_lock = invalid.join(".rubin.lock");
+        fs::write(&invalid_lock, b"x").expect("write invalid lock");
+        let invalid_name = invalid.display().to_string();
+        let (code, err) = cli(&["--datadir", &invalid_name, "--create-store"]);
+        assert_eq!(code, 2);
+        assert_eq!(
+            err,
+            format!(
+                "cannot open datadir lock {}: datadir lock must be empty, got size 1\n",
+                invalid_lock.display()
+            )
+        );
+        assert!(!block_store_path(&invalid).exists());
+        assert!(!chain_state_path(&invalid).exists());
+        let _ = fs::remove_dir_all(&invalid);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -23,6 +23,9 @@ use rubin_node::{
 };
 use serde::{Deserialize, Serialize};
 
+mod datadir_lock;
+mod file_lock;
+
 const PRODUCTION_STOP_SIGNAL_SET: &str = "SIGINT/SIGTERM";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -140,30 +143,35 @@ fn load_legacy_exposure_scan_chain_state(
     Ok(chain_state)
 }
 
-/// Select the explicit create path or the strict open-existing path. In create
-/// mode the CLI owns the preconditions: the blockstore root must be absent (its
-/// error wins) and the chainstate must be absent, both checked before the datadir
-/// or any store artifact is created.
+/// Select the explicit create path or the strict open-existing path. Mutating
+/// paths return their held datadir lock; dry-run preserves the strict open
+/// without acquiring or creating that lock.
 fn create_or_open_block_store(
     cfg: &CliConfig,
     chain_state_file: &Path,
     stderr: &mut dyn Write,
-) -> Result<BlockStore, i32> {
+) -> Result<(BlockStore, Option<datadir_lock::HeldDatadirLock>), i32> {
     let root_path = block_store_path(&cfg.data_dir);
     if !cfg.create_store {
-        return BlockStore::open(root_path).map_err(|err| {
-            let _ = writeln!(stderr, "blockstore open failed: {err}");
-            2
-        });
-    }
-    for (label, path) in [
-        ("blockstore root", root_path.as_path()),
-        ("chainstate", chain_state_file),
-    ] {
-        if let Err(err) = require_absent_path(label, path) {
-            let _ = writeln!(stderr, "blockstore create failed: {err}");
+        if cfg.dry_run {
+            return open_block_store(&root_path, stderr).map(|store| (store, None));
+        }
+        if let Some(error) = missing_block_store_open_error(&cfg.data_dir, &root_path) {
+            let _ = writeln!(stderr, "blockstore open failed: {error}");
             return Err(2);
         }
+        let lock = datadir_lock::acquire(&cfg.data_dir, stderr)?;
+        return match open_block_store(&root_path, stderr) {
+            Ok(store) => Ok((store, Some(lock))),
+            Err(code) => {
+                lock.release();
+                Err(code)
+            }
+        };
+    }
+    if let Err(err) = require_create_paths(&root_path, chain_state_file) {
+        let _ = writeln!(stderr, "blockstore create failed: {err}");
+        return Err(2);
     }
     if let Err(err) = fs::create_dir_all(&cfg.data_dir) {
         let _ = writeln!(
@@ -173,10 +181,57 @@ fn create_or_open_block_store(
         );
         return Err(2);
     }
-    BlockStore::create(root_path).map_err(|err| {
+    let lock = datadir_lock::acquire(&cfg.data_dir, stderr)?;
+    if let Err(err) = require_create_paths(&root_path, chain_state_file) {
+        lock.release();
         let _ = writeln!(stderr, "blockstore create failed: {err}");
+        return Err(2);
+    }
+    match BlockStore::create(root_path) {
+        Ok(store) => Ok((store, Some(lock))),
+        Err(err) => {
+            lock.release();
+            let _ = writeln!(stderr, "blockstore create failed: {err}");
+            Err(2)
+        }
+    }
+}
+
+fn open_block_store(root_path: &Path, stderr: &mut dyn Write) -> Result<BlockStore, i32> {
+    BlockStore::open(root_path.to_path_buf()).map_err(|err| {
+        let _ = writeln!(stderr, "blockstore open failed: {err}");
         2
     })
+}
+
+fn data_dir_is_missing(path: &Path) -> bool {
+    matches!(
+        fs::symlink_metadata(path),
+        Err(err) if err.kind() == io::ErrorKind::NotFound
+    )
+}
+
+fn missing_block_store_open_error(data_dir: &Path, root_path: &Path) -> Option<String> {
+    if !data_dir_is_missing(data_dir) {
+        return None;
+    }
+    match fs::metadata(root_path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Some(format!(
+            "blockstore directory {}: {error}",
+            root_path.display()
+        )),
+        _ => None,
+    }
+}
+
+fn require_create_paths(root_path: &Path, chain_state_file: &Path) -> Result<(), String> {
+    for (label, path) in [
+        ("blockstore root", root_path),
+        ("chainstate", chain_state_file),
+    ] {
+        require_absent_path(label, path)?;
+    }
+    Ok(())
 }
 
 /// Reject any existing filesystem entry at `path`. `symlink_metadata`, not
@@ -262,10 +317,11 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     // Storage lifecycle runs BEFORE the chainstate load: an uninitialized or
     // half-initialized store must reject before anything reads or writes
     // chainstate. Ordinary startup performs no mkdir at all.
-    let mut block_store = match create_or_open_block_store(&cfg, &chain_state_file, stderr) {
-        Ok(block_store) => block_store,
-        Err(code) => return code,
-    };
+    let (mut block_store, _datadir_lock) =
+        match create_or_open_block_store(&cfg, &chain_state_file, stderr) {
+            Ok(block_store_and_lock) => block_store_and_lock,
+            Err(code) => return code,
+        };
     let mut chain_state = match load_chain_state(&chain_state_file) {
         Ok(chain_state) => chain_state,
         Err(err) => {
@@ -3867,6 +3923,9 @@ mod tests {
             assert!(root.join(sub).is_dir());
         }
         assert!(root.join("index.json").is_file());
+        let lock = fs::metadata(dir.join(".rubin.lock")).expect("datadir lock");
+        assert!(lock.file_type().is_file());
+        assert_eq!(lock.len(), 0);
 
         // Re-create: root exists -> refused, existing store untouched.
         let marker_before = fs::read(root.join("index.json")).expect("marker");
@@ -3891,6 +3950,7 @@ mod tests {
         let both = unique_temp_dir("rubin-node-create-both");
         fs::create_dir_all(block_store_path(&both)).expect("mkdir root");
         fs::write(chain_state_path(&both), b"{}").expect("seed chainstate");
+        fs::write(both.join(".rubin.lock"), b"not empty").expect("seed invalid lock");
         let (code, err) = cli(&mk(&both.display().to_string()));
         assert_eq!(code, 2);
         assert!(err.contains("blockstore root already exists"), "{err}");
@@ -3925,6 +3985,8 @@ mod tests {
     fn open_existing_startup_never_synthesizes_a_store() {
         let dir = unique_temp_dir("rubin-node-open-existing");
         let d = dir.display().to_string();
+        let root_path = block_store_path(&dir);
+        let missing_root_error = fs::metadata(&root_path).expect_err("missing root metadata");
 
         let (code, err) = cli(&["--datadir", &d, "--dry-run"]);
         assert_eq!(code, 2);
@@ -3932,6 +3994,20 @@ mod tests {
         assert!(
             !dir.exists(),
             "ordinary startup must not create the datadir"
+        );
+
+        let (code, err) = cli(&["--datadir", &d]);
+        assert_eq!(code, 2);
+        assert_eq!(
+            err,
+            format!(
+                "blockstore open failed: blockstore directory {}: {missing_root_error}\n",
+                root_path.display()
+            )
+        );
+        assert!(
+            !dir.exists(),
+            "mutating strict open must not create the datadir or lock"
         );
 
         let (code, err) = cli(&[
@@ -3960,6 +4036,128 @@ mod tests {
         let (code, err) = cli(&["--datadir", &d, "--dry-run"]);
         assert_eq!(code, 0, "{err}");
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn strict_open_holds_lock_while_dry_run_does_not() {
+        let dir = unique_temp_dir("rubin-node-strict-open-lock");
+        seed_block_store(&dir);
+        let data_dir = dir.display().to_string();
+        let args = vec!["--datadir".to_string(), data_dir];
+        let cfg = parse_args(&args).expect("parse strict-open config");
+        let chain_state_file = chain_state_path(&dir);
+
+        let (store, lock) =
+            super::create_or_open_block_store(&cfg, &chain_state_file, &mut Vec::new())
+                .expect("mutating strict open");
+        assert_eq!(store.root_dir(), block_store_path(&dir).as_path());
+        let lock = lock.expect("mutating strict open must hold a lock");
+        match super::file_lock::acquire(&dir.join(".rubin.lock")) {
+            Err(error) => assert_eq!(error.class(), super::file_lock::LockClass::Contended),
+            Ok(challenger) => {
+                challenger.release();
+                panic!("mutating strict open did not hold the datadir lock");
+            }
+        }
+        lock.release();
+
+        let mut dry_run = cfg;
+        dry_run.dry_run = true;
+        let (store, lock) =
+            super::create_or_open_block_store(&dry_run, &chain_state_file, &mut Vec::new())
+                .expect("dry-run strict open");
+        assert_eq!(store.root_dir(), block_store_path(&dir).as_path());
+        assert!(lock.is_none(), "dry-run must not hold a lock");
+        super::file_lock::acquire(&dir.join(".rubin.lock"))
+            .unwrap_or_else(|error| panic!("dry-run lock probe: {}", error.cause()))
+            .release();
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn held_datadir_lock_rejects_mutating_lifecycle_before_store_access() {
+        let strict = unique_temp_dir("rubin-node-lock-strict");
+        fs::create_dir_all(&strict).expect("mkdir strict datadir");
+        let strict_name = strict.display().to_string();
+        let holder = super::file_lock::acquire(&strict.join(".rubin.lock"))
+            .unwrap_or_else(|err| panic!("acquire strict lock: {}", err.cause()));
+        let (code, err) = cli(&["--datadir", &strict_name]);
+        assert_eq!(code, 2);
+        assert!(
+            err.contains("datadir is already in use by another rubin-node:"),
+            "{err}"
+        );
+        assert!(!block_store_path(&strict).exists());
+        holder.release();
+        let _ = fs::remove_dir_all(&strict);
+
+        let create = unique_temp_dir("rubin-node-lock-create");
+        fs::create_dir_all(&create).expect("mkdir create datadir");
+        let create_name = create.display().to_string();
+        let holder = super::file_lock::acquire(&create.join(".rubin.lock"))
+            .unwrap_or_else(|err| panic!("acquire create lock: {}", err.cause()));
+        let (code, err) = cli(&["--datadir", &create_name, "--create-store"]);
+        assert_eq!(code, 2);
+        assert!(
+            err.contains("datadir is already in use by another rubin-node:"),
+            "{err}"
+        );
+        assert!(!block_store_path(&create).exists());
+        assert!(!chain_state_path(&create).exists());
+        holder.release();
+        let _ = fs::remove_dir_all(&create);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn read_only_modes_ignore_datadir_lock() {
+        let dir = unique_temp_dir("rubin-node-lock-read-only");
+        let name = dir.display().to_string();
+        let (code, err) = cli(&[
+            "--datadir",
+            &name,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ]);
+        assert_eq!(code, 0, "{err}");
+        let index = fs::read(block_store_path(&dir).join("index.json")).expect("index");
+        let lock_path = dir.join(".rubin.lock");
+
+        let holder = super::file_lock::acquire(&lock_path)
+            .unwrap_or_else(|err| panic!("acquire held lock: {}", err.cause()));
+        assert_read_only_modes(&name);
+        holder.release();
+
+        fs::remove_file(&lock_path).expect("remove valid lock");
+        fs::write(&lock_path, b"not empty").expect("write invalid lock");
+        assert_read_only_modes(&name);
+        assert_eq!(
+            fs::read(block_store_path(&dir).join("index.json")).expect("index"),
+            index
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn assert_read_only_modes(data_dir: &str) {
+        for args in [
+            vec!["--dry-run", "--datadir", data_dir],
+            vec![
+                "--legacy-exposure-scan",
+                "--legacy-suite-id",
+                "1",
+                "--datadir",
+                data_dir,
+            ],
+        ] {
+            let (code, err) = cli(&args);
+            assert_eq!(code, 0, "{args:?}: {err}");
+        }
     }
 
     /// FIX-1 / state machine rule 4: identity guards precede the storage

--- a/clients/rust/fuzz/Cargo.lock
+++ b/clients/rust/fuzz/Cargo.lock
@@ -334,6 +334,7 @@ version = "0.0.0"
 dependencies = [
  "ctrlc",
  "hex",
+ "libc",
  "num-bigint",
  "rubin-consensus",
  "serde",

--- a/scripts/node-runtime-total-parity-gate.sh
+++ b/scripts/node-runtime-total-parity-gate.sh
@@ -15,19 +15,25 @@ run_stage() {
   "$@"
 }
 
-run_stage "Stage 1/5: live Go↔Rust devnet RPC parity smoke" \
+run_stage "Stage 1/7: dry-run storage parity" \
+  "${DEV_ENV}" -- bash -lc "cd '${REPO_ROOT}' && bash scripts/test_node_dry_run_parity.sh"
+
+run_stage "Stage 2/7: storage writer-lock parity" \
+  "${DEV_ENV}" -- bash -lc "cd '${REPO_ROOT}' && bash scripts/test_node_storage_lock_parity.sh datadir"
+
+run_stage "Stage 3/7: live Go↔Rust devnet RPC parity smoke" \
   "${REPO_ROOT}/scripts/devnet-rpc-parity-smoke.sh"
 
-run_stage "Stage 2/5: live Go↔Rust P2P interop coverage" \
+run_stage "Stage 4/7: live Go↔Rust P2P interop coverage" \
   "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop_(GoDialRustServerHandshake|RustClientDialGoServerHandshake|RustServerPingGoClientPong|RustClientReceivesTxFromGo|RustClientSyncsFiveBlocksFromGo)$' -count=1"
 
-run_stage "Stage 3/5: Go relay + txpool lifecycle parity checks" \
+run_stage "Stage 5/7: Go relay + txpool lifecycle parity checks" \
   "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && go test ./node/p2p -run '^(TestAnnounceTx|TestAnnounceTxMetadataError)$' -count=1 && go test ./node -run '^TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool$' -count=1"
 
-run_stage "Stage 4/5: Rust relay + txpool lifecycle parity checks" \
+run_stage "Stage 6/7: Rust relay + txpool lifecycle parity checks" \
   "${DEV_ENV}" -- bash -lc "cd '${RUST_MODULE_ROOT}' && cargo test -p rubin-node handle_received_tx_with_valid_fixture_stores_and_relays -- --test-threads=1 && cargo test -p rubin-node announce_tx_uses_real_metadata_for_relay_pool_priority -- --test-threads=1 && cargo test -p rubin-node apply_block_with_reorg_tip_extension_with_pool -- --test-threads=1 && cargo test -p rubin-node apply_block_with_reorg_tip_extension_removes_conflicting_pool_spends -- --test-threads=1"
 
-run_stage "Stage 5/5: PV/shadow parity soak gate" \
+run_stage "Stage 7/7: PV/shadow parity soak gate" \
   "${REPO_ROOT}/scripts/pv-soak-ci-gate.sh" --report "${PV_REPORT_PATH}"
 
 HEAD_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
@@ -54,6 +60,14 @@ report = {
     "head_sha": head_sha,
     "timestamp_utc": timestamp_utc,
     "stages": [
+        {
+            "name": "dry_run_parity",
+            "command": "bash scripts/test_node_dry_run_parity.sh",
+        },
+        {
+            "name": "storage_lock_parity",
+            "command": "bash scripts/test_node_storage_lock_parity.sh datadir",
+        },
         {
             "name": "live_devnet_rpc_smoke",
             "command": "./scripts/devnet-rpc-parity-smoke.sh",

--- a/scripts/test_node_storage_lock_parity.sh
+++ b/scripts/test_node_storage_lock_parity.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# RUB-1078: cross-client datadir writer-lock evidence.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+[[ $# == 1 && "$1" == datadir ]] || { printf 'usage: %s datadir\n' "${0##*/}" >&2; exit 2; }
+for tool in cmp cp grep ln mkfifo python3 tr; do
+  command -v "${tool}" >/dev/null 2>&1 || { printf 'missing required tool: %s\n' "${tool}" >&2; exit 1; }
+done
+
+# shellcheck source=scripts/devnet-process-common.sh
+source "${REPO_ROOT}/scripts/devnet-process-common.sh"
+rubin_process_init rubin-storage-lock-parity
+ART="${RUBIN_PROCESS_ARTIFACT_ROOT}"
+RESTORE_MODE_DIR=""
+storage_lock_exit_trap() {
+  local status=$? cleanup_status=0
+  [[ -z "${RESTORE_MODE_DIR}" ]] || chmod 0700 "${RESTORE_MODE_DIR}" 2>/dev/null || true
+  rubin_process_cleanup "${status}" || cleanup_status=$?
+  (( status != 0 )) && exit "${status}"
+  exit "${cleanup_status}"
+}
+trap storage_lock_exit_trap EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+node_bin() {
+  case "$1" in
+    go) printf '%s\n' "${GO_NODE}" ;;
+    rust) printf '%s\n' "${RUST_NODE}" ;;
+    *) fail "unknown implementation: $1" ;;
+  esac
+}
+
+# Sorted recursive lstat inventory: path, kind, regular SHA-256 or symlink
+# target, size, mode, device/inode/link count and mtime. atime/ctime are absent.
+snapshot_datadir() {
+  python3 - "$1" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+
+root = os.path.abspath(sys.argv[1])
+if not os.path.isdir(root):
+    raise SystemExit(f"snapshot root is not a directory: {root}")
+def digest(path):
+    value = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            value.update(chunk)
+    return value.hexdigest()
+def row(path):
+    st = os.lstat(path)
+    if stat.S_ISREG(st.st_mode):
+        payload = "sha256:" + digest(path)
+    elif stat.S_ISLNK(st.st_mode):
+        payload = "target:" + os.readlink(path)
+    else:
+        payload = "-"
+    return "\t".join((os.path.relpath(path, root), stat.filemode(st.st_mode)[0], payload,
+        str(st.st_size), format(stat.S_IMODE(st.st_mode), "04o"), str(st.st_dev),
+        str(st.st_ino), str(st.st_nlink), str(st.st_mtime_ns)))
+rows, pending = [], [root]
+while pending:
+    path = pending.pop()
+    st = os.lstat(path)
+    rows.append(row(path))
+    if stat.S_ISDIR(st.st_mode):
+        with os.scandir(path) as directory:
+            pending.extend(sorted((entry.path for entry in directory), key=os.fsencode))
+sys.stdout.write("\n".join(sorted(rows)) + "\n")
+PY
+}
+take_snapshot() { snapshot_datadir "$2" >"$3" || fail "$1: snapshot failed for $2"; }
+assert_same_snapshot() { cmp -s "$2" "$3" || fail "$1: datadir snapshot changed (before=$2 after=$3)"; }
+assert_exact_file() {
+  local expected="${ART}/markers/$1.expected"
+  printf '%s\n' "$3" >"${expected}"
+  cmp -s "${expected}" "$2" || fail "$1: unexpected file content: $2"
+}
+assert_absent() { [[ ! -e "$2" && ! -L "$2" ]] || fail "$1: unexpected artifact exists: $2"; }
+
+mkdir -p "${ART}/markers" "${ART}/fixtures"
+GO_NODE="${ART}/rubin-node-go"
+RUST_NODE="${ART}/rubin-node-rust"
+GO_LOCK_TEST="${ART}/go-filelock.test"
+RUST_LOCK_TEST="${ART}/rust-filelock.test"
+BASH_BIN="${BASH}"
+[[ "${BASH_BIN}" == /* && -x "${BASH_BIN}" ]] || fail 'current Bash binary is not absolute and executable'
+
+echo 'Building Go node and test-only filelock protocol from this checkout'
+"${DEV_ENV}" -- go -C "${REPO_ROOT}/clients/go" build -o "${GO_NODE}" ./cmd/rubin-node
+"${DEV_ENV}" -- go -C "${REPO_ROOT}/clients/go" test -c -o "${GO_LOCK_TEST}" ./internal/filelock
+rust_artifact() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, want_test = sys.argv[1], sys.argv[2] == "test"
+found = None
+with open(path, encoding="utf-8") as source:
+    for raw in source:
+        event = json.loads(raw)
+        target = event.get("target") or {}
+        profile = event.get("profile") or {}
+        if (event.get("reason") == "compiler-artifact" and target.get("name") == "rubin-node"
+                and "bin" in target.get("kind", []) and bool(profile.get("test")) == want_test
+                and event.get("executable")):
+            found = event["executable"]
+if found is None:
+    raise SystemExit("no rubin-node binary artifact")
+print(found)
+PY
+}
+echo 'Building Rust node and test-only filelock protocol from this checkout'
+RUST_BUILD_LOG="${ART}/rust-node-build.jsonl"
+"${DEV_ENV}" -- cargo build --manifest-path "${REPO_ROOT}/clients/rust/Cargo.toml" -p rubin-node \
+  --message-format=json-render-diagnostics >"${RUST_BUILD_LOG}"
+RUST_NODE_SOURCE="$(rust_artifact "${RUST_BUILD_LOG}" node)" || fail 'cargo did not report the Rust node binary'
+[[ -x "${RUST_NODE_SOURCE}" ]] || fail "cargo-reported Rust node is not executable: ${RUST_NODE_SOURCE}"
+cp -- "${RUST_NODE_SOURCE}" "${RUST_NODE}"
+RUST_TEST_LOG="${ART}/rust-filelock-test-build.jsonl"
+"${DEV_ENV}" -- cargo test --manifest-path "${REPO_ROOT}/clients/rust/Cargo.toml" -p rubin-node --no-run \
+  --message-format=json-render-diagnostics >"${RUST_TEST_LOG}"
+RUST_TEST_SOURCE="$(rust_artifact "${RUST_TEST_LOG}" test)" || fail 'cargo did not report the Rust filelock test binary'
+[[ -x "${RUST_TEST_SOURCE}" ]] || fail "cargo-reported Rust test binary is not executable: ${RUST_TEST_SOURCE}"
+cp -- "${RUST_TEST_SOURCE}" "${RUST_LOCK_TEST}"
+
+wait_clean() {
+  local pid="$1" label="$2" rc=0
+  wait "${pid}" || rc=$?
+  (( rc == 0 )) || fail "${label}: process exited ${rc}"
+}
+HOLDER_PID=""
+HOLDER_RELEASE=""
+start_holder() {
+  local impl="$1" label="$2" lock="$3" log="${ART}/${2}.${1}.holder.log" ready="${ART}/markers/${2}.${1}.ready"
+  HOLDER_RELEASE="${ART}/markers/${label}.${impl}.release"
+  case "${impl}" in
+    go) rubin_process_start "${log}" env RUBIN_FILELOCK_PROTOCOL_MODE=holder \
+      RUBIN_FILELOCK_PROTOCOL_LOCK_PATH="${lock}" RUBIN_FILELOCK_PROTOCOL_READY_PATH="${ready}" \
+      RUBIN_FILELOCK_PROTOCOL_RELEASE_PATH="${HOLDER_RELEASE}" "${GO_LOCK_TEST}" \
+      -test.run '^TestFileLockExternalProtocol$' -test.count=1 ;;
+    rust) rubin_process_start "${log}" env RUBIN_FILE_LOCK_PROTOCOL_MODE=holder \
+      RUBIN_FILE_LOCK_PROTOCOL_LOCK_PATH="${lock}" RUBIN_FILE_LOCK_PROTOCOL_READY_PATH="${ready}" \
+      RUBIN_FILE_LOCK_PROTOCOL_RELEASE_PATH="${HOLDER_RELEASE}" "${RUST_LOCK_TEST}" \
+      file_lock::tests::external_file_lock_protocol --exact --nocapture ;;
+    *) fail "${label}: unknown holder ${impl}" ;;
+  esac || fail "${label}: ${impl} holder start"
+  HOLDER_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${ready}" ready 15 "${HOLDER_PID}" || fail "${label}: holder did not publish ready marker"
+  assert_exact_file "${label}.${impl}.ready" "${ready}" ready
+}
+release_holder() { printf 'release\n' >"${HOLDER_RELEASE}"; wait_clean "${HOLDER_PID}" "$1: holder release"; }
+crash_holder() {
+  rubin_process_stop_pid "${HOLDER_PID}" || fail "$1: holder stop failed"
+  rubin_process_is_alive "${HOLDER_PID}" && fail "$1: holder survived stop"
+  return 0
+}
+protocol_challenger() {
+  local impl="$1" label="$2" lock="$3" want="$4" result="${ART}/markers/${2}.${1}.result" rc=0 got
+  case "${impl}" in
+    go) env RUBIN_FILELOCK_PROTOCOL_MODE=challenger RUBIN_FILELOCK_PROTOCOL_LOCK_PATH="${lock}" \
+      RUBIN_FILELOCK_PROTOCOL_RESULT_PATH="${result}" "${GO_LOCK_TEST}" -test.run '^TestFileLockExternalProtocol$' \
+      -test.count=1 >"${ART}/${label}.${impl}.stdout" 2>"${ART}/${label}.${impl}.stderr" || rc=$? ;;
+    rust) env RUBIN_FILE_LOCK_PROTOCOL_MODE=challenger RUBIN_FILE_LOCK_PROTOCOL_LOCK_PATH="${lock}" \
+      RUBIN_FILE_LOCK_PROTOCOL_RESULT_PATH="${result}" "${RUST_LOCK_TEST}" file_lock::tests::external_file_lock_protocol \
+      --exact --nocapture >"${ART}/${label}.${impl}.stdout" 2>"${ART}/${label}.${impl}.stderr" || rc=$? ;;
+    *) fail "${label}: unknown challenger ${impl}" ;;
+  esac
+  (( rc == 0 )) || fail "${label}: ${impl} protocol exited ${rc}"
+  [[ -f "${result}" ]] || fail "${label}: ${impl} did not write a result marker"
+  got="$(tr -d '[:space:]' <"${result}")"
+  [[ "${got}" == "${want}" ]] || fail "${label}: ${impl} result=${got:-<empty>} want=${want}"
+}
+assert_contention() {
+  local holder="$1" challenger="$2" label="$3" dir="${ART}/fixtures/${3}"
+  mkdir -p "${dir}"
+  start_holder "${holder}" "${label}" "${dir}/.rubin.lock"
+  protocol_challenger "${challenger}" "${label}.challenger" "${dir}/.rubin.lock" contended
+  release_holder "${label}"
+}
+assert_alias_contention() {
+  local holder="$1" challenger="$2" label="$3" target="${ART}/fixtures/${3}-target" alias="${ART}/fixtures/${3}-alias"
+  mkdir -p "${target}"
+  ln -s "${target}" "${alias}"
+  start_holder "${holder}" "${label}" "${target}/.rubin.lock"
+  protocol_challenger "${challenger}" "${label}.challenger" "${alias}/.rubin.lock" contended
+  release_holder "${label}"
+}
+assert_invalid() {
+  protocol_challenger go "$1" "$2" invalid_or_unopenable
+  protocol_challenger rust "$1" "$2" invalid_or_unopenable
+}
+
+echo 'Checking test-only same-client and cross-client lock contention'
+assert_contention go go same-go
+assert_contention rust rust same-rust
+assert_contention go rust go-holds-rust-protocol
+assert_contention rust go rust-holds-go-protocol
+REACQUIRE_DIR="${ART}/fixtures/reacquire"
+mkdir -p "${REACQUIRE_DIR}"
+start_holder go release-reacquire "${REACQUIRE_DIR}/.rubin.lock"
+release_holder release-reacquire
+[[ -f "${REACQUIRE_DIR}/.rubin.lock" && ! -s "${REACQUIRE_DIR}/.rubin.lock" ]] || fail 'released lock is not persistent and empty'
+protocol_challenger rust release-reacquire.reopen "${REACQUIRE_DIR}/.rubin.lock" acquired
+CRASH_DIR="${ART}/fixtures/crash-reacquire"
+mkdir -p "${CRASH_DIR}"
+start_holder rust crash-reacquire "${CRASH_DIR}/.rubin.lock"
+crash_holder crash-reacquire
+protocol_challenger go crash-reacquire.reopen "${CRASH_DIR}/.rubin.lock" acquired
+assert_alias_contention go rust parent-alias-go-rust
+assert_alias_contention rust go parent-alias-rust-go
+DISTINCT_A="${ART}/fixtures/distinct-a"
+DISTINCT_B="${ART}/fixtures/distinct-b"
+mkdir -p "${DISTINCT_A}" "${DISTINCT_B}"
+start_holder go distinct-roots "${DISTINCT_A}/.rubin.lock"
+protocol_challenger rust distinct-roots.challenger "${DISTINCT_B}/.rubin.lock" acquired
+release_holder distinct-roots
+
+echo 'Checking unsafe lock leaves, permission denial, and strict missing parents'
+INVALID_DIR="${ART}/fixtures/invalid-leaves"
+mkdir -p "${INVALID_DIR}"
+: >"${INVALID_DIR}/target"
+ln -s "${INVALID_DIR}/target" "${INVALID_DIR}/symlink"
+ln -s "${INVALID_DIR}/missing-target" "${INVALID_DIR}/dangling-symlink"
+mkdir "${INVALID_DIR}/directory"
+mkfifo "${INVALID_DIR}/fifo"
+printf x >"${INVALID_DIR}/nonempty"
+: >"${INVALID_DIR}/hardlink-source"
+ln "${INVALID_DIR}/hardlink-source" "${INVALID_DIR}/hardlink"
+for leaf in symlink dangling-symlink directory fifo nonempty hardlink; do assert_invalid "invalid-${leaf}" "${INVALID_DIR}/${leaf}"; done
+(( EUID != 0 )) || fail 'permission-denial leaf is mandatory but cannot be exercised as uid 0 without a portable unprivileged runner'
+RESTORE_MODE_DIR="${INVALID_DIR}/no-access"
+mkdir "${RESTORE_MODE_DIR}"
+chmod 000 "${RESTORE_MODE_DIR}"
+assert_invalid invalid-permission "${RESTORE_MODE_DIR}/.rubin.lock"
+chmod 0700 "${RESTORE_MODE_DIR}"
+RESTORE_MODE_DIR=""
+MISSING_PARENT="${ART}/fixtures/missing-parent/child"
+assert_invalid missing-parent "${MISSING_PARENT}/.rubin.lock"
+[[ ! -e "${ART}/fixtures/missing-parent" ]] || fail 'strict missing lock parent was created'
+
+LIVE_PID=""
+start_live() {
+  local impl="$1" datadir="$2" label="$3" create="${4:-}" bin rpc log="${ART}/${3}.${1}.live.log"
+  bin="$(node_bin "${impl}")"
+  if [[ "${create}" == create ]]; then
+    rubin_process_start "${log}" "${bin}" --network devnet --datadir "${datadir}" --create-store --mine-blocks 1 --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0
+  else
+    rubin_process_start "${log}" "${bin}" --network devnet --datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0
+  fi || fail "${label}: ${impl} live start"
+  LIVE_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${log}" 'rpc: listening=' 30 "${LIVE_PID}" || fail "${label}: RPC banner"
+  rpc="$(rubin_process_extract_rpc_addr "${log}")" || fail "${label}: RPC address"
+  rubin_process_wait_for_rpc_ready "${rpc}" 30 || fail "${label}: RPC readiness"
+}
+stop_live() {
+  rubin_process_stop_pid "${LIVE_PID}" || fail "$1: live stop failed"
+  rubin_process_is_alive "${LIVE_PID}" && fail "$1: live node survived stop"
+  return 0
+}
+initialize_store() {
+  start_live "$1" "$2" "$3" create
+  stop_live "$3"
+  [[ -f "$2/.rubin.lock" && ! -s "$2/.rubin.lock" ]] || fail "$3: initialized store has no valid persistent lock"
+}
+RUN_RC=0
+RUN_OUT=""
+RUN_ERR=""
+run_node() {
+  local impl="$1" label="$2"
+  shift 2
+  RUN_OUT="${ART}/${label}.${impl}.stdout"
+  RUN_ERR="${ART}/${label}.${impl}.stderr"
+  RUN_RC=0
+  "$(node_bin "${impl}")" "$@" >"${RUN_OUT}" 2>"${RUN_ERR}" || RUN_RC=$?
+}
+assert_contention_error() { assert_exact_file "$1" "${RUN_ERR}" "datadir is already in use by another rubin-node: $2"; }
+assert_live_cross_contention() {
+  local holder="$1" challenger="$2" label="$3" datadir="${ART}/fixtures/${3}" before="${ART}/${3}.before" after="${ART}/${3}.after"
+  initialize_store "${holder}" "${datadir}" "${label}.init"
+  start_live "${holder}" "${datadir}" "${label}.holder"
+  take_snapshot "${label}.before" "${datadir}" "${before}"
+  run_node "${challenger}" "${label}.challenger" --network devnet --datadir "${datadir}" --mine-blocks 1 --mine-exit --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0
+  [[ "${RUN_RC}" == 2 ]] || fail "${label}: contender exit=${RUN_RC}, want=2"
+  assert_contention_error "${label}.challenger.contention" "${datadir}"
+  take_snapshot "${label}.after" "${datadir}" "${after}"
+  assert_same_snapshot "${label}: contender changed held datadir" "${before}" "${after}"
+  stop_live "${label}.holder"
+}
+assert_create_path_contention() {
+  local holder="$1" challenger="$2" label="$3" datadir="${ART}/fixtures/${3}"
+  mkdir -p "${datadir}"
+  start_holder "${holder}" "${label}" "${datadir}/.rubin.lock"
+  run_node "${challenger}" "${label}.challenger" --network devnet --datadir "${datadir}" --create-store --mine-blocks 1 --mine-exit
+  [[ "${RUN_RC}" == 2 ]] || fail "${label}: create contender exit=${RUN_RC}, want=2"
+  assert_contention_error "${label}.challenger.contention" "${datadir}"
+  assert_absent "${label}" "${datadir}/blockstore"
+  assert_absent "${label}" "${datadir}/chainstate.json"
+  release_holder "${label}"
+}
+
+RACE_PID=""
+RACE_ERR=""
+start_race_node() {
+  local impl="$1" label="$2" datadir="$3" gate="$4" bin ready out err log
+  bin="$(node_bin "${impl}")"
+  [[ "${bin}" == /* && -x "${bin}" ]] || fail "${label}: ${impl} race binary is not absolute and executable"
+  ready="${ART}/markers/${label}.${impl}.race.ready"
+  out="${ART}/${label}.${impl}.race.stdout"
+  err="${ART}/${label}.${impl}.race.stderr"
+  log="${ART}/${label}.${impl}.race.log"
+  # shellcheck disable=SC2016 # The wrapper owns these positional parameters.
+  rubin_process_start "${log}" "${BASH_BIN}" -c '
+set -euo pipefail
+ready="$1"; gate="$2"; out="$3"; err="$4"
+shift 4
+[[ -p "${gate}" ]] || exit 2
+printf "ready\n" >"${ready}"
+IFS= read -r token <"${gate}"
+[[ "${token}" == release ]] || exit 2
+exec "$@" >"${out}" 2>"${err}"
+' rubin-race-gate "${ready}" "${gate}" "${out}" "${err}" "${bin}" --network devnet --datadir "${datadir}" --create-store --mine-blocks 1 --mine-exit ||
+    fail "${label}: ${impl} race start"
+  RACE_PID="${RUBIN_PROCESS_LAST_PID}"
+  RACE_ERR="${err}"
+  rubin_process_wait_for_log "${ready}" ready 15 "${RACE_PID}" || fail "${label}: ${impl} race process did not reach barrier"
+  assert_exact_file "${label}.${impl}.race.ready" "${ready}" ready
+}
+release_race_barrier() {
+  local a="$1" b="$2" apid bpid arc=0 brc=0
+  printf 'release\n' >"${a}" & apid=$!
+  printf 'release\n' >"${b}" & bpid=$!
+  wait "${apid}" || arc=$?
+  wait "${bpid}" || brc=$?
+  (( arc == 0 && brc == 0 )) || fail "create race barrier release failed (first=${arc} second=${brc})"
+}
+assert_store_readable() {
+  local label="$1" datadir="$2" impl
+  [[ -d "${datadir}/blockstore" && -f "${datadir}/chainstate.json" && -f "${datadir}/.rubin.lock" && ! -s "${datadir}/.rubin.lock" ]] ||
+    fail "${label}: winner did not leave one readable store, chainstate, and persistent lock"
+  for impl in go rust; do
+    run_node "${impl}" "${label}.${impl}.read" --network devnet --datadir "${datadir}" --dry-run
+    [[ "${RUN_RC}" == 0 && ! -s "${RUN_ERR}" ]] || fail "${label}: ${impl} cannot read winning store (exit=${RUN_RC})"
+    grep -F -q 'blockstore:' "${RUN_OUT}" || fail "${label}: ${impl} read produced no blockstore observation"
+  done
+}
+post_winner_create_refusal() {
+  run_node "$1" "$2.$1.post-create" --network devnet --datadir "$3" --create-store --mine-blocks 1 --mine-exit
+  [[ "${RUN_RC}" == 2 ]] || fail "$2: $1 post-winner create exit=${RUN_RC}, want=2"
+  assert_exact_file "$2.$1.post-create.root-exists" "${RUN_ERR}" "blockstore create failed: blockstore root already exists: $3/blockstore"
+}
+assert_create_race() {
+  local first="$1" second="$2" label="$3" datadir="${ART}/fixtures/${3}" first_gate second_gate first_pid second_pid first_err second_err first_rc=0 second_rc=0 winner loser loser_err actual before after
+  assert_absent "${label}: initial datadir" "${datadir}"
+  first_gate="${ART}/markers/${label}.${first}.gate"
+  second_gate="${ART}/markers/${label}.${second}.gate"
+  mkfifo "${first_gate}" "${second_gate}" || fail "${label}: cannot create FIFO race barrier"
+  start_race_node "${first}" "${label}" "${datadir}" "${first_gate}"
+  first_pid="${RACE_PID}"; first_err="${RACE_ERR}"
+  start_race_node "${second}" "${label}" "${datadir}" "${second_gate}"
+  second_pid="${RACE_PID}"; second_err="${RACE_ERR}"
+  release_race_barrier "${first_gate}" "${second_gate}"
+  wait "${first_pid}" || first_rc=$?
+  wait "${second_pid}" || second_rc=$?
+  printf '%s\n' "${first_rc}" >"${ART}/${label}.${first}.race.exit"
+  printf '%s\n' "${second_rc}" >"${ART}/${label}.${second}.race.exit"
+  if (( first_rc == 0 && second_rc == 2 )); then winner="${first}"; loser="${second}"; loser_err="${second_err}";
+  elif (( first_rc == 2 && second_rc == 0 )); then winner="${second}"; loser="${first}"; loser_err="${first_err}";
+  else fail "${label}: race exits must be exactly one 0 and one 2 (first=${first_rc} second=${second_rc})"; fi
+  printf '%s\n' "${winner}" >"${ART}/${label}.winner"
+  actual="$(<"${loser_err}")"
+  case "${actual}" in
+    "datadir is already in use by another rubin-node: ${datadir}") assert_exact_file "${label}.${loser}.race.contention" "${loser_err}" "${actual}" ;;
+    "blockstore create failed: blockstore root already exists: ${datadir}/blockstore") assert_exact_file "${label}.${loser}.race.root-exists" "${loser_err}" "${actual}" ;;
+    *) fail "${label}: ${loser} race loser emitted no contract-legal refusal" ;;
+  esac
+  before="${ART}/${label}.post.before"; after="${ART}/${label}.post.after"
+  take_snapshot "${label}.post.before" "${datadir}" "${before}"
+  post_winner_create_refusal go "${label}" "${datadir}"
+  post_winner_create_refusal rust "${label}" "${datadir}"
+  take_snapshot "${label}.post.after" "${datadir}" "${after}"
+  assert_same_snapshot "${label}: post-winner create mutated store" "${before}" "${after}"
+  assert_store_readable "${label}" "${datadir}"
+}
+assert_reader() {
+  local reader="$1" mode="$2" label="$3" datadir="$4" holder="${5:-}" before="${ART}/${3}.${1}.before" after="${ART}/${3}.${1}.after" needle
+  take_snapshot "${label}.${reader}.before" "${datadir}" "${before}"
+  [[ -z "${holder}" ]] || rubin_process_is_alive "${holder}" || fail "${label}: holder died before ${reader} ${mode}"
+  case "${mode}" in
+    dry-run) run_node "${reader}" "${label}" --network devnet --datadir "${datadir}" --dry-run; needle='"data_dir"' ;;
+    legacy) run_node "${reader}" "${label}" --network devnet --datadir "${datadir}" --legacy-exposure-scan --legacy-suite-id 1; needle='"report_version"' ;;
+    *) fail "${label}: unknown read-only mode ${mode}" ;;
+  esac
+  [[ -z "${holder}" ]] || rubin_process_is_alive "${holder}" || fail "${label}: holder died after ${reader} ${mode}"
+  [[ "${RUN_RC}" == 0 && ! -s "${RUN_ERR}" ]] || fail "${label}: ${reader} ${mode} failed (exit=${RUN_RC})"
+  grep -F -q "${needle}" "${RUN_OUT}" || fail "${label}: ${reader} ${mode} output missing ${needle}"
+  take_snapshot "${label}.${reader}.after" "${datadir}" "${after}"
+  assert_same_snapshot "${label}: ${reader} ${mode} mutated datadir" "${before}" "${after}"
+}
+assert_readers_with_holder() {
+  local holder="$1" label="$2" datadir="${ART}/fixtures/${2}" mode reader
+  initialize_store "${holder}" "${datadir}" "${label}.init"
+  start_live "${holder}" "${datadir}" "${label}.holder"
+  for mode in dry-run legacy; do for reader in go rust; do assert_reader "${reader}" "${mode}" "${label}.${reader}-${mode}" "${datadir}" "${LIVE_PID}"; done; done
+  stop_live "${label}.holder"
+}
+assert_readers_without_lock() {
+  local label=readonly-no-lock datadir="${ART}/fixtures/readonly-no-lock" lock="${ART}/fixtures/readonly-no-lock/.rubin.lock" mode reader
+  initialize_store go "${datadir}" "${label}.init"
+  [[ -f "${lock}" && ! -s "${lock}" ]] || fail "${label}: prepared store has no removable lock"
+  rm -f -- "${lock}"
+  assert_absent "${label}: pre-reader lock" "${lock}"
+  for mode in dry-run legacy; do for reader in go rust; do assert_reader "${reader}" "${mode}" "${label}.${reader}-${mode}" "${datadir}"; done; done
+  assert_absent "${label}: readers created a lock" "${lock}"
+}
+
+echo 'Checking create-path lock acquisition before store creation'
+assert_create_path_contention go rust create-lock-go-holds-rust
+assert_create_path_contention rust go create-lock-rust-holds-go
+echo 'Checking real Go-holds-Rust and Rust-holds-Go datadir contention'
+assert_live_cross_contention go rust live-go-holds-rust
+assert_live_cross_contention rust go live-rust-holds-go
+echo 'Checking concurrent create/store losers and read-only modes'
+assert_create_race go rust create-race-go-rust
+assert_create_race rust go create-race-rust-go
+assert_readers_with_holder go readonly-go-holder
+assert_readers_with_holder rust readonly-rust-holder
+assert_readers_without_lock
+echo 'PASS: storage lock parity (datadir)'

--- a/scripts/test_node_storage_lock_parity.sh
+++ b/scripts/test_node_storage_lock_parity.sh
@@ -128,32 +128,69 @@ RUST_TEST_SOURCE="$(rust_artifact "${RUST_TEST_LOG}" test)" || fail 'cargo did n
 [[ -x "${RUST_TEST_SOURCE}" ]] || fail "cargo-reported Rust test binary is not executable: ${RUST_TEST_SOURCE}"
 cp -- "${RUST_TEST_SOURCE}" "${RUST_LOCK_TEST}"
 
-wait_clean() {
-  local pid="$1" label="$2" rc=0
-  wait "${pid}" || rc=$?
-  (( rc == 0 )) || fail "${label}: process exited ${rc}"
+wait_managed_exit() {
+  local marker="$1" label="$2" pid="$3"
+  local line="" extra=""
+  rubin_process_wait_for_log "${marker}" 'exit=' 30 "${pid}" || fail "${label}: process did not publish an exit marker"
+  {
+    IFS= read -r line || fail "${label}: malformed exit marker"
+    if IFS= read -r extra || [[ -n "${extra}" ]]; then
+      fail "${label}: malformed exit marker"
+    fi
+  } <"${marker}"
+  case "${line}" in
+    exit=0) return 0 ;;
+    exit=2) return 2 ;;
+    *) fail "${label}: invalid exit marker ${line}" ;;
+  esac
 }
 HOLDER_PID=""
 HOLDER_RELEASE=""
+HOLDER_STATUS=""
 start_holder() {
-  local impl="$1" label="$2" lock="$3" log="${ART}/${2}.${1}.holder.log" ready="${ART}/markers/${2}.${1}.ready"
+  local impl="$1" label="$2" lock="$3" log="${ART}/${2}.${1}.holder.log" ready="${ART}/markers/${2}.${1}.ready" status="${ART}/markers/${2}.${1}.holder.status"
   HOLDER_RELEASE="${ART}/markers/${label}.${impl}.release"
+  # shellcheck disable=SC2016 # The wrapper owns these positional parameters.
   case "${impl}" in
-    go) rubin_process_start "${log}" env RUBIN_FILELOCK_PROTOCOL_MODE=holder \
+    go) rubin_process_start "${log}" "${BASH_BIN}" -c '
+set -euo pipefail
+status="$1"
+shift
+rc=0
+"$@" || rc=$?
+printf "exit=%s\n" "${rc}" >"${status}.tmp.$$"
+mv -f -- "${status}.tmp.$$" "${status}"
+exit "${rc}"
+' rubin-holder-status "${status}" env RUBIN_FILELOCK_PROTOCOL_MODE=holder \
       RUBIN_FILELOCK_PROTOCOL_LOCK_PATH="${lock}" RUBIN_FILELOCK_PROTOCOL_READY_PATH="${ready}" \
       RUBIN_FILELOCK_PROTOCOL_RELEASE_PATH="${HOLDER_RELEASE}" "${GO_LOCK_TEST}" \
       -test.run '^TestFileLockExternalProtocol$' -test.count=1 ;;
-    rust) rubin_process_start "${log}" env RUBIN_FILE_LOCK_PROTOCOL_MODE=holder \
+    rust) rubin_process_start "${log}" "${BASH_BIN}" -c '
+set -euo pipefail
+status="$1"
+shift
+rc=0
+"$@" || rc=$?
+printf "exit=%s\n" "${rc}" >"${status}.tmp.$$"
+mv -f -- "${status}.tmp.$$" "${status}"
+exit "${rc}"
+' rubin-holder-status "${status}" env RUBIN_FILE_LOCK_PROTOCOL_MODE=holder \
       RUBIN_FILE_LOCK_PROTOCOL_LOCK_PATH="${lock}" RUBIN_FILE_LOCK_PROTOCOL_READY_PATH="${ready}" \
       RUBIN_FILE_LOCK_PROTOCOL_RELEASE_PATH="${HOLDER_RELEASE}" "${RUST_LOCK_TEST}" \
       file_lock::tests::external_file_lock_protocol --exact --nocapture ;;
     *) fail "${label}: unknown holder ${impl}" ;;
   esac || fail "${label}: ${impl} holder start"
   HOLDER_PID="${RUBIN_PROCESS_LAST_PID}"
+  HOLDER_STATUS="${status}"
   rubin_process_wait_for_log "${ready}" ready 15 "${HOLDER_PID}" || fail "${label}: holder did not publish ready marker"
   assert_exact_file "${label}.${impl}.ready" "${ready}" ready
 }
-release_holder() { printf 'release\n' >"${HOLDER_RELEASE}"; wait_clean "${HOLDER_PID}" "$1: holder release"; }
+release_holder() {
+  local rc=0
+  printf 'release\n' >"${HOLDER_RELEASE}"
+  wait_managed_exit "${HOLDER_STATUS}" "$1: holder release" "${HOLDER_PID}" || rc=$?
+  (( rc == 0 )) || fail "$1: holder release exited ${rc}"
+}
 crash_holder() {
   rubin_process_stop_pid "${HOLDER_PID}" || fail "$1: holder stop failed"
   rubin_process_is_alive "${HOLDER_PID}" && fail "$1: holder survived stop"
@@ -303,30 +340,35 @@ assert_create_path_contention() {
   release_holder "${label}"
 }
 
-RACE_PID=""
-RACE_ERR=""
+RACE_PID=""; RACE_ERR=""; RACE_STATUS=""
 start_race_node() {
-  local impl="$1" label="$2" datadir="$3" gate="$4" bin ready out err log
+  local impl="$1" label="$2" datadir="$3" gate="$4" bin ready out err log status
   bin="$(node_bin "${impl}")"
   [[ "${bin}" == /* && -x "${bin}" ]] || fail "${label}: ${impl} race binary is not absolute and executable"
   ready="${ART}/markers/${label}.${impl}.race.ready"
   out="${ART}/${label}.${impl}.race.stdout"
   err="${ART}/${label}.${impl}.race.stderr"
   log="${ART}/${label}.${impl}.race.log"
+  status="${ART}/markers/${label}.${impl}.race.status"
   # shellcheck disable=SC2016 # The wrapper owns these positional parameters.
   rubin_process_start "${log}" "${BASH_BIN}" -c '
 set -euo pipefail
-ready="$1"; gate="$2"; out="$3"; err="$4"
-shift 4
+ready="$1"; gate="$2"; out="$3"; err="$4"; status="$5"
+shift 5
 [[ -p "${gate}" ]] || exit 2
 printf "ready\n" >"${ready}"
 IFS= read -r token <"${gate}"
 [[ "${token}" == release ]] || exit 2
-exec "$@" >"${out}" 2>"${err}"
-' rubin-race-gate "${ready}" "${gate}" "${out}" "${err}" "${bin}" --network devnet --datadir "${datadir}" --create-store --mine-blocks 1 --mine-exit ||
+rc=0
+"$@" >"${out}" 2>"${err}" || rc=$?
+printf "exit=%s\n" "${rc}" >"${status}.tmp.$$"
+mv -f -- "${status}.tmp.$$" "${status}"
+exit "${rc}"
+' rubin-race-gate "${ready}" "${gate}" "${out}" "${err}" "${status}" "${bin}" --network devnet --datadir "${datadir}" --create-store --mine-blocks 1 --mine-exit ||
     fail "${label}: ${impl} race start"
   RACE_PID="${RUBIN_PROCESS_LAST_PID}"
   RACE_ERR="${err}"
+  RACE_STATUS="${status}"
   rubin_process_wait_for_log "${ready}" ready 15 "${RACE_PID}" || fail "${label}: ${impl} race process did not reach barrier"
   assert_exact_file "${label}.${impl}.race.ready" "${ready}" ready
 }
@@ -354,18 +396,18 @@ post_winner_create_refusal() {
   assert_exact_file "$2.$1.post-create.root-exists" "${RUN_ERR}" "blockstore create failed: blockstore root already exists: $3/blockstore"
 }
 assert_create_race() {
-  local first="$1" second="$2" label="$3" datadir="${ART}/fixtures/${3}" first_gate second_gate first_pid second_pid first_err second_err first_rc=0 second_rc=0 winner loser loser_err actual before after
+  local first="$1" second="$2" label="$3" datadir="${ART}/fixtures/${3}" first_gate second_gate first_pid second_pid first_err second_err first_status second_status first_rc=0 second_rc=0 winner loser loser_err actual before after
   assert_absent "${label}: initial datadir" "${datadir}"
   first_gate="${ART}/markers/${label}.${first}.gate"
   second_gate="${ART}/markers/${label}.${second}.gate"
   mkfifo "${first_gate}" "${second_gate}" || fail "${label}: cannot create FIFO race barrier"
   start_race_node "${first}" "${label}" "${datadir}" "${first_gate}"
-  first_pid="${RACE_PID}"; first_err="${RACE_ERR}"
+  first_pid="${RACE_PID}"; first_err="${RACE_ERR}"; first_status="${RACE_STATUS}"
   start_race_node "${second}" "${label}" "${datadir}" "${second_gate}"
-  second_pid="${RACE_PID}"; second_err="${RACE_ERR}"
+  second_pid="${RACE_PID}"; second_err="${RACE_ERR}"; second_status="${RACE_STATUS}"
   release_race_barrier "${first_gate}" "${second_gate}"
-  wait "${first_pid}" || first_rc=$?
-  wait "${second_pid}" || second_rc=$?
+  wait_managed_exit "${first_status}" "${label}: ${first} race" "${first_pid}" || first_rc=$?
+  wait_managed_exit "${second_status}" "${label}: ${second} race" "${second_pid}" || second_rc=$?
   printf '%s\n' "${first_rc}" >"${ART}/${label}.${first}.race.exit"
   printf '%s\n' "${second_rc}" >"${ART}/${label}.${second}.race.exit"
   if (( first_rc == 0 && second_rc == 2 )); then winner="${first}"; loser="${second}"; loser_err="${second_err}";


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1078
- GitHub Issue mirror (non-authoritative): #2752

Refs: Q-NODE-DATADIR-WRITER-LOCK-01

## Summary
Add one held, non-blocking Unix writer lock per physical datadir in the Go and Rust nodes. Mutating startup acquires the same inode-compatible lock before storage access, while read-only inspection remains lock-free. Add source-built same-client and cross-client lifecycle evidence and wire both the existing dry-run parity harness and the new writer-lock harness into the aggregate parity gate.

## Invariant
On supported production hosts (Linux and macOS), exactly one mutating `rubin-node` process may own one physical datadir at a time, while `--dry-run` and `--legacy-exposure-scan` never create or acquire the writer lock and remain usable as explicitly non-atomic read-only observations of a live node.

## Scope
- Changed files: 16
- Surfaces: clients/go, clients/rust, tooling
- Non-scope: Windows production support; network-filesystem guarantees; PID, heartbeat, retry, stale-lock reaping, lock bypass, storage-schema changes, consensus changes, and wire changes.
- Consensus rules unchanged: YES — no consensus rules or authoritative stored bytes are changed.
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash scripts/test_node_storage_lock_parity.sh datadir` — PASS; `scripts/dev-env.sh -- bash scripts/node-runtime-total-parity-gate.sh` — PASS

## Follow-ups / Waivers
- None.