### PR TITLE
RUB-1084: bound atomic scratch per storage parent

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -465,6 +465,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if datadirLock != nil {
 		defer func() { _ = datadirLock.Release() }()
 	}
+	if !*dryRun {
+		var reclaimErr error
+		if *createStore {
+			reclaimErr = node.ReclaimAtomicWriteScratchInParent(cfg.DataDir)
+		} else {
+			reclaimErr = node.ReclaimAtomicWriteScratch(cfg.DataDir)
+		}
+		if reclaimErr != nil {
+			_, _ = fmt.Fprintf(stderr, "%v\n", reclaimErr)
+			return 2
+		}
+	}
 	chainState, err := node.LoadChainState(chainStatePath)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "chainstate load failed: %v\n", err)

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -2867,6 +2867,132 @@ func TestRunDryRunWritesNothing(t *testing.T) {
 	assertNoFilesystemWrite(t, before, datadirSnapshot(t, dir))
 }
 
+func TestRunMutatingStartupReclaimsFixedScratchBeforeChainStateLoad(t *testing.T) {
+	dir := t.TempDir()
+	storeRoot := node.BlockStorePath(dir)
+	if _, err := node.CreateBlockStore(storeRoot); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	parents := []string{
+		dir,
+		storeRoot,
+		filepath.Join(storeRoot, "blocks"),
+		filepath.Join(storeRoot, "headers"),
+		filepath.Join(storeRoot, "undo"),
+	}
+	for _, parent := range parents {
+		if err := os.WriteFile(filepath.Join(parent, ".rubin-atomic-write.tmp"), []byte("crash residue"), 0o600); err != nil {
+			t.Fatalf("seed scratch in %s: %v", parent, err)
+		}
+	}
+	if err := os.WriteFile(node.ChainStatePath(dir), []byte("{"), 0o600); err != nil {
+		t.Fatalf("seed malformed chainstate: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := run([]string{"--datadir", dir}, &out, &errOut); code != 2 {
+		t.Fatalf("run code=%d, want 2 (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "chainstate load failed") {
+		t.Fatalf("startup did not reach chainstate load after reclaim: %q", errOut.String())
+	}
+	for _, parent := range parents {
+		if _, err := os.Lstat(filepath.Join(parent, ".rubin-atomic-write.tmp")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("scratch remained in %s: %v", parent, err)
+		}
+	}
+}
+
+func TestRunReadOnlyModesLeaveFixedScratchAndLockUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args func(string) []string
+	}{
+		{name: "dry_run", args: func(dir string) []string { return []string{"--dry-run", "--datadir", dir} }},
+		{name: "legacy_exposure_scan", args: func(dir string) []string {
+			return []string{"--legacy-exposure-scan", "--legacy-suite-id", "1", "--datadir", dir}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := preparedDatadir(t)
+			storeRoot := node.BlockStorePath(dir)
+			parents := []string{
+				dir,
+				storeRoot,
+				filepath.Join(storeRoot, "blocks"),
+				filepath.Join(storeRoot, "headers"),
+				filepath.Join(storeRoot, "undo"),
+			}
+			for _, parent := range parents {
+				if err := os.Remove(filepath.Join(parent, ".rubin-atomic-write.lock")); err != nil && !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("remove setup lock in %s: %v", parent, err)
+				}
+				if err := os.WriteFile(filepath.Join(parent, ".rubin-atomic-write.tmp"), []byte(parent), 0o600); err != nil {
+					t.Fatalf("seed scratch in %s: %v", parent, err)
+				}
+			}
+			before := datadirSnapshot(t, dir)
+			var out, errOut bytes.Buffer
+			if code := run(tc.args(dir), &out, &errOut); code != 0 {
+				t.Fatalf("read-only run code=%d (stderr=%q)", code, errOut.String())
+			}
+			assertNoFilesystemWrite(t, before, datadirSnapshot(t, dir))
+			for _, parent := range parents {
+				if _, err := os.Lstat(filepath.Join(parent, ".rubin-atomic-write.lock")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("read-only run opened or created a reserved lock in %s: %v", parent, err)
+				}
+				if _, err := os.Lstat(filepath.Join(parent, ".rubin-atomic-write.tmp")); err != nil {
+					t.Fatalf("read-only run removed scratch in %s: %v", parent, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunFailsClosedWhenFixedScratchIsDirectoryBeforeChainStateLoad(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		createStore bool
+	}{
+		{name: "existing_store"},
+		{name: "fresh_store", createStore: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if !tc.createStore {
+				if _, err := node.CreateBlockStore(node.BlockStorePath(dir)); err != nil {
+					t.Fatalf("CreateBlockStore: %v", err)
+				}
+			}
+			scratch := filepath.Join(dir, ".rubin-atomic-write.tmp")
+			if err := os.Mkdir(scratch, 0o700); err != nil {
+				t.Fatalf("mkdir scratch: %v", err)
+			}
+			args := []string{"--datadir", dir}
+			if tc.createStore {
+				args = append(args, "--create-store")
+			}
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			if code := run(args, &out, &errOut); code != 2 {
+				t.Fatalf("run code=%d, want 2 (stderr=%q)", code, errOut.String())
+			}
+			wantPrefix := "atomic scratch reclaim failed: " + dir + ":"
+			if !strings.Contains(errOut.String(), wantPrefix) {
+				t.Fatalf("stderr=%q, want prefix %q", errOut.String(), wantPrefix)
+			}
+			info, err := os.Stat(scratch)
+			if err != nil || !info.IsDir() {
+				t.Fatalf("scratch directory changed: info=%v err=%v", info, err)
+			}
+			if _, err := os.Lstat(node.ChainStatePath(dir)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("reclaim failure reached chainstate load or write: %v", err)
+			}
+		})
+	}
+}
+
 // TestRunDryRunReportsStaleChainStateWithoutRepairing pins the shape that
 // makes the reconcile want to mutate: a snapshot reset to genesis while the
 // blockstore still holds canonical blocks. --dry-run must print the

--- a/clients/go/cmd/rubin-node/main_unix_test.go
+++ b/clients/go/cmd/rubin-node/main_unix_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -90,6 +91,39 @@ func TestRunChainstateSaveFailsWhenDatadirNotWritable(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), "chainstate save failed") {
 		t.Fatalf("must reach and fail at the save, got stderr=%q", errOut.String())
+	}
+}
+
+func TestRunReclaimSyncFailureStopsBeforeChainStateLoad(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := preparedDatadir(t)
+	scratch := filepath.Join(dir, ".rubin-atomic-write.tmp")
+	if err := os.WriteFile(scratch, []byte("crash residue"), 0o600); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := os.WriteFile(node.ChainStatePath(dir), []byte("{"), 0o600); err != nil {
+		t.Fatalf("seed malformed chainstate: %v", err)
+	}
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod execute-only datadir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	if code := run([]string{"--datadir", dir}, &out, &errOut); code != 2 {
+		t.Fatalf("run code=%d, want 2 (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "atomic scratch reclaim failed: "+dir+":") || strings.Contains(errOut.String(), "chainstate load failed") {
+		t.Fatalf("reclaim sync failure did not stop before chainstate load: %q", errOut.String())
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore datadir mode: %v", err)
+	}
+	if _, err := os.Lstat(scratch); !os.IsNotExist(err) {
+		t.Fatalf("reclaim did not unlink scratch before strict sync failure: %v", err)
 	}
 }
 

--- a/clients/go/node/atomic_unlink_test.go
+++ b/clients/go/node/atomic_unlink_test.go
@@ -1,0 +1,378 @@
+//go:build darwin || linux
+
+package node
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/internal/filelock"
+)
+
+type atomicScratchStub struct{ writeErr, syncErr, closeErr, chmodErr error }
+
+func mustAtomic(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireAtomicTest(t *testing.T, ok bool, format string, args ...any) {
+	t.Helper()
+	if !ok {
+		t.Fatalf(format, args...)
+	}
+}
+
+func atomicStubOpen(stub *atomicScratchStub) func(string, int, os.FileMode) (atomicWriteScratchFile, error) {
+	return func(string, int, os.FileMode) (atomicWriteScratchFile, error) { return stub, nil }
+}
+
+func (f *atomicScratchStub) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+func (f *atomicScratchStub) Sync() error             { return f.syncErr }
+func (f *atomicScratchStub) Close() error            { return f.closeErr }
+func (f *atomicScratchStub) Chmod(os.FileMode) error { return f.chmodErr }
+func withAtomicWriteOps(t *testing.T, mutate func(*atomicWriteOps)) {
+	t.Helper()
+	previous, next := atomicWriteIO, atomicWriteIO
+	mutate(&next)
+	atomicWriteIO = next
+	t.Cleanup(func() { atomicWriteIO = previous })
+}
+
+func requireAtomicWriteError(t *testing.T, err error, stage atomicWriteStage, operation atomicWriteOperation) *atomicWriteError {
+	t.Helper()
+	var got *atomicWriteError
+	requireAtomicTest(t, err != nil && errors.As(err, &got) && got.stage == stage && got.operation == operation, "atomic error=%+v, want stage=%q operation=%q", err, stage, operation)
+	return got
+}
+
+func atomicTestPath(t *testing.T, leaf string) string {
+	path := filepath.Join(t.TempDir(), leaf)
+	mustAtomic(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	return path
+}
+
+var atomicDestinationClasses = []string{"blockstore/blocks/block.bin", "blockstore/headers/header.bin", "blockstore/undo/undo.bin", "blockstore/index.json", "chainstate.json"}
+
+func TestAtomicWriteRejectsReservedDestinationBeforeReadOrMutation(t *testing.T) {
+	for _, leaf := range []string{atomicWriteLockLeaf, atomicWriteScratchLeaf} {
+		t.Run(leaf, func(t *testing.T) {
+			path, previousRead := atomicTestPath(t, leaf), readFileByPathFn
+			var reads, opens, unlinks, syncs atomic.Int32
+			readFileByPathFn = func(string, int64) ([]byte, error) { reads.Add(1); return nil, errors.New("read") }
+			t.Cleanup(func() { readFileByPathFn = previousRead })
+			withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+				ops.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) {
+					opens.Add(1)
+					return &atomicScratchStub{}, nil
+				}
+				ops.unlink = func(string) error { unlinks.Add(1); return nil }
+				ops.syncParent = func(string) error { syncs.Add(1); return nil }
+			})
+			for _, row := range []struct {
+				name string
+				op   atomicWriteOperation
+				call func() error
+			}{
+				{"overwrite", atomicWriteOverwrite, func() error { return writeFileAtomic(path, []byte("p"), 0o600) }},
+				{"create", atomicWriteCreateIfAbsent, func() error { return writeFileIfAbsent(path, []byte("p")) }},
+			} {
+				t.Run(row.name, func(t *testing.T) { requireAtomicWriteError(t, row.call(), atomicWriteBeforeNamespaceCommit, row.op) })
+			}
+			requireAtomicTest(t, reads.Load()+opens.Load()+unlinks.Load()+syncs.Load() == 0, "reserved destination touched helpers: read=%d open=%d unlink=%d sync=%d", reads.Load(), opens.Load(), unlinks.Load(), syncs.Load())
+		})
+	}
+}
+
+func TestAtomicWriteExactMatchIsLockAndScratchFreeButStrictlyResyncs(t *testing.T) {
+	path := atomicTestPath(t, "block.bin")
+	mustAtomic(t, os.WriteFile(path, []byte("same"), 0o600))
+	mustAtomic(t, os.Chmod(path, 0o644))
+	var open, unlink, sync atomic.Int32
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		parentSync := ops.syncParent
+		ops.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) {
+			open.Add(1)
+			return &atomicScratchStub{}, nil
+		}
+		ops.unlink = func(string) error { unlink.Add(1); return nil }
+		ops.syncParent = func(parent string) error { sync.Add(1); return parentSync(parent) }
+	})
+	mustAtomic(t, writeFileIfAbsent(path, []byte("same")))
+	requireAtomicTest(t, open.Load()+unlink.Load() == 0 && sync.Load() == 1, "exact match write lane: open=%d unlink=%d sync=%d", open.Load(), unlink.Load(), sync.Load())
+	assertNodePathMode(t, path, 0o644)
+	for _, leaf := range []string{atomicWriteLockLeaf, atomicWriteScratchLeaf} {
+		_, err := os.Lstat(filepath.Join(filepath.Dir(path), leaf))
+		requireAtomicTest(t, errors.Is(err, os.ErrNotExist), "exact match created %s: %v", leaf, err)
+	}
+	syncErr := errors.New("sync existing")
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) { ops.syncParent = func(string) error { return syncErr } })
+	got := requireAtomicWriteError(t, writeFileIfAbsent(path, []byte("same")), atomicWriteAfterNamespaceCommit, atomicWriteCreateIfAbsent)
+	requireAtomicTest(t, errors.Is(got, syncErr), "exact match sync: %+v", got)
+}
+
+func TestAtomicWriteSameProcessSerializesSameAndDifferentDestinations(t *testing.T) {
+	for _, paths := range [][2]string{{"one", "one"}, {"one", "two"}} {
+		t.Run(paths[0]+"_"+paths[1], func(t *testing.T) {
+			dir, first, second, release := t.TempDir(), make(chan struct{}), make(chan struct{}), make(chan struct{})
+			var opens atomic.Int32
+			withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+				ops.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) {
+					if opens.Add(1) == 1 {
+						close(first)
+						<-release
+					} else {
+						close(second)
+					}
+					return &atomicScratchStub{}, nil
+				}
+				ops.unlink, ops.rename, ops.syncParent = func(string) error { return nil }, func(string, string) error { return nil }, func(string) error { return nil }
+			})
+			done := make(chan error, 2)
+			go func() { done <- writeFileAtomic(filepath.Join(dir, paths[0]), []byte("one"), 0o600) }()
+			<-first
+			go func() { done <- writeFileAtomic(filepath.Join(dir, paths[1]), []byte("two"), 0o600) }()
+			select {
+			case <-second:
+				t.Fatal("second writer entered scratch window")
+			case <-time.After(100 * time.Millisecond):
+			}
+			close(release)
+			mustAtomic(t, <-done)
+			mustAtomic(t, <-done)
+		})
+	}
+}
+
+func TestAtomicWriteParentAliasUsesOnePhysicalReservedLock(t *testing.T) {
+	physical, alias := t.TempDir(), filepath.Join(t.TempDir(), "alias")
+	mustAtomic(t, os.Symlink(physical, alias))
+	holder, _, err := filelock.Acquire(filepath.Join(physical, atomicWriteLockLeaf))
+	mustAtomic(t, err)
+	t.Cleanup(func() { _ = holder.Release() })
+	path := filepath.Join(alias, "two")
+	requireAtomicTest(t, requireAtomicWriteError(t, writeFileAtomic(path, []byte("two"), 0o600), atomicWriteBeforeNamespaceCommit, atomicWriteOverwrite).primary != nil, "missing lock cause")
+	_, err = os.Lstat(path)
+	requireAtomicTest(t, errors.Is(err, os.ErrNotExist), "contended alias created destination: %v", err)
+	mustAtomic(t, holder.Release())
+	mustAtomic(t, writeFileAtomic(path, []byte("two"), 0o600))
+	a, err := os.Stat(filepath.Join(physical, atomicWriteLockLeaf))
+	mustAtomic(t, err)
+	b, err := os.Stat(filepath.Join(alias, atomicWriteLockLeaf))
+	mustAtomic(t, err)
+	requireAtomicTest(t, os.SameFile(a, b), "parent aliases have different lock inodes")
+}
+
+func TestAtomicUnlinkOnlyRemovesExactLeafShapes(t *testing.T) {
+	for _, row := range []struct {
+		name    string
+		seed    func(string) error
+		refused bool
+	}{
+		{"missing", func(string) error { return nil }, false},
+		{"regular", func(p string) error { return os.WriteFile(p, []byte("x"), 0o600) }, false},
+		{"fifo", func(p string) error { return syscall.Mkfifo(p, 0o600) }, false},
+		{"live_symlink", func(p string) error {
+			target := filepath.Join(filepath.Dir(p), "live")
+			mustAtomic(t, os.WriteFile(target, []byte("x"), 0o600))
+			return os.Symlink(target, p)
+		}, false},
+		{"dangling_symlink", func(p string) error { return os.Symlink("missing", p) }, false},
+		{"directory", func(p string) error { return os.Mkdir(p, 0o700) }, true},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			path := atomicTestPath(t, atomicWriteScratchLeaf)
+			mustAtomic(t, row.seed(path))
+			err := atomicUnlink(path)
+			requireAtomicTest(t, (err != nil) == row.refused, "unlink err=%v refused=%v", err, row.refused)
+			if row.refused {
+				info, err := os.Stat(path)
+				requireAtomicTest(t, err == nil && info.IsDir(), "directory changed: %v %v", info, err)
+			} else if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("scratch remains: %v", err)
+			}
+		})
+	}
+	t.Run("hardlink", func(t *testing.T) {
+		dir := t.TempDir()
+		live := filepath.Join(dir, "live")
+		scratch := filepath.Join(dir, atomicWriteScratchLeaf)
+		mustAtomic(t, os.WriteFile(live, []byte("live"), 0o600))
+		mustAtomic(t, os.Link(live, scratch))
+		mustAtomic(t, atomicUnlink(scratch))
+		got, err := os.ReadFile(live)
+		requireAtomicTest(t, err == nil && bytes.Equal(got, []byte("live")), "live=%q err=%v", got, err)
+		n := osStatNlink(t, live)
+		requireAtomicTest(t, n == 1, "nlink=%d", n)
+	})
+}
+
+func osStatNlink(t *testing.T, path string) uint64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	mustAtomic(t, err)
+	return uint64(info.Sys().(*syscall.Stat_t).Nlink)
+}
+
+func TestAtomicWriteCreatesExact0600AcrossUmasks(t *testing.T) {
+	for _, mask := range []int{0, 0o22, 0o77} {
+		t.Run(strconv.Itoa(mask), func(t *testing.T) {
+			old := syscall.Umask(mask)
+			t.Cleanup(func() { syscall.Umask(old) })
+			var modes []os.FileMode
+			withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+				rename, link := ops.rename, ops.link
+				capture := func(s string) {
+					info, err := os.Stat(s)
+					mustAtomic(t, err)
+					modes = append(modes, info.Mode().Perm())
+				}
+				ops.rename = func(s, d string) error { capture(s); return rename(s, d) }
+				ops.link = func(s, d string) error { capture(s); return link(s, d) }
+			})
+			overwrite, create := atomicTestPath(t, "overwrite"), atomicTestPath(t, "create")
+			mustAtomic(t, os.WriteFile(overwrite, []byte("old"), 0o600))
+			mustAtomic(t, os.Chmod(overwrite, 0o644))
+			mustAtomic(t, writeFileAtomic(overwrite, []byte("new"), 0o600))
+			mustAtomic(t, writeFileIfAbsent(create, []byte("new")))
+			for _, mode := range modes {
+				requireAtomicTest(t, mode == 0o600, "scratch mode=%04o", mode)
+			}
+			assertNodePathMode(t, overwrite, 0o600)
+			assertNodePathMode(t, create, 0o600)
+		})
+	}
+}
+
+type atomicPreCommitCase struct {
+	name      string
+	operation atomicWriteOperation
+	primary   error
+	preUnlink bool
+	cleanup   bool
+	configure func(*atomicWriteOps, error)
+	resolve   bool
+}
+
+func assertAtomicPreCommit(t *testing.T, tc atomicPreCommitCase, path string) {
+	t.Helper()
+	unlinks, syncs := 0, 0
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		ops.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) { return &atomicScratchStub{}, nil }
+		ops.unlink = func(string) error {
+			unlinks++
+			if tc.preUnlink && unlinks == 1 {
+				return tc.primary
+			}
+			if tc.cleanup && unlinks == 2 {
+				return syscall.EACCES
+			}
+			return nil
+		}
+		ops.syncParent = func(string) error {
+			syncs++
+			if tc.cleanup {
+				return syscall.EIO
+			}
+			return nil
+		}
+		if tc.configure != nil {
+			tc.configure(ops, tc.primary)
+		}
+	})
+	resolve := func() error { return nil }
+	if tc.resolve {
+		resolve = func() error { return tc.primary }
+	}
+	got := requireAtomicWriteError(t, writeAtomicFile(path, []byte("p"), tc.operation, resolve), atomicWriteBeforeNamespaceCommit, tc.operation)
+	requireAtomicTest(t, got.destination == path && errors.Is(got.primary, tc.primary), "destination=%q primary=%v", got.destination, got.primary)
+	if tc.cleanup {
+		requireAtomicTest(t, unlinks == 2 && syncs == 1 && len(got.secondary) == 2 && errors.Is(got.secondary[0], syscall.EACCES) && errors.Is(got.secondary[1], syscall.EIO), "cleanup order: unlink=%d sync=%d secondary=%v", unlinks, syncs, got.secondary)
+	} else if unlinks != 1 || syncs != 0 || len(got.secondary) != 0 {
+		t.Fatalf("pre-unlink order: unlink=%d sync=%d secondary=%v", unlinks, syncs, got.secondary)
+	}
+}
+
+func TestAtomicWritePreCommitPrecedenceAcrossFrozenDestinations(t *testing.T) {
+	cases := []atomicPreCommitCase{
+		{"scratch_pre_unlink", atomicWriteOverwrite, errors.New("scratch pre-unlink"), true, false, nil, false},
+		{"exclusive_open", atomicWriteOverwrite, errors.New("exclusive open"), false, true, func(o *atomicWriteOps, e error) {
+			o.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) { return nil, e }
+		}, false},
+		{"scratch_mode", atomicWriteOverwrite, errors.New("scratch mode"), false, true, func(o *atomicWriteOps, e error) { o.openScratch = atomicStubOpen(&atomicScratchStub{chmodErr: e}) }, false},
+		{"write", atomicWriteOverwrite, syscall.ENOSPC, false, true, func(o *atomicWriteOps, e error) { o.openScratch = atomicStubOpen(&atomicScratchStub{writeErr: e}) }, false},
+		{"file_sync", atomicWriteOverwrite, syscall.ENOSPC, false, true, func(o *atomicWriteOps, e error) { o.openScratch = atomicStubOpen(&atomicScratchStub{syncErr: e}) }, false},
+		{"rename", atomicWriteOverwrite, errors.New("rename"), false, true, func(o *atomicWriteOps, e error) { o.rename = func(string, string) error { return e } }, false},
+		{"link", atomicWriteCreateIfAbsent, errors.New("link"), false, true, func(o *atomicWriteOps, e error) { o.link = func(string, string) error { return e } }, false},
+		{"eexist_decision", atomicWriteCreateIfAbsent, errors.New("existing mismatch"), false, true, func(o *atomicWriteOps, _ error) { o.link = func(string, string) error { return os.ErrExist } }, true},
+	}
+	for _, tc := range cases {
+		for _, class := range atomicDestinationClasses {
+			t.Run(tc.name+"/"+class, func(t *testing.T) { assertAtomicPreCommit(t, tc, atomicTestPath(t, class)) })
+		}
+	}
+}
+
+func TestAtomicWriteGoClosePrecedenceIsSeparate(t *testing.T) {
+	tc := atomicPreCommitCase{"go_close", atomicWriteOverwrite, errors.New("close"), false, true, func(o *atomicWriteOps, e error) { o.openScratch = atomicStubOpen(&atomicScratchStub{closeErr: e}) }, false}
+	for _, class := range atomicDestinationClasses {
+		t.Run(class, func(t *testing.T) { assertAtomicPreCommit(t, tc, atomicTestPath(t, class)) })
+	}
+}
+
+func TestAtomicWritePostCommitUnlinkThenSyncPrecedence(t *testing.T) {
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		calls := 0
+		ops.openScratch = func(string, int, os.FileMode) (atomicWriteScratchFile, error) { return &atomicScratchStub{}, nil }
+		ops.unlink = func(string) error {
+			calls++
+			if calls == 2 {
+				return syscall.EACCES
+			}
+			return nil
+		}
+		ops.rename = func(string, string) error { return nil }
+		ops.syncParent = func(string) error { return syscall.EIO }
+	})
+	got := requireAtomicWriteError(t, writeFileAtomic(atomicTestPath(t, "destination"), []byte("p"), 0o600), atomicWriteAfterNamespaceCommit, atomicWriteOverwrite)
+	requireAtomicTest(t, errors.Is(got.primary, syscall.EACCES) && len(got.secondary) == 1 && errors.Is(got.secondary[0], syscall.EIO), "postcommit precedence: %+v", got)
+	var nilAtomic *atomicWriteError
+	requireAtomicTest(t, nilAtomic.Error() == "" && nilAtomic.Unwrap() == nil && bytes.Contains([]byte(got.Error()), []byte("cleanup:")) && errors.Is(got, syscall.EIO), "postcommit error: %+v", got)
+	release := errors.New("release")
+	got = requireAtomicWriteError(t, appendAtomicWriteReleaseError(nil, false, "destination", atomicWriteOverwrite, release), atomicWriteBeforeNamespaceCommit, atomicWriteOverwrite)
+	requireAtomicTest(t, errors.Is(got, release), "release error: %+v", got)
+}
+
+func TestReclaimAtomicWriteScratchUsesOnlyFiveFrozenParentsInOrder(t *testing.T) {
+	dir := t.TempDir()
+	root := BlockStorePath(dir)
+	want := []string{dir, root, filepath.Join(root, "blocks"), filepath.Join(root, "headers"), filepath.Join(root, "undo")}
+	for _, parent := range want {
+		mustAtomic(t, os.MkdirAll(parent, 0o700))
+		mustAtomic(t, os.WriteFile(filepath.Join(parent, atomicWriteScratchLeaf), []byte("x"), 0o600))
+	}
+	var unlinked, synced []string
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		unlink, sync := ops.unlink, ops.syncParent
+		ops.unlink = func(path string) error { unlinked = append(unlinked, path); return unlink(path) }
+		ops.syncParent = func(path string) error { synced = append(synced, path); return sync(path) }
+	})
+	mustAtomic(t, ReclaimAtomicWriteScratch(dir))
+	for i, parent := range want {
+		requireAtomicTest(t, unlinked[i] == filepath.Join(parent, atomicWriteScratchLeaf) && synced[i] == parent, "reclaim[%d]=%q/%q", i, unlinked[i], synced[i])
+	}
+}

--- a/clients/go/node/atomic_unlink_unix.go
+++ b/clients/go/node/atomic_unlink_unix.go
@@ -1,0 +1,19 @@
+//go:build darwin || linux
+
+package node
+
+import (
+	"errors"
+	"syscall"
+)
+
+// atomicUnlink removes one exact directory entry with unlink(2). It never
+// follows the final component and never falls back to rmdir, so a scratch
+// directory is rejected rather than removed.
+func atomicUnlink(path string) error {
+	err := syscall.Unlink(path)
+	if errors.Is(err, syscall.ENOENT) {
+		return nil
+	}
+	return err
+}

--- a/clients/go/node/atomic_unlink_unsupported.go
+++ b/clients/go/node/atomic_unlink_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package node
+
+import "errors"
+
+func atomicUnlink(_ string) error {
+	return errors.New("atomic scratch unlink is unsupported on this host")
+}

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -109,6 +109,23 @@ func OpenBlockStore(rootPath string) (*BlockStore, error) {
 	return newBlockStore(paths, index)
 }
 
+// reloadFromDisk read-only replaces this store's visible index/cache in place.
+func (bs *BlockStore) reloadFromDisk() error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	refreshed, err := OpenBlockStore(bs.rootPath)
+	if err != nil {
+		return err
+	}
+	bs.stateMu.Lock()
+	defer bs.stateMu.Unlock()
+	bs.index = refreshed.index
+	bs.canonicalHeightByHash = refreshed.canonicalHeightByHash
+	bs.chainWorkByHash = refreshed.chainWorkByHash
+	return nil
+}
+
 // requireInitialized checks the resolved filesystem kind of every path the store
 // needs. Stat, not Lstat: symlinks resolve normally on open.
 func (p blockStorePaths) requireInitialized() error {

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -206,11 +206,6 @@ func TestWriteFileIfAbsentRejectsDifferentContent(t *testing.T) {
 }
 
 func TestWriteFileIfAbsentPropagatesReadError(t *testing.T) {
-	// Only the readFileByPathFn injection is relevant after the E.3
-	// TOCTOU hardening: writeFileIfAbsent no longer routes writes
-	// through writeFileAtomicFn (it goes directly through
-	// allocateAndWriteTemp + os.Link), so mocking writeFileAtomicFn
-	// here was dead-but-harmless and has been removed.
 	prevRead := readFileByPathFn
 	t.Cleanup(func() {
 		readFileByPathFn = prevRead
@@ -362,31 +357,13 @@ func TestWriteFileIfAbsent_ConcurrentDifferentContent(t *testing.T) {
 	}
 }
 
-// Copilot P1 regression on PR #1220: a stale `<dest>.tmp.<pid>.<seq>`
-// leftover from a crashed prior process (potentially hard-linked to
-// a live destination inode) must NOT be reopened with O_TRUNC —
-// that would truncate the destination through the shared inode.
-// writeAndSyncTemp uses O_CREATE|O_EXCL (no O_TRUNC), and
-// allocateAndWriteTemp retries with a fresh seq on os.ErrExist.
-// Verify the retry path by pre-creating a temp at the next seq the
-// allocator would produce, then confirm writeFileAtomic succeeds,
-// the pre-existing stale temp is NOT truncated, and the destination
-// has the expected bytes.
-func TestWriteFileAtomic_SkipsStaleTempViaExclusiveCreate(t *testing.T) {
+func TestWriteFileAtomic_ReclaimsFixedScratchBeforeExclusiveCreate(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "payload.bin")
-
-	// Pre-create stale temp at the seq the next allocation would hit.
-	staleSeq := nextTempSeq() + 1
-	staleTmp := tempPathFor(path, os.Getpid(), staleSeq)
-	staleBytes := []byte("STALE LEFTOVER - must not be truncated")
-	if err := os.WriteFile(staleTmp, staleBytes, 0o600); err != nil {
-		t.Fatalf("seed stale temp: %v", err)
+	scratch := filepath.Join(dir, atomicWriteScratchLeaf)
+	if err := os.WriteFile(scratch, []byte("STALE LEFTOVER"), 0o600); err != nil {
+		t.Fatalf("seed stale scratch: %v", err)
 	}
-
-	// Counter is already at staleSeq-1 after the `nextTempSeq()+1`
-	// probe above; the next nextTempSeq() call (first allocator attempt)
-	// returns staleSeq and triggers the O_EXCL AlreadyExists branch.
 
 	if err := writeFileAtomic(path, []byte("fresh bytes"), 0o600); err != nil {
 		t.Fatalf("writeFileAtomic: %v", err)
@@ -401,13 +378,8 @@ func TestWriteFileAtomic_SkipsStaleTempViaExclusiveCreate(t *testing.T) {
 		t.Fatalf("dest: got %q, want %q", got, "fresh bytes")
 	}
 
-	// Stale temp untouched — O_EXCL refused to reopen/truncate.
-	gotStale, err := os.ReadFile(staleTmp)
-	if err != nil {
-		t.Fatalf("read stale after: %v", err)
-	}
-	if !bytes.Equal(gotStale, staleBytes) {
-		t.Fatalf("stale temp was overwritten — O_EXCL retry path is broken: got %q", gotStale)
+	if _, err := os.Lstat(scratch); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fixed scratch remained after commit: %v", err)
 	}
 }
 

--- a/clients/go/node/blockstore_write_if_absent.go
+++ b/clients/go/node/blockstore_write_if_absent.go
@@ -8,129 +8,39 @@ import (
 	"path/filepath"
 )
 
-// writeFileIfAbsent writes content to path only if the destination is
-// absent (idempotent replay: a subsequent call with matching bytes is a
-// silent no-op). Hardened against the TOCTOU race audited as E.3: the
-// previous implementation read then wrote, which could silently
-// overwrite a file that appeared between the two syscalls. The new
-// implementation writes content to a per-call-unique temp path, then
-// uses os.Link for atomic create-if-absent at the syscall layer. On
-// EEXIST we read the current destination and preserve the idempotent-
-// same-content contract; on content mismatch we surface an explicit
-// error — we never silently overwrite.
-//
-// Mirrors the Rust io_utils::write_file_exclusive helper's hard_link
-// flow for cross-client storage parity.
-//
-// Threat model:
-//
-//	concurrent actors:  Two writers race on os.Link(tmp, path); exactly
-//	                    one link succeeds. The loser sees os.ErrExist,
-//	                    reads the winner's content, and returns nil if
-//	                    content matches (idempotent replay) or an error
-//	                    if it differs (never overwrite). Per-call
-//	                    tempPathFor(path, pid, nextTempSeq()) gives
-//	                    distinct temp paths so in-process goroutines
-//	                    never collide.
-//	process crash:      Crash between os.Link and os.Remove(tmp) leaves
-//	                    a stale tmp hard-linked to the destination
-//	                    inode. That is safe: writeAndSyncTemp uses
-//	                    O_CREATE|O_EXCL (no O_TRUNC), so a later call
-//	                    hitting the same tmp path gets os.ErrExist from
-//	                    allocateAndWriteTemp and retries with a fresh
-//	                    seq (16-retry budget). NOTHING removes that
-//	                    sibling today: a crash between the temp write
-//	                    and the link or rename leaks one
-//	                    <dest>.tmp.<pid>.<seq> file, and there is no
-//	                    startup sweep. The leak exists only because the
-//	                    name is unique per write; the fix is a FIXED
-//	                    temp name per destination (which the next write
-//	                    truncates) plus a datadir lock, not a startup
-//	                    deletion pass — Bitcoin Core and Monero take
-//	                    the naming route and sweep nothing at startup.
-//	                    Tracked as its own contract. Crash before
-//	                    syncDir leaves the dirent in page cache; the
-//	                    fast-path on retry re-runs syncDir and
-//	                    propagates its error so durability is surfaced.
-//	cross-platform:     Unix (Linux, macOS): os.Link, O_EXCL, dir Sync
-//	                    all semantically honored. Windows: Sync on
-//	                    directories is a no-op in stdlib; Rubin does
-//	                    not ship Windows as a production target.
-//	                    Test surfaces that rely on os.Geteuid()/chmod
-//	                    for permission-denied paths are gated behind
-//	                    //go:build unix.
-//	retry / exhaustion: allocateAndWriteTemp retries up to
-//	                    maxTempAllocRetries (16) on os.ErrExist with a
-//	                    fresh nextTempSeq. Fatal I/O surfaces
-//	                    immediately. Exhaustion surfaces as an error
-//	                    mentioning the destination path.
-//	inode / fs-layer:   os.Link is refcount-safe: destination and tmp
-//	                    share the inode; unlinking tmp drops the name
-//	                    without affecting data visible through path.
-//	                    O_TRUNC on a shared-inode path is intentionally
-//	                    avoided everywhere in the helper stack; see
-//	                    writeAndSyncTemp for the explicit O_EXCL
-//	                    contract.
-//	durability:         writeAndSyncTemp fsync's the temp's bytes and
-//	                    inode metadata before returning. os.Link then
-//	                    exposes the inode under `path`. syncDir on the
-//	                    parent flushes the directory entry so the
-//	                    rename/link is itself durable. Both the Ok and
-//	                    EEXIST-retry branches PROPAGATE the final
-//	                    syncDir error — the previous `_ = syncDir(...)`
-//	                    double-swallowed EIO through syncDir's own
-//	                    best-effort wrapper (Copilot P1 wave-7 on
-//	                    PR #1220).
-//
-// writeFileIfAbsent writes content to path only if the file does not already
-// exist with matching bytes. It returns an error when an existing file has
-// different content (never overwrites).
-//
-// Fast path: destination already exists. Read once and verify match
-// before attempting any writes. Same behavior as the Rust helper
-// via `write_file_exclusive` + EEXIST branch, but short-circuited
-// here to avoid a useless temp write when the file is already
-// present with the right bytes (dominant case during idempotent
-// replay on sync-engine restart).
-//
-// Copilot P1 on PR #1220: a previous call may have successfully
-// created the destination but returned an error from the final
-// syncDir step. If the caller retries, we land in this fast-path
-// and would silently report nil without ever making the directory
-// entry durable. Re-run syncDir on the idempotent match branch and
-// PROPAGATE its result — syncDir already applies the intended
-// permission policy internally (execute-only/hardened parents are
-// treated as nil return), so propagating does NOT break the
-// idempotent-replay-on-hardened-dir contract; it only surfaces
-// real durability failures (EIO / ENOENT) that would otherwise be
-// silent.
-//
-// Copilot P1 wave-7 on PR #1220: `_ = syncDir(...)` double-
-// swallowed errors — syncDir is already best-effort, so the outer
-// `_ = ...` discarded the exact failures that MUST reach the
-// caller. Propagate via `return` instead.
+// writeFileIfAbsent keeps exact matches lock-free and sends only NotFound
+// through the fixed-scratch append-only write lane.
 func writeFileIfAbsent(path string, content []byte) error {
+	if err := validateAtomicWriteDestination(path, atomicWriteCreateIfAbsent); err != nil {
+		return err
+	}
 	existing, err := readVerifyTarget(path, content)
 	if err == nil {
-		return syncMatchingExistingFile(path, content, existing)
+		if !bytes.Equal(existing, content) {
+			return newAtomicWriteError(
+				atomicWriteBeforeNamespaceCommit,
+				path,
+				atomicWriteCreateIfAbsent,
+				errExistingContentDiffers(path),
+			)
+		}
+		return syncMatchingExistingFile(path)
 	}
 	if errors.Is(err, errStoreFileTooLarge) {
-		return errExistingContentDiffers(path)
+		return newAtomicWriteError(
+			atomicWriteBeforeNamespaceCommit,
+			path,
+			atomicWriteCreateIfAbsent,
+			errExistingContentDiffers(path),
+		)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return newAtomicWriteError(atomicWriteBeforeNamespaceCommit, path, atomicWriteCreateIfAbsent, err)
 	}
 	return writeFileViaTempLink(path, content)
 }
 
-// readVerifyTarget reads the existing destination bounded by len(content).
-// These reads exist ONLY to compare against content, so a destination of any
-// other size cannot match: bounding by the caller's own length means a
-// corrupt multi-gigabyte file at a 116-byte header destination is refused
-// before allocation instead of being buffered whole (RUB-1057). Callers map
-// the size refusal onto the pre-existing content-mismatch error, so the
-// caller-visible taxonomy is identical for every mismatch regardless of the
-// existing file's size.
+// readVerifyTarget bounds reads by content length; different sizes reject.
 func readVerifyTarget(path string, content []byte) ([]byte, error) {
 	return readFileByPathFn(path, int64(len(content)))
 }
@@ -139,23 +49,14 @@ func errExistingContentDiffers(path string) error {
 	return fmt.Errorf("file already exists with different content: %s", path)
 }
 
-// writeFileViaTempLink writes content to a temp file and atomically links it to path.
 func writeFileViaTempLink(path string, content []byte) error {
-	tmpPath, err := allocateAndWriteTemp(path, content, 0o600)
-	if err != nil {
-		return err
-	}
-	linkErr := os.Link(tmpPath, path)
-	_ = os.Remove(tmpPath)
-	if linkErr != nil {
-		if errors.Is(linkErr, os.ErrExist) {
-			return handleLinkEEXIST(path, content)
-		}
-		return fmt.Errorf("link %s -> %s: %w", tmpPath, path, linkErr)
-	}
-	return syncDir(filepath.Dir(path))
+	return writeAtomicFile(path, content, atomicWriteCreateIfAbsent, func() error {
+		return handleLinkEEXIST(path, content)
+	})
 }
 
+// handleLinkEEXIST decides the destination only; the scratch lane retains
+// decision, scratch-unlink, then parent-sync precedence.
 func handleLinkEEXIST(path string, content []byte) error {
 	existing, err := readVerifyTarget(path, content)
 	if errors.Is(err, errStoreFileTooLarge) {
@@ -164,12 +65,20 @@ func handleLinkEEXIST(path string, content []byte) error {
 	if err != nil {
 		return fmt.Errorf("read existing after link EEXIST %s: %w", path, err)
 	}
-	return syncMatchingExistingFile(path, content, existing)
-}
-
-func syncMatchingExistingFile(path string, content []byte, existing []byte) error {
 	if !bytes.Equal(existing, content) {
 		return errExistingContentDiffers(path)
 	}
-	return syncDir(filepath.Dir(path))
+	return nil
+}
+
+func syncMatchingExistingFile(path string) error {
+	if err := atomicWriteIO.syncParent(filepath.Dir(path)); err != nil {
+		return newAtomicWriteError(
+			atomicWriteAfterNamespaceCommit,
+			path,
+			atomicWriteCreateIfAbsent,
+			err,
+		)
+	}
+	return nil
 }

--- a/clients/go/node/chainstate_fsync_unix_test.go
+++ b/clients/go/node/chainstate_fsync_unix_test.go
@@ -3,17 +3,12 @@
 package node
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// TestWriteFileAtomicFailsWhenParentNotWritable exercises the OpenFile
-// error path of writeAndSyncTemp by chmod'ing the parent dir read-only
-// before the temp file can be created. Skipped when running as root since
-// root bypasses the mode check on most filesystems.
-//
 // Lives in a `//go:build unix` file because os.Geteuid() is Unix-only and
 // would prevent the chainstate_test.go file from compiling under
 // GOOS=windows (Copilot review feedback on PR #1218).
@@ -32,52 +27,43 @@ func TestWriteFileAtomicFailsWhenParentNotWritable(t *testing.T) {
 		t.Fatalf("writeFileAtomic to read-only parent: expected error, got nil")
 	}
 
-	// Tmp file must NOT remain on the filesystem either way (writeFileAtomic
-	// either failed before creating it or cleaned it up via os.Remove).
 	if err := os.Chmod(dir, 0o700); err != nil {
 		t.Fatalf("chmod parent restore: %v", err)
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read dir: %v", err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if strings.Contains(name, ".tmp.") {
-			t.Fatalf("stale tmp file remained after open failure: %s", name)
-		}
+	if _, err := os.Lstat(filepath.Join(dir, atomicWriteScratchLeaf)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fixed scratch remained after rejected write: %v", err)
 	}
 }
 
-// TestWriteAndSyncTempFailsOnUnwritableParent exercises writeAndSyncTemp's
-// OpenFile error path directly, ensuring the helper is honestly testable
-// without going through the full writeFileAtomic + Rename + syncDir chain.
-//
-// Lives in a `//go:build unix` file for the same reason as
-// TestWriteFileAtomicFailsWhenParentNotWritable.
-func TestWriteAndSyncTempFailsOnUnwritableParent(t *testing.T) {
+func TestWriteFileIfAbsentExactMatchResyncsMode0500WithoutReservedNames(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root: chmod-based permission check does not apply")
 	}
 	dir := t.TempDir()
+	path := filepath.Join(dir, "exact.bin")
+	content := []byte("already present")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("seed destination: %v", err)
+	}
 	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatalf("chmod parent read-only: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 
-	tmpPath := filepath.Join(dir, "x.tmp.1")
-	if err := writeAndSyncTemp(tmpPath, []byte("nope"), 0o600); err == nil {
-		t.Fatalf("writeAndSyncTemp into read-only parent: expected error, got nil")
+	if err := writeFileIfAbsent(path, content); err != nil {
+		t.Fatalf("exact-match write in mode-0500 parent: %v", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod parent restore: %v", err)
+	}
+	for _, leaf := range []string{atomicWriteLockLeaf, atomicWriteScratchLeaf} {
+		if _, err := os.Lstat(filepath.Join(dir, leaf)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("exact-match write created %s: %v", leaf, err)
+		}
 	}
 }
 
-// TestSyncDirIsBestEffortOnExecuteOnlyParent — exercises the Codex P2 fix
-// from PR #1218. A parent directory with mode 0300 (write+execute, no read)
-// permits create/rename but blocks os.Open(dir) for reading. Before the
-// fix, syncDir returned EACCES after the rename had already succeeded,
-// making callers treat committed state as failed. After the fix, syncDir
-// silently returns nil on EACCES so the rename is reported as successful.
-func TestSyncDirIsBestEffortOnExecuteOnlyParent(t *testing.T) {
+func TestSyncDirRejectsExecuteOnlyParent(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root: chmod-based permission check does not apply")
 	}
@@ -87,7 +73,7 @@ func TestSyncDirIsBestEffortOnExecuteOnlyParent(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 
-	if err := syncDir(dir); err != nil {
-		t.Fatalf("syncDir on execute-only dir: expected nil (best-effort), got %v", err)
+	if err := syncDir(dir); err == nil {
+		t.Fatal("syncDir on execute-only dir: expected error")
 	}
 }

--- a/clients/go/node/chainstate_io.go
+++ b/clients/go/node/chainstate_io.go
@@ -7,15 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/internal/filelock"
 )
 
 func stateToDisk(s *ChainState) (chainStateDisk, error) {
@@ -128,9 +128,12 @@ func (s *ChainState) Save(path string) error {
 		return fmt.Errorf("encode chainstate: %w", err)
 	}
 	raw = append(raw, '\n')
+	if err := validateAtomicWriteDestination(path, atomicWriteOverwrite); err != nil {
+		return err
+	}
 	// nosemgrep: Semgrep_go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil { // nosemgrep
-		return err
+		return newAtomicWriteError(atomicWriteBeforeNamespaceCommit, path, atomicWriteOverwrite, err)
 	}
 	return writeFileAtomic(path, raw, 0o600)
 }
@@ -275,195 +278,366 @@ func nextBlockContextFromFields(hasTip bool, height uint64, tipHash [32]byte) (u
 	return nextHeight, &prev, nil
 }
 
-// writeFileAtomic writes data to path via a temp+rename pattern with an
-// honest fsync durability contract (E.1). The actual file IO lives in
-// the helpers allocateAndWriteTemp, writeAndSyncTemp, and syncDir.
-//
-// Sequence (any failure removes the temp file before returning):
-//  1. delegate to allocateAndWriteTemp: pick a unique temp path via
-//     tempPathFor+nextTempSeq and delegate to writeAndSyncTemp, which
-//     opens the temp with O_CREATE|O_EXCL|O_WRONLY (NO O_TRUNC — see
-//     that helper's doc for the crash-safety rationale), loops Write
-//     until all bytes are persisted, Sync, Close, returns joined
-//     errors. A stale-temp collision (PID + seq reuse across a crash)
-//     retries up to maxTempAllocRetries with a fresh seq;
-//  2. Rename temp -> destination (atomic on the same filesystem);
-//  3. delegate to syncDir on the parent directory so the rename itself
-//     is durable (without this the destination's bytes are on disk
-//     after step 1's Sync, but the directory entry mapping `path` to
-//     the new inode may still live only in the kernel page cache and
-//     be lost on crash).
-//
-// Mirrors the Rust `clients/rust/crates/rubin-node/src/io_utils.rs`
-// `write_file_atomic` for cross-client storage parity.
-func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
-	tmpPath, err := allocateAndWriteTemp(path, data, mode)
-	if err != nil {
-		return err
+const (
+	atomicWriteLockLeaf    = ".rubin-atomic-write.lock"
+	atomicWriteScratchLeaf = ".rubin-atomic-write.tmp"
+)
+
+type atomicWriteStage string
+
+const (
+	atomicWriteBeforeNamespaceCommit atomicWriteStage = "before_namespace_commit"
+	atomicWriteAfterNamespaceCommit  atomicWriteStage = "after_namespace_commit"
+)
+
+type atomicWriteOperation string
+
+const (
+	atomicWriteOverwrite      atomicWriteOperation = "overwrite"
+	atomicWriteCreateIfAbsent atomicWriteOperation = "create_if_absent"
+)
+
+type atomicWriteError struct {
+	stage       atomicWriteStage
+	destination string
+	operation   atomicWriteOperation
+	primary     error
+	secondary   []error
+}
+
+func (e *atomicWriteError) Error() string {
+	if e == nil {
+		return ""
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
+	if len(e.secondary) == 0 {
+		return fmt.Sprintf("atomic write %s %s for %s: %v", e.stage, e.operation, e.destination, e.primary)
 	}
-	return syncDir(filepath.Dir(path))
+	return fmt.Sprintf("atomic write %s %s for %s: %v (cleanup: %v)", e.stage, e.operation, e.destination, e.primary, errors.Join(e.secondary...))
 }
 
-// tempSeq is a process-wide monotonic counter appended to every
-// temp-file name so two concurrent writers in the same process
-// (goroutines, or the same goroutine retrying after a previous failed
-// attempt) never collide on a shared `.tmp.<pid>` path (audit E.3).
-// Without this, two goroutines writing different content to the same
-// destination would silently overwrite each other's temp bytes between
-// Write and Rename/Link.
-//
-// Scope is in-process uniqueness only. After a process crash the
-// counter resets to zero, and PID reuse across processes is possible
-// on long-running systems — so a fresh process CAN pick the same
-// `<pid>.<seq>` prefix as a stale leftover on disk. That cross-process
-// collision is handled at a different layer: `writeAndSyncTemp` opens
-// the temp with O_CREATE|O_EXCL (no O_TRUNC) and returns os.ErrExist
-// on collision, and `allocateAndWriteTemp` retries with a fresh seq
-// up to `maxTempAllocRetries` times. tempSeq narrows the collision
-// window; O_EXCL + retries close it.
-//
-// Note: this is a filesystem-uniqueness counter, not a cryptographic
-// nonce.
-var tempSeq atomic.Uint64
-
-func nextTempSeq() uint64 {
-	return tempSeq.Add(1)
+func (e *atomicWriteError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	errList := make([]error, 0, 1+len(e.secondary))
+	if e.primary != nil {
+		errList = append(errList, e.primary)
+	}
+	return append(errList, e.secondary...)
 }
 
-// tempPathFor builds the companion temp path for a destination. Keeps
-// pid + monotonic seq in the filename so the temp is unique across
-// threads, processes, and retries. Mirrors the Rust
-// `io_utils::temp_path_for` helper for cross-client parity.
-func tempPathFor(path string, pid int, seq uint64) string {
-	return fmt.Sprintf("%s.tmp.%d.%d", path, pid, seq)
-}
-
-// maxTempAllocRetries bounds the stale-temp collision retries in
-// allocateAndWriteTemp. A collision on `<dest>.tmp.<pid>.<seq>` should
-// be vanishingly rare (it requires PID reuse PLUS nextTempSeq wrapping
-// back over a stale leftover from a prior process), so 16 is
-// deliberately generous for the tail case while bounding pathological
-// loops.
-const maxTempAllocRetries = 16
-
-// allocateAndWriteTemp picks a unique temp path for `path`, writes
-// `data` to it via writeAndSyncTemp (exclusive-create + fsync), and
-// returns the temp path on success. Retries up to maxTempAllocRetries
-// with a fresh nextTempSeq on the rare os.ErrExist case (stale
-// leftover temp after PID + seq reuse across a crash). Fatal I/O
-// errors surface immediately without retry.
-//
-// On success the caller owns `tmpPath` and is responsible for the
-// final rename/link + removing the temp name on error paths. On
-// failure writeAndSyncTemp already best-effort removes the temp
-// before returning.
-func allocateAndWriteTemp(path string, data []byte, mode os.FileMode) (string, error) {
-	pid := os.Getpid()
-	var lastCollision error
-	for i := 0; i < maxTempAllocRetries; i++ {
-		tmpPath := tempPathFor(path, pid, nextTempSeq())
-		err := writeAndSyncTemp(tmpPath, data, mode)
-		if err == nil {
-			return tmpPath, nil
+func newAtomicWriteError(stage atomicWriteStage, destination string, operation atomicWriteOperation, primary error, secondary ...error) *atomicWriteError {
+	clean := make([]error, 0, len(secondary))
+	for _, err := range secondary {
+		if err != nil {
+			clean = append(clean, err)
 		}
-		if errors.Is(err, os.ErrExist) {
-			lastCollision = fmt.Errorf("temp path already exists: %s", tmpPath)
-			continue
-		}
-		return "", err
 	}
-	if lastCollision == nil {
-		lastCollision = fmt.Errorf("exhausted %d retries allocating temp for %s", maxTempAllocRetries, path)
+	return &atomicWriteError{
+		stage:       stage,
+		destination: destination,
+		operation:   operation,
+		primary:     primary,
+		secondary:   clean,
 	}
-	return "", lastCollision
 }
 
-// writeAndSyncTemp writes data to a fresh temp path, syncs the file's
-// bytes and inode metadata to stable storage, and closes it. Opens
-// with O_CREATE|O_EXCL|O_WRONLY — NO O_TRUNC — so a stale temp
-// leftover from a crashed prior process that happens to be hard-linked
-// to a live destination inode cannot be truncated through the shared
-// inode (Copilot P1 audit on PR #1220). The caller
-// (allocateAndWriteTemp) retries with a fresh seq on os.ErrExist.
-//
-// Write is looped until all bytes are persisted, matching Rust's
-// `Write::write_all` contract: io.Writer is allowed to return a short
-// write without an error, and treating that as success would let us
-// sync+rename a truncated file (Copilot review feedback on PR #1218).
-// A zero-byte short write is reported as io.ErrShortWrite to avoid an
-// infinite loop on a well-behaved-but-stuck writer.
-//
-// We always run Write, Sync and Close, then combine their errors with
-// errors.Join (Go 1.20+). This guarantees:
-//  1. the Close error is NOT silently dropped — it surfaces in the joined
-//     error and reaches the caller;
-//  2. the FD is always released, even when Write or Sync fail, without
-//     duplicating cleanup branches that would otherwise be unreachable
-//     from a unit test (no realistic way to provoke a Write or Sync
-//     failure on an already-opened regular file in CI).
-//
-// On any error after successful open, the temp is best-effort removed
-// before returning so callers (allocateAndWriteTemp / writeFileAtomic
-// / writeFileIfAbsent) do not need to clean up the error path.
-func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
-	// nosemgrep: Semgrep_go_filesystem_rule-fileread
-	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // nosemgrep
-	if err != nil {
+func atomicWriteStageOf(err error) (atomicWriteStage, bool) {
+	var atomicErr *atomicWriteError
+	if !errors.As(err, &atomicErr) {
+		return "", false
+	}
+	return atomicErr.stage, true
+}
+
+func isAtomicWritePostCommit(err error) bool {
+	stage, ok := atomicWriteStageOf(err)
+	return ok && stage == atomicWriteAfterNamespaceCommit
+}
+
+type atomicWriteScratchFile interface {
+	io.Writer
+	Sync() error
+	Close() error
+	Chmod(os.FileMode) error
+}
+
+type atomicWriteOps struct {
+	openScratch func(string, int, os.FileMode) (atomicWriteScratchFile, error)
+	rename      func(string, string) error
+	link        func(string, string) error
+	unlink      func(string) error
+	syncParent  func(string) error
+}
+
+var atomicWriteIO = atomicWriteOps{
+	openScratch: func(path string, flag int, mode os.FileMode) (atomicWriteScratchFile, error) {
+		// nosemgrep: Semgrep_go_filesystem_rule-fileread
+		return os.OpenFile(path, flag, mode) // nosemgrep
+	},
+	rename:     os.Rename,
+	link:       os.Link,
+	unlink:     atomicUnlink,
+	syncParent: syncDir,
+}
+
+var atomicWriteProcessMu sync.Mutex
+
+func validateAtomicWriteDestination(path string, operation atomicWriteOperation) error {
+	leaf := filepath.Base(path)
+	if leaf != atomicWriteLockLeaf && leaf != atomicWriteScratchLeaf {
+		return nil
+	}
+	return newAtomicWriteError(
+		atomicWriteBeforeNamespaceCommit,
+		path,
+		operation,
+		fmt.Errorf("reserved atomic persistence destination: %s", path),
+	)
+}
+
+// writeFileAtomic replaces path from a fixed 0600 scratch in its parent.
+func writeFileAtomic(path string, data []byte, _ os.FileMode) error {
+	if err := validateAtomicWriteDestination(path, atomicWriteOverwrite); err != nil {
 		return err
 	}
-	var werr error
+	return writeAtomicFile(path, data, atomicWriteOverwrite, nil)
+}
+
+func writeAtomicFile(path string, data []byte, operation atomicWriteOperation, resolveExisting func() error) error {
+	if err := validateAtomicWriteDestination(path, operation); err != nil {
+		return err
+	}
+	parent := filepath.Dir(path)
+	atomicWriteProcessMu.Lock()
+	defer atomicWriteProcessMu.Unlock()
+
+	lock, result, err := filelock.Acquire(filepath.Join(parent, atomicWriteLockLeaf))
+	if err != nil {
+		return newAtomicWriteError(
+			atomicWriteBeforeNamespaceCommit,
+			path,
+			operation,
+			fmt.Errorf("atomic write lock failed: %s: %s: %w", parent, result, err),
+		)
+	}
+	committed, writeErr := writeAtomicFileLocked(path, data, operation, resolveExisting)
+	if releaseErr := lock.Release(); releaseErr != nil {
+		return appendAtomicWriteReleaseError(writeErr, committed, path, operation, releaseErr)
+	}
+	return writeErr
+}
+
+func appendAtomicWriteReleaseError(writeErr error, committed bool, path string, operation atomicWriteOperation, releaseErr error) error {
+	if writeErr == nil {
+		stage := atomicWriteBeforeNamespaceCommit
+		if committed {
+			stage = atomicWriteAfterNamespaceCommit
+		}
+		return newAtomicWriteError(stage, path, operation, releaseErr)
+	}
+	var atomicErr *atomicWriteError
+	if errors.As(writeErr, &atomicErr) {
+		atomicErr.secondary = append(atomicErr.secondary, releaseErr)
+	}
+	return writeErr
+}
+
+func writeAtomicFileLocked(path string, data []byte, operation atomicWriteOperation, resolveExisting func() error) (bool, error) {
+	parent := filepath.Dir(path)
+	scratch := filepath.Join(parent, atomicWriteScratchLeaf)
+	if err := atomicWriteIO.unlink(scratch); err != nil {
+		return false, newAtomicWriteError(atomicWriteBeforeNamespaceCommit, path, operation, err)
+	}
+
+	file, err := atomicWriteIO.openScratch(scratch, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return false, atomicWritePreCommitFailure(path, operation, parent, scratch, err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		closeErr := file.Close()
+		return false, atomicWritePreCommitFailure(path, operation, parent, scratch, err, closeErr)
+	}
+	writeErr, closeErr := writeAndCloseAtomicScratch(file, data)
+	if writeErr != nil {
+		return false, atomicWritePreCommitFailure(path, operation, parent, scratch, writeErr, closeErr)
+	}
+	return commitAtomicScratch(path, operation, parent, scratch, resolveExisting)
+}
+
+func commitAtomicScratch(path string, operation atomicWriteOperation, parent, scratch string, resolveExisting func() error) (bool, error) {
+	switch operation {
+	case atomicWriteOverwrite:
+		return commitAtomicOverwrite(path, operation, parent, scratch)
+	case atomicWriteCreateIfAbsent:
+		return commitAtomicCreateIfAbsent(path, operation, parent, scratch, resolveExisting)
+	default:
+		return false, atomicWritePreCommitFailure(path, operation, parent, scratch, errors.New("unknown atomic write operation"))
+	}
+}
+
+func commitAtomicOverwrite(path string, operation atomicWriteOperation, parent, scratch string) (bool, error) {
+	if err := atomicWriteIO.rename(scratch, path); err != nil {
+		return false, atomicWritePreCommitFailure(path, operation, parent, scratch, err)
+	}
+	return true, atomicWritePostCommitFailure(path, operation, parent, scratch, nil)
+}
+
+func commitAtomicCreateIfAbsent(path string, operation atomicWriteOperation, parent, scratch string, resolveExisting func() error) (bool, error) {
+	if err := atomicWriteIO.link(scratch, path); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return false, atomicWritePreCommitFailure(path, operation, parent, scratch, err)
+		}
+		if resolveExisting == nil {
+			return false, atomicWritePreCommitFailure(path, operation, parent, scratch, errors.New("missing create-if-absent destination decision"))
+		}
+		if decisionErr := resolveExisting(); decisionErr != nil {
+			return false, atomicWritePreCommitFailure(path, operation, parent, scratch, decisionErr)
+		}
+	}
+	return true, atomicWritePostCommitFailure(path, operation, parent, scratch, nil)
+}
+
+func writeAndCloseAtomicScratch(file atomicWriteScratchFile, data []byte) (error, error) {
+	writeErr := writeAllAtomicScratch(file, data)
+	var syncErr error
+	if writeErr == nil {
+		syncErr = file.Sync()
+	}
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr, firstNonNil(syncErr, closeErr)
+	}
+	if syncErr != nil {
+		return syncErr, closeErr
+	}
+	return closeErr, nil
+}
+
+func writeAllAtomicScratch(file io.Writer, data []byte) error {
 	for written := 0; written < len(data); {
-		n, e := tmp.Write(data[written:])
-		if e != nil {
-			werr = e
-			break
+		n, err := file.Write(data[written:])
+		if err != nil {
+			return err
 		}
 		if n == 0 {
-			werr = io.ErrShortWrite
-			break
+			return io.ErrShortWrite
 		}
 		written += n
 	}
-	serr := tmp.Sync()
-	cerr := tmp.Close()
-	joined := errors.Join(werr, serr, cerr)
-	if joined != nil {
-		_ = os.Remove(tmpPath)
-	}
-	return joined
+	return nil
 }
 
-// syncDir opens the directory and calls Sync so any rename or unlink
-// performed in it is itself durable. Unix-only: directory Sync is the
-// portable way to flush the parent's directory entry on Linux/macOS;
-// Windows lacks an equivalent and is not a Rubin production target.
-//
-// Sync and Close errors are combined via errors.Join so a Close error after
-// a successful Sync still surfaces (Copilot review feedback on PR #1218,
-// mirrors the writeAndSyncTemp pattern).
-//
-// Best-effort on permission-denied open: a parent directory with mode
-// 0300 (write+execute, no read) permits create/rename but blocks
-// os.Open(dir) for reading (Codex review feedback on PR #1218). The
-// rename has already succeeded by the time we get here, so returning
-// an error would make the caller treat committed state as failed on
-// hardened directory-permission setups. Return nil instead — the
-// destination bytes are already on disk via the temp file's Sync; only
-// the directory-entry fsync is degraded to best-effort. Any other open
-// error (ENOENT, EIO, etc) still propagates as a real anomaly.
+func firstNonNil(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func atomicWritePreCommitFailure(path string, operation atomicWriteOperation, parent, scratch string, primary error, priorSecondary ...error) error {
+	secondary := append([]error(nil), priorSecondary...)
+	if err := atomicWriteIO.unlink(scratch); err != nil {
+		secondary = append(secondary, err)
+	}
+	if err := atomicWriteIO.syncParent(parent); err != nil {
+		secondary = append(secondary, err)
+	}
+	return newAtomicWriteError(atomicWriteBeforeNamespaceCommit, path, operation, primary, secondary...)
+}
+
+func atomicWritePostCommitFailure(path string, operation atomicWriteOperation, parent, scratch string, primary error) error {
+	secondary := make([]error, 0, 1)
+	if err := atomicWriteIO.unlink(scratch); err != nil {
+		if primary == nil {
+			primary = err
+		} else {
+			secondary = append(secondary, err)
+		}
+	}
+	if err := atomicWriteIO.syncParent(parent); err != nil {
+		if primary == nil {
+			primary = err
+		} else {
+			secondary = append(secondary, err)
+		}
+	}
+	if primary == nil {
+		return nil
+	}
+	return newAtomicWriteError(atomicWriteAfterNamespaceCommit, path, operation, primary, secondary...)
+}
+
+// syncDir strictly persists the parent; permission errors remain durability errors.
 func syncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
-		if errors.Is(err, fs.ErrPermission) {
-			return nil
-		}
 		return err
 	}
-	serr := d.Sync()
-	cerr := d.Close()
-	return errors.Join(serr, cerr)
+	return errors.Join(d.Sync(), d.Close())
+}
+
+type atomicScratchReclaimError struct {
+	parent string
+	cause  error
+}
+
+func (e *atomicScratchReclaimError) Error() string {
+	return fmt.Sprintf("atomic scratch reclaim failed: %s: %v", e.parent, e.cause)
+}
+
+func (e *atomicScratchReclaimError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// ReclaimAtomicWriteScratch visits the five production parents in frozen order.
+func ReclaimAtomicWriteScratch(dataDir string) error {
+	root := BlockStorePath(dataDir)
+	parents := []string{
+		dataDir,
+		root,
+		filepath.Join(root, "blocks"),
+		filepath.Join(root, "headers"),
+		filepath.Join(root, "undo"),
+	}
+	for _, parent := range parents {
+		if err := ReclaimAtomicWriteScratchInParent(parent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReclaimAtomicWriteScratchInParent reclaims only the named parent's scratch.
+func ReclaimAtomicWriteScratchInParent(parent string) error {
+	if err := reclaimAtomicWriteScratchInParent(parent); err != nil {
+		return &atomicScratchReclaimError{parent: parent, cause: err}
+	}
+	return nil
+}
+
+func reclaimAtomicWriteScratchInParent(parent string) (resultErr error) {
+	atomicWriteProcessMu.Lock()
+	defer atomicWriteProcessMu.Unlock()
+	lock, result, err := filelock.Acquire(filepath.Join(parent, atomicWriteLockLeaf))
+	if err != nil {
+		return fmt.Errorf("atomic write lock failed: %s: %s: %w", parent, result, err)
+	}
+	defer func() {
+		if releaseErr := lock.Release(); resultErr == nil && releaseErr != nil {
+			resultErr = releaseErr
+		}
+	}()
+	if err := atomicWriteIO.unlink(filepath.Join(parent, atomicWriteScratchLeaf)); err != nil {
+		return err
+	}
+	if err := atomicWriteIO.syncParent(parent); err != nil {
+		return err
+	}
+	return nil
 }

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -738,10 +737,6 @@ func TestWriteFileAtomicDurablyPersistsFreshFile(t *testing.T) {
 	}
 }
 
-// TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes verifies the
-// dominant chainstate/blockstore path: rewriting the index file on every
-// commit must atomically replace it AND leave no stale .tmp.* sibling
-// behind once the rename succeeds.
 func TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "index.json")
@@ -761,15 +756,8 @@ func TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes(t *testing.T) {
 		t.Fatalf("payload mismatch: got %q want %q", got, "second")
 	}
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read dir: %v", err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if strings.Contains(name, ".tmp.") {
-			t.Fatalf("stale tmp file remained after rename: %s", name)
-		}
+	if _, err := os.Lstat(filepath.Join(dir, atomicWriteScratchLeaf)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fixed scratch remained after rename: %v", err)
 	}
 }
 
@@ -790,91 +778,5 @@ func TestSyncDirFailsOnMissingDirectory(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "no-such-subdir")
 	if err := syncDir(missing); err == nil {
 		t.Fatalf("syncDir on missing dir: expected error, got nil")
-	}
-}
-
-// Permission-based tests that rely on os.Geteuid() (Unix-only) live in
-// chainstate_fsync_unix_test.go behind a `//go:build unix` tag so this
-// file still compiles under GOOS=windows (Copilot review feedback on
-// PR #1218).
-
-// TestAllocateAndWriteTemp_RetriesOnStaleTemp exercises the stale-temp
-// collision retry path added for Copilot P1 on PR #1220. Pre-create a
-// stale `.tmp.<pid>.<seq>` at the next-expected seq, verify the
-// allocator returns a DIFFERENT path on success, and verify the stale
-// file was NOT truncated.
-func TestAllocateAndWriteTemp_RetriesOnStaleTemp(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "target.bin")
-
-	staleSeq := nextTempSeq() + 1
-	staleTmp := tempPathFor(path, os.Getpid(), staleSeq)
-	staleBytes := []byte("stale - must survive")
-	if err := os.WriteFile(staleTmp, staleBytes, 0o600); err != nil {
-		t.Fatalf("seed stale: %v", err)
-	}
-	// Counter is already at staleSeq-1 after the `nextTempSeq()+1`
-	// probe above; the next nextTempSeq() call (first allocator attempt)
-	// returns staleSeq and triggers the O_EXCL AlreadyExists branch.
-	// Do NOT spin a `for nextTempSeq() < staleSeq-1 {}` loop — the
-	// condition itself calls nextTempSeq() and advances the counter,
-	// which can overshoot staleSeq-1 and skip the collision path.
-
-	payload := []byte("new payload")
-	got, err := allocateAndWriteTemp(path, payload, 0o600)
-	if err != nil {
-		t.Fatalf("allocateAndWriteTemp: %v", err)
-	}
-	if got == staleTmp {
-		t.Fatalf("allocator returned stale path %q — O_EXCL retry bypassed", got)
-	}
-	gotBytes, err := os.ReadFile(got)
-	if err != nil {
-		t.Fatalf("read allocated temp: %v", err)
-	}
-	if !bytes.Equal(gotBytes, payload) {
-		t.Fatalf("allocated temp content mismatch")
-	}
-	gotStale, err := os.ReadFile(staleTmp)
-	if err != nil {
-		t.Fatalf("read stale after: %v", err)
-	}
-	if !bytes.Equal(gotStale, staleBytes) {
-		t.Fatalf("stale temp was mutated — O_EXCL retry path broken")
-	}
-	_ = os.Remove(got)
-}
-
-// TestAllocateAndWriteTemp_ExhaustsRetries pre-creates stale files at
-// every seq the allocator would hit within maxTempAllocRetries, so
-// every attempt collides and the function must surface the
-// collision error rather than silently succeed.
-func TestAllocateAndWriteTemp_ExhaustsRetries(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "exhausted.bin")
-
-	baseSeq := nextTempSeq() + 1
-	var created []string
-	for i := 0; i < maxTempAllocRetries; i++ {
-		stale := tempPathFor(path, os.Getpid(), baseSeq+uint64(i))
-		if err := os.WriteFile(stale, []byte("blocker"), 0o600); err != nil {
-			t.Fatalf("seed stale #%d: %v", i, err)
-		}
-		created = append(created, stale)
-	}
-	// Counter is already at baseSeq-1 after the `nextTempSeq()+1`
-	// probe above; the next nextTempSeq() call (first allocator attempt)
-	// returns baseSeq, which is the first seeded stale path.
-
-	_, err := allocateAndWriteTemp(path, []byte("data"), 0o600)
-	if err == nil {
-		t.Fatalf("expected exhaustion error, got nil")
-	}
-	if !strings.Contains(err.Error(), "already exists") &&
-		!strings.Contains(err.Error(), "exhausted") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for _, stale := range created {
-		_ = os.Remove(stale)
 	}
 }

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -15,7 +15,10 @@ const defaultIBDLagSeconds = 24 * 60 * 60
 
 const defaultPVShadowMaxSamples = 3
 
-var ErrParentNotFound = errors.New("parent block not found")
+var (
+	ErrParentNotFound          = errors.New("parent block not found")
+	errStoragePersistenceFault = errors.New("storage persistence fault; restart required")
+)
 
 type SyncConfig struct {
 	ExpectedTarget   *[32]byte
@@ -101,23 +104,45 @@ const (
 )
 
 type SyncEngine struct {
-	chainState      *ChainState
-	blockStore      *BlockStore
-	mempool         *Mempool
-	cfg             SyncConfig
-	stderr          io.Writer
-	mu              sync.RWMutex
-	tipTimestamp    uint64
-	bestKnownHeight uint64
-	lastReorgDepth  uint64
-	reorgCount      uint64
-	blockApply      BlockApplyCounts
+	chainState         *ChainState
+	blockStore         *BlockStore
+	mempool            *Mempool
+	cfg                SyncConfig
+	stderr             io.Writer
+	mu                 sync.RWMutex
+	tipTimestamp       uint64
+	bestKnownHeight    uint64
+	lastReorgDepth     uint64
+	reorgCount         uint64
+	blockApply         BlockApplyCounts
+	mutationMu         sync.Mutex
+	persistenceFaultMu sync.Mutex
+	persistenceFault   *storagePersistenceFault
 
 	pvMode             parallelValidationMode
 	pvShadowMax        uint64
 	pvShadowMismatches uint64
 	pvShadowSamples    []string
 	pvTelemetry        *PVTelemetry
+}
+
+type storagePersistenceFault struct {
+	cause     error
+	reloadErr error
+}
+
+func (e *storagePersistenceFault) Error() string {
+	if e.reloadErr == nil {
+		return fmt.Sprintf("storage persistence fault: %v", e.cause)
+	}
+	return fmt.Sprintf("storage persistence fault: %v (reload failed: %v)", e.cause, e.reloadErr)
+}
+
+func (e *storagePersistenceFault) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
 }
 
 func DefaultSyncConfig(expectedTarget *[32]byte, chainID [32]byte, chainStatePath string) SyncConfig {
@@ -295,29 +320,31 @@ func ValidateDevnetGenesisIdentity(chainID, genesisHash [32]byte) error {
 // exported methods are nil-safe and there are existing tests that exercise
 // the nil-receiver path; this method joins that contract for consistency.
 func (s *SyncEngine) BootstrapCanonicalGenesisIfEmpty() error {
-	if s == nil || s.chainState == nil {
+	if s == nil {
 		return errors.New("sync engine is not initialized")
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	if err := s.mutationAllowed(); err != nil {
+		return err
 	}
 	if s.chainState.view().hasTip || s.cfg.ChainID != devnetGenesisChainID {
 		return nil
 	}
-	_, applyErr := s.ApplyBlock(devnetGenesisBlockBytes, nil)
+	_, applyErr := s.applyBlock(devnetGenesisBlockBytes, nil)
+	if errors.Is(applyErr, errStoragePersistenceFault) || isAtomicWritePostCommit(applyErr) {
+		return applyErr
+	}
 	return raceTolerantBootstrapResult(applyErr, s.chainState.view().hasTip)
 }
 
-// raceTolerantBootstrapResult absorbs the TOCTOU window between the hasTip
-// check at the start of BootstrapCanonicalGenesisIfEmpty and the ApplyBlock
-// call below it. If another goroutine installs a tip in that window — for
-// example a P2P inbound block path racing a /mine_next request that both
-// observe an empty chain — our ApplyBlock will fail (typically with a
-// linkage error because nextBlockContextFromFields now sees a non-zero
-// next height) even though the chain is no longer empty. In that case the
-// failure is benign: the chain has the tip we wanted to install, and the
-// caller (e.g. Miner.MineOne) can proceed with normal post-genesis mining.
+// raceTolerantBootstrapResult tolerates a directly changed shared ChainState:
+// if apply fails after an external tip appears, bootstrap is already satisfied.
 //
 // Returns:
 //   - nil when ApplyBlock succeeded (applyErr == nil), regardless of hasTip.
-//   - nil when ApplyBlock failed AND hasTip is true at recheck (race-recovery).
+//   - nil when a non-persistence ApplyBlock failure finds a tip at recheck
+//     (race-recovery).
 //   - applyErr when ApplyBlock failed AND hasTip is still false (real failure
 //     unrelated to concurrent tip installation, e.g. blockstore I/O error).
 func raceTolerantBootstrapResult(applyErr error, hasTip bool) error {
@@ -328,6 +355,18 @@ func raceTolerantBootstrapResult(applyErr error, hasTip bool) error {
 }
 
 func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
+	if s == nil {
+		return nil, errors.New("sync engine is not initialized")
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	return s.applyBlock(blockBytes, prevTimestamps)
+}
+
+func (s *SyncEngine) applyBlock(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
+	if err := s.mutationAllowed(); err != nil {
+		return nil, err
+	}
 	pb, err := consensus.ParseBlockBytes(blockBytes)
 	if err != nil {
 		return nil, err
@@ -558,7 +597,15 @@ func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
 }
 
 func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) error {
+	if s.persistenceFaulted() {
+		return cause
+	}
 	restoreErr := s.restoreRollbackPersistentState(state)
+	if isAtomicWritePostCommit(restoreErr) {
+		var atomicErr *atomicWriteError
+		reloadStore := errors.As(restoreErr, &atomicErr) && s.blockStore != nil && atomicErr.destination == s.blockStore.indexPath
+		return s.handlePersistenceError(restoreErr, reloadStore, !reloadStore)
+	}
 	s.restoreRollbackRuntimeState(state)
 	if restoreErr != nil {
 		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
@@ -566,10 +613,89 @@ func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) er
 	return cause
 }
 
+func (s *SyncEngine) mutationAllowed() error {
+	if s == nil || s.chainState == nil {
+		return errors.New("sync engine is not initialized")
+	}
+	if s.persistenceFaulted() {
+		return errStoragePersistenceFault
+	}
+	return nil
+}
+
+func (s *SyncEngine) persistenceFaulted() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.persistenceFault != nil
+}
+
+func (s *SyncEngine) handlePersistenceError(err error, reloadStore, reloadState bool) error {
+	if !isAtomicWritePostCommit(err) {
+		return err
+	}
+	s.persistenceFaultMu.Lock()
+	defer s.persistenceFaultMu.Unlock()
+	s.mu.Lock()
+	stable := s.persistenceFault
+	if stable == nil {
+		stable = &storagePersistenceFault{cause: err}
+		s.persistenceFault = stable
+	}
+	s.mu.Unlock()
+
+	reloadErr := s.reloadVisiblePersistenceState(reloadStore, reloadState)
+	if reloadErr == nil {
+		return stable
+	}
+	completed := &storagePersistenceFault{cause: stable.cause, reloadErr: errors.Join(stable.reloadErr, reloadErr)}
+	s.mu.Lock()
+	s.persistenceFault = completed
+	s.mu.Unlock()
+	return completed
+}
+
+func (s *SyncEngine) reloadVisiblePersistenceState(reloadStore, reloadState bool) error {
+	if s == nil {
+		return errors.New("nil sync engine")
+	}
+	s.mu.RLock()
+	store := s.blockStore
+	state := s.chainState
+	chainStatePath := s.cfg.ChainStatePath
+	s.mu.RUnlock()
+	var reloadErr error
+	if reloadStore && store != nil {
+		reloadErr = firstRollbackRestoreErr(reloadErr, store.reloadFromDisk())
+	}
+	if !reloadState || chainStatePath == "" {
+		return reloadErr
+	}
+	loaded, err := LoadChainState(chainStatePath)
+	if err != nil {
+		return firstRollbackRestoreErr(reloadErr, err)
+	}
+	if state == nil {
+		return firstRollbackRestoreErr(reloadErr, errors.New("nil chainstate destination"))
+	}
+	state.mu.RLock()
+	loaded.Rotation = state.Rotation
+	loaded.Registry = state.Registry
+	state.mu.RUnlock()
+	state.replaceFrom(loaded)
+	return reloadErr
+}
+
 func (s *SyncEngine) restoreRollbackPersistentState(state syncRollbackState) error {
 	restoreErr := s.restoreRollbackChainState(state)
 	if s.blockStore != nil {
-		restoreErr = firstRollbackRestoreErr(restoreErr, s.blockStore.RestoreCanonicalIndex(state.canonicalIndex))
+		indexErr := s.blockStore.RestoreCanonicalIndex(state.canonicalIndex)
+		if isAtomicWritePostCommit(indexErr) {
+			return indexErr
+		}
+		restoreErr = firstRollbackRestoreErr(restoreErr, indexErr)
 	}
 	restoreErr = firstRollbackRestoreErr(restoreErr, restoreMempoolSnapshot(s.mempool, state.mempool))
 	if restoreErr == nil && s.cfg.ChainStatePath != "" {
@@ -579,6 +705,9 @@ func (s *SyncEngine) restoreRollbackPersistentState(state syncRollbackState) err
 }
 
 func firstRollbackRestoreErr(current error, next error) error {
+	if isAtomicWritePostCommit(next) {
+		return next
+	}
 	if current != nil {
 		return current
 	}
@@ -612,6 +741,9 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	prevTimestamps []uint64,
 	target *canonicalApplyTarget,
 ) (*ChainStateConnectSummary, error) {
+	if err := s.mutationAllowed(); err != nil {
+		return nil, err
+	}
 	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps, target)
 	s.noteBlockApplyOutcome(outcome)
 	return summary, err

--- a/clients/go/node/sync_disconnect.go
+++ b/clients/go/node/sync_disconnect.go
@@ -14,6 +14,15 @@ type disconnectTipContext struct {
 }
 
 func (s *SyncEngine) DisconnectTip() (*ChainStateDisconnectSummary, error) {
+	if s == nil {
+		return nil, errors.New("sync engine is not initialized")
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	return s.disconnectTip()
+}
+
+func (s *SyncEngine) disconnectTip() (*ChainStateDisconnectSummary, error) {
 	ctx, err := s.prepareDisconnectTip()
 	if err != nil {
 		return nil, err
@@ -71,8 +80,8 @@ func (s *SyncEngine) prepareDisconnectTip() (disconnectTipContext, error) {
 }
 
 func (s *SyncEngine) validateDisconnectTipReady() error {
-	if s == nil || s.chainState == nil {
-		return errors.New("sync engine is not initialized")
+	if err := s.mutationAllowed(); err != nil {
+		return err
 	}
 	if s.blockStore == nil {
 		return errors.New("sync engine has no blockstore")
@@ -97,7 +106,7 @@ func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64) 
 			return nil, 0, err
 		}
 		disconnectedBlocks = append(disconnectedBlocks, append([]byte(nil), disconnectedBlockBytes...))
-		if _, err := s.DisconnectTip(); err != nil {
+		if _, err := s.disconnectTip(); err != nil {
 			return nil, 0, err
 		}
 		currentTipHeight--
@@ -167,10 +176,16 @@ func (s *SyncEngine) getParentTimestamp(tipHeight uint64, prevBlockHash [32]byte
 // finalizeDisconnectState updates chain state after disconnect.
 func (s *SyncEngine) finalizeDisconnectState(rollbackState syncRollbackState, newTipTimestamp uint64) error {
 	if err := s.blockStore.TruncateCanonical(uint64(len(rollbackState.canonicalIndex)) - 1); err != nil {
+		if isAtomicWritePostCommit(err) {
+			return s.handlePersistenceError(err, true, false)
+		}
 		return s.rollbackApplyBlock(err, rollbackState)
 	}
 	if s.cfg.ChainStatePath != "" {
 		if err := s.chainState.Save(s.cfg.ChainStatePath); err != nil {
+			if isAtomicWritePostCommit(err) {
+				return s.handlePersistenceError(err, false, true)
+			}
 			return s.rollbackApplyBlock(err, rollbackState)
 		}
 	}

--- a/clients/go/node/sync_persistence_fault_test.go
+++ b/clients/go/node/sync_persistence_fault_test.go
@@ -1,0 +1,290 @@
+//go:build darwin || linux
+
+package node
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func newPersistenceFaultEngine(t *testing.T) (*SyncEngine, *BlockStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := CreateBlockStore(BlockStorePath(dir))
+	mustAtomic(t, err)
+	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(nil, devnetGenesisChainID, ChainStatePath(dir)))
+	mustAtomic(t, err)
+	return engine, store, dir
+}
+
+func requirePersistenceFault(t *testing.T, err error, operation atomicWriteOperation) *storagePersistenceFault {
+	t.Helper()
+	atomic := requireAtomicWriteError(t, err, atomicWriteAfterNamespaceCommit, operation)
+	var fault *storagePersistenceFault
+	requireAtomicTest(t, errors.Is(atomic.primary, os.ErrPermission) && errors.As(err, &fault) && fault != nil, "primary=%v error type=%T, want permission *storagePersistenceFault", atomic.primary, err)
+	return fault
+}
+
+func awaitPersistenceResult(t *testing.T, result <-chan error, name string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		t.Fatalf("timed out joining %s", name)
+		return nil
+	}
+}
+
+func startBlockedApply(t *testing.T, engine *SyncEngine, store *BlockStore, secondScratch chan<- struct{}) (chan<- struct{}, <-chan error) {
+	t.Helper()
+	entered, release, result := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		open, link, unlink, links, opens, injected := ops.openScratch, ops.link, ops.unlink, 0, 0, false
+		ops.openScratch = func(path string, flag int, mode os.FileMode) (atomicWriteScratchFile, error) {
+			opens++
+			if opens > 1 && secondScratch != nil {
+				select {
+				case secondScratch <- struct{}{}:
+				default:
+				}
+			}
+			return open(path, flag, mode)
+		}
+		ops.link = func(a, b string) error { links++; return link(a, b) }
+		ops.unlink = func(path string) error {
+			if !injected && links == 1 && filepath.Dir(path) == store.blocksDir {
+				injected = true
+				close(entered)
+				<-release
+				return os.ErrPermission
+			}
+			return unlink(path)
+		}
+	})
+	go func() { _, err := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil); result <- err }()
+	select {
+	case <-entered:
+	case err := <-result:
+		close(release)
+		t.Fatalf("apply returned before injection: %v", err)
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("timed out waiting for cleanup failure")
+	}
+	return release, result
+}
+
+func TestSyncEnginePostCommitFailuresReloadVisibleStateWithoutCompensation(t *testing.T) {
+	targets := []struct {
+		name   string
+		parent func(*BlockStore, string) string
+	}{
+		{"block", func(s *BlockStore, _ string) string { return s.blocksDir }},
+		{"header", func(s *BlockStore, _ string) string { return s.headersDir }},
+		{"undo", func(s *BlockStore, _ string) string { return s.undoDir }},
+		{"index", func(s *BlockStore, _ string) string { return s.rootPath }},
+		{"chainstate", func(_ *BlockStore, d string) string { return d }},
+	}
+	entries := []func(*SyncEngine, []byte, []uint64) (*ChainStateConnectSummary, error){
+		(*SyncEngine).ApplyBlock,
+		(*SyncEngine).ApplyBlockWithReorg,
+	}
+	for targetIndex, tc := range targets {
+		for _, failure := range []string{"unlink", "sync"} {
+			for entryIndex, entry := range entries {
+				t.Run(tc.name+"/"+failure+"/"+[]string{"apply", "reorg"}[entryIndex], func(t *testing.T) {
+					engine, store, dir := newPersistenceFaultEngine(t)
+					engine.cfg.ChainStatePath = []string{"", engine.cfg.ChainStatePath, engine.cfg.ChainStatePath, engine.cfg.ChainStatePath, engine.cfg.ChainStatePath}[targetIndex]
+					parent, failed, commits := tc.parent(store, dir), false, 0
+					withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+						link, rename, unlink, sync := ops.link, ops.rename, ops.unlink, ops.syncParent
+						ops.link = func(a, b string) error { commits++; return link(a, b) }
+						ops.rename = func(a, b string) error { commits++; return rename(a, b) }
+						ops.unlink = func(path string) error {
+							if failure == "unlink" && !failed && commits == targetIndex+1 && filepath.Dir(path) == parent {
+								failed = true
+								return os.ErrPermission
+							}
+							return unlink(path)
+						}
+						ops.syncParent = func(path string) error {
+							if failure == "sync" && !failed && path == parent {
+								failed = true
+								return os.ErrPermission
+							}
+							return sync(path)
+						}
+					})
+					summary, err := entry(engine, DevnetGenesisBlockBytes(), nil)
+					requireAtomicTest(t, summary == nil && failed, "summary=%+v injected=%v", summary, failed)
+					fault := requirePersistenceFault(t, err, []atomicWriteOperation{atomicWriteCreateIfAbsent, atomicWriteCreateIfAbsent, atomicWriteCreateIfAbsent, atomicWriteOverwrite, atomicWriteOverwrite}[targetIndex])
+					requireAtomicTest(t, fault == engine.persistenceFault && errors.Is(fault.cause, os.ErrPermission) && commits == targetIndex+1, "fault=%+v commits=%d", fault, commits)
+					disk, err := OpenBlockStore(BlockStorePath(dir))
+					mustAtomic(t, err)
+					_, _, diskStore, err := disk.Tip()
+					mustAtomic(t, err)
+					_, _, cachedStore, err := store.Tip()
+					requireAtomicTest(t, err == nil && diskStore == cachedStore && diskStore == (targetIndex >= 3), "store disk=%v cache=%v err=%v", diskStore, cachedStore, err)
+					diskState, err := LoadChainState(ChainStatePath(dir))
+					mustAtomic(t, err)
+					requireAtomicTest(t, diskState.HasTip == (targetIndex == 4) && engine.chainState.view().hasTip == (targetIndex >= 3), "state disk=%v cache=%v", diskState.HasTip, engine.chainState.view().hasTip)
+				})
+			}
+		}
+	}
+	var nilStore *BlockStore
+	requireAtomicTest(t, nilStore.reloadFromDisk() != nil, "nil blockstore reload")
+	cause, reload := errors.New("cause"), errors.New("reload")
+	fault := &storagePersistenceFault{cause: cause}
+	requireAtomicTest(t, fault.Error() == "storage persistence fault: cause" && errors.Is(fault, cause), "fault=%v", fault)
+	fault.reloadErr = reload
+	requireAtomicTest(t, fault.Error() == "storage persistence fault: cause (reload failed: reload)" && errors.Is(fault, cause), "fault=%v", fault)
+	var nilFault *storagePersistenceFault
+	requireAtomicTest(t, nilFault.Unwrap() == nil, "nil fault unwrap")
+}
+
+func TestSyncEnginePostCommitFaultLatchesBeforeCapturedStateReplacement(t *testing.T) {
+	engine, store, _ := newPersistenceFaultEngine(t)
+	release, result := startBlockedApply(t, engine, store, nil)
+	engine.chainState.admissionMu.Lock()
+	close(release)
+	for deadline := time.Now().Add(time.Second); !engine.persistenceFaulted() && time.Now().Before(deadline); {
+		time.Sleep(time.Millisecond)
+	}
+	if !engine.persistenceFaulted() {
+		t.Error("persistence fault was not published before replacement")
+	}
+	engine.chainState.admissionMu.Unlock()
+	requirePersistenceFault(t, awaitPersistenceResult(t, result, "failed apply"), atomicWriteCreateIfAbsent)
+}
+
+func TestSyncEngineQueuesMutatorsUntilPostCommitFaultIsPublished(t *testing.T) {
+	engine, store, _ := newPersistenceFaultEngine(t)
+	target, started, secondScratch, secondResult, bootstrapResult := consensus.POW_LIMIT, make(chan struct{}, 2), make(chan struct{}, 1), make(chan error, 1), make(chan error, 1)
+	release, firstResult := startBlockedApply(t, engine, store, secondScratch)
+	engine.cfg.Network, engine.cfg.ExpectedTarget = "regtest", &target
+	block1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, 1))
+	engine.persistenceFaultMu.Lock()
+	start := func(call func() error, result chan<- error) { started <- struct{}{}; result <- call() }
+	go start(func() error { _, err := engine.ApplyBlock(block1, nil); return err }, secondResult)
+	go start(engine.BootstrapCanonicalGenesisIfEmpty, bootstrapResult)
+	func() { <-started; <-started }()
+	close(release)
+	select {
+	case <-secondScratch:
+		t.Error("queued mutator reached scratch before fault publication")
+	case <-time.After(100 * time.Millisecond):
+	}
+	engine.persistenceFaultMu.Unlock()
+	requirePersistenceFault(t, awaitPersistenceResult(t, firstResult, "first apply"), atomicWriteCreateIfAbsent)
+	results := [2]error{awaitPersistenceResult(t, secondResult, "second apply"), awaitPersistenceResult(t, bootstrapResult, "bootstrap")}
+	requireAtomicTest(t, errors.Is(results[0], errStoragePersistenceFault) && errors.Is(results[1], errStoragePersistenceFault), "second apply=%v bootstrap=%v", results[0], results[1])
+}
+
+func TestBootstrapPostCommitFaultIsNeverRaceRecovered(t *testing.T) {
+	for _, reloadFails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "reloads", true: "reload_fails"}[reloadFails], func(t *testing.T) {
+			engine, _, dir := newPersistenceFaultEngine(t)
+			failed := false
+			withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+				sync := ops.syncParent
+				ops.syncParent = func(parent string) error {
+					if !failed && parent == dir {
+						failed = true
+						if reloadFails {
+							mustAtomic(t, os.Remove(ChainStatePath(dir)))
+							mustAtomic(t, os.Mkdir(ChainStatePath(dir), 0o700))
+						}
+						return os.ErrPermission
+					}
+					return sync(parent)
+				}
+			})
+			fault, later := requirePersistenceFault(t, engine.BootstrapCanonicalGenesisIfEmpty(), atomicWriteOverwrite), engine.BootstrapCanonicalGenesisIfEmpty()
+			requireAtomicTest(t, failed && fault == engine.persistenceFault && errors.Is(fault.cause, os.ErrPermission) && (fault.reloadErr != nil) == reloadFails && errors.Is(later, errStoragePersistenceFault), "fault=%+v injected=%v later=%v", fault, failed, later)
+		})
+	}
+}
+
+func TestSyncEnginePersistenceFaultBlocksEveryMutationEntrypoint(t *testing.T) {
+	engine, store, _ := newPersistenceFaultEngine(t)
+	failed := false
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		sync := ops.syncParent
+		ops.syncParent = func(parent string) error {
+			if !failed && parent == store.rootPath {
+				failed = true
+				return os.ErrPermission
+			}
+			return sync(parent)
+		}
+	})
+	_, err := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil)
+	requireAtomicTest(t, err != nil && failed, "expected injected post-commit fault")
+	miner, err := NewMiner(engine.chainState, store, engine, DefaultMinerConfig())
+	mustAtomic(t, err)
+	for _, row := range []struct {
+		name string
+		call func() error
+	}{
+		{"bootstrap", engine.BootstrapCanonicalGenesisIfEmpty}, {"apply", func() error { _, e := engine.ApplyBlock([]byte{0}, nil); return e }}, {"reorg", func() error { _, e := engine.ApplyBlockWithReorg([]byte{0}, nil); return e }}, {"disconnect", func() error { _, e := engine.DisconnectTip(); return e }}, {"miner", func() error { _, e := miner.MineOne(context.Background(), nil); return e }},
+	} {
+		err := row.call()
+		requireAtomicTest(t, errors.Is(err, errStoragePersistenceFault), "%s=%v", row.name, err)
+	}
+}
+
+func TestSyncEngineRollbackAndDisconnectPostCommitFaultsDoNotCompensate(t *testing.T) {
+	t.Run("rollback", func(t *testing.T) {
+		engine, store, _ := newPersistenceFaultEngine(t)
+		openFailed, syncFailed, commits := false, false, 0
+		withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+			open, rename, sync := ops.openScratch, ops.rename, ops.syncParent
+			ops.openScratch = func(path string, f int, m os.FileMode) (atomicWriteScratchFile, error) {
+				if !openFailed && filepath.Dir(path) == store.blocksDir {
+					openFailed = true
+					return nil, syscall.ENOSPC
+				}
+				return open(path, f, m)
+			}
+			ops.rename = func(a, b string) error { commits++; return rename(a, b) }
+			ops.syncParent = func(parent string) error {
+				if !syncFailed && parent == store.rootPath {
+					syncFailed = true
+					return os.ErrPermission
+				}
+				return sync(parent)
+			}
+		})
+		requirePersistenceFault(t, func() error { _, err := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil); return err }(), atomicWriteOverwrite)
+		requireAtomicTest(t, openFailed && syncFailed && commits == 1 && engine.persistenceFault != nil, "open=%v sync=%v commits=%d fault=%+v", openFailed, syncFailed, commits, engine.persistenceFault)
+	})
+	t.Run("disconnect", func(t *testing.T) {
+		engine, store, _ := newPersistenceFaultEngine(t)
+		mustAtomic(t, func() error { _, err := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil); return err }())
+		failed, commits := false, 0
+		withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+			rename, sync := ops.rename, ops.syncParent
+			ops.rename = func(a, b string) error { commits++; return rename(a, b) }
+			ops.syncParent = func(parent string) error {
+				if !failed && parent == store.rootPath {
+					failed = true
+					return os.ErrPermission
+				}
+				return sync(parent)
+			}
+		})
+		requirePersistenceFault(t, func() error { _, err := engine.DisconnectTip(); return err }(), atomicWriteOverwrite)
+		requireAtomicTest(t, failed && commits == 1 && engine.persistenceFault != nil, "failed=%v commits=%d fault=%+v", failed, commits, engine.persistenceFault)
+		_, _, ok, err := store.Tip()
+		requireAtomicTest(t, err == nil && !ok, "cache tip=%v err=%v", ok, err)
+	})
+}

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -103,6 +104,19 @@ func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uin
 func (s *SyncEngine) finalizeAppliedBlock(summary *ChainStateConnectSummary, blockHash [32]byte, pb *consensus.ParsedBlock, blockBytes []byte, prevState *ChainState, rollbackState syncRollbackState) error {
 	commitStart := time.Now()
 	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
+		if isAtomicWritePostCommit(err) {
+			var atomicErr *atomicWriteError
+			errors.As(err, &atomicErr)
+			if s.blockStore != nil && atomicErr.destination == s.blockStore.indexPath {
+				return s.handlePersistenceError(err, true, false)
+			}
+			if atomicErr.destination == s.cfg.ChainStatePath {
+				return s.handlePersistenceError(err, false, true)
+			}
+			fault := s.handlePersistenceError(err, false, false)
+			s.chainState.replaceFrom(rollbackState.chainState)
+			return fault
+		}
 		return s.rollbackApplyBlock(err, rollbackState)
 	}
 	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -18,8 +18,13 @@ type reorgBranchBlock struct {
 }
 
 func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
-	if s == nil || s.chainState == nil {
+	if s == nil {
 		return nil, errors.New("sync engine is not initialized")
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	if err := s.mutationAllowed(); err != nil {
+		return nil, err
 	}
 	pb, blockHash, err := parseReorgBlock(blockBytes)
 	if err != nil {
@@ -71,6 +76,9 @@ func (s *SyncEngine) evaluateSideBranch(
 }
 
 func (s *SyncEngine) storeSideBlockAndSummary(branch []reorgBranchBlock, commonAncestorHeight uint64, candidateHeight uint64) (*ChainStateConnectSummary, error) {
+	if err := s.mutationAllowed(); err != nil {
+		return nil, err
+	}
 	if len(branch) == 0 {
 		return nil, errors.New("empty side branch")
 	}
@@ -93,6 +101,9 @@ func (s *SyncEngine) storeSideBlockAndSummary(branch []reorgBranchBlock, commonA
 		return nil, err
 	}
 	if err := s.blockStore.StoreBlock(candidate.hash, candidate.parsed.HeaderBytes, candidate.blockBytes); err != nil {
+		if isAtomicWritePostCommit(err) {
+			return nil, s.handlePersistenceError(err, false, false)
+		}
 		return nil, err
 	}
 	return s.syntheticSideChainSummary(candidateHeight, candidate.hash), nil

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -504,7 +504,7 @@ func TestSyncEngineBlockApplyCountsCanonicalAcceptedRejected(t *testing.T) {
 // TestSyncEngineApplyBlockPutUndoFailureRollsBackCanonicalTip lives in
 // sync_unix_test.go behind a `//go:build unix` tag: after the E.3
 // TOCTOU hardening the undo write no longer routes through
-// writeFileAtomicFn (it uses writeAndSyncTemp + os.Link), so the only
+// writeFileAtomicFn (it uses the fixed-scratch hard-link lane), so the only
 // portable way to provoke an undo-write failure is a chmod-based
 // permission error on the undo directory, which needs os.Geteuid() to
 // skip under root. See that file for the actual test body.

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -8,9 +8,11 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{
-    parse_hex32, read_file_by_path, read_file_from_dir, read_file_from_dir_unbounded,
-    write_file_atomic, write_file_exclusive, AtomicWriteError, BLOCK_FILE_MAX_BYTES,
-    HEADER_FILE_MAX_BYTES, UNDO_FILE_MAX_BYTES,
+    atomic_write_error_after, atomic_write_error_before, parse_hex32, read_file_by_path,
+    read_file_from_dir, read_file_from_dir_unbounded, sync_atomic_parent,
+    validate_atomic_write_destination, write_file_atomic_typed, write_file_create_if_absent,
+    AtomicWriteError, AtomicWriteOperation, BLOCK_FILE_MAX_BYTES, HEADER_FILE_MAX_BYTES,
+    UNDO_FILE_MAX_BYTES,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 use std::ffi::OsStr;
@@ -188,11 +190,7 @@ impl BlockStore {
     /// sequence in `sync.rs`, this API shrinks the failure surface: the
     /// tip never advances before undo durability, so no post-hoc
     /// `truncate_canonical` rewind is needed on undo-write failure.
-    /// Note: a subsequent `chain_state.save` failure AFTER a successful
-    /// `commit_canonical_block` still requires the caller to call
-    /// `truncate_canonical(canonical_len_before)` because the tip has
-    /// already advanced; that rewind is outside the atomic boundary of
-    /// this API (see `sync.rs` main commit callsite).
+    /// Precommit preserves tip; postcommit may advance disk. Standalone returns the error; typed SyncEngine reloads index/cache and latches.
     ///
     /// **Orphan semantics on retry.** A failure at any step before the
     /// tip advance may leave block/header/undo files on disk without a
@@ -212,6 +210,17 @@ impl BlockStore {
         block_bytes: &[u8],
         undo: &BlockUndo,
     ) -> Result<(), String> {
+        self.commit_canonical_block_typed(height, block_hash_bytes, header_bytes, block_bytes, undo)
+            .map_err(|error| error.to_string())
+    }
+    pub(crate) fn commit_canonical_block_typed(
+        &mut self,
+        height: u64,
+        block_hash_bytes: [u8; 32],
+        header_bytes: &[u8],
+        block_bytes: &[u8],
+        undo: &BlockUndo,
+    ) -> Result<(), AtomicWriteError> {
         // 0. Reject mismatched undo up front. If `undo.block_height` does
         //    not match the canonical height being committed, a later
         //    `ChainState::disconnect_block` would trip its height invariant
@@ -219,9 +228,13 @@ impl BlockStore {
         //    non-atomic failure mode this API is closing. Rejecting before
         //    any disk write keeps the canonical state untouched.
         if undo.block_height != height {
-            return Err(format!(
-                "undo block_height mismatch: commit height={height}, undo.block_height={}",
-                undo.block_height
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                format!(
+                    "undo block_height mismatch: commit height={height}, undo.block_height={}",
+                    undo.block_height
+                ),
             ));
         }
         // 0a. Height-range + idempotent same-hash no-op guards. Semantics
@@ -260,12 +273,18 @@ impl BlockStore {
         //     - `height == canonical_len` is the normal append.
         let current_len = self.canonical_len() as u64;
         if height > current_len {
-            return Err(format!(
-                "commit_canonical_block height gap: height={height} > canonical_len={current_len}"
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                format!(
+                    "commit_canonical_block height gap: height={height} > canonical_len={current_len}"
+                ),
             ));
         }
         if height < current_len {
-            let existing = self.canonical_hash(height)?;
+            let existing = self.canonical_hash(height).map_err(|error| {
+                atomic_write_error_before(&self.index_path, AtomicWriteOperation::Overwrite, error)
+            })?;
             if existing == Some(block_hash_bytes) {
                 // Idempotent same-hash replay with symmetric healing.
                 //
@@ -288,9 +307,9 @@ impl BlockStore {
                 //    write), `put_undo` back-fills it.
                 //
                 //  Canonical index / tip remain unchanged regardless.
-                self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
+                self.persist_block_bytes_typed(block_hash_bytes, header_bytes, block_bytes)?;
                 if !self.has_undo(block_hash_bytes) {
-                    self.put_undo(block_hash_bytes, undo)?;
+                    self.put_undo_typed(block_hash_bytes, undo)?;
                 }
                 return Ok(());
             }
@@ -298,12 +317,12 @@ impl BlockStore {
             // through to persist + tip replace.
         }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
-        self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
+        self.persist_block_bytes_typed(block_hash_bytes, header_bytes, block_bytes)?;
         // 2. Persist undo BEFORE any tip advance. Matches Go ordering in
         //    `CommitCanonicalBlock` (StoreBlock → PutUndo → SetCanonicalTip).
-        self.put_undo(block_hash_bytes, undo)?;
+        self.put_undo_typed(block_hash_bytes, undo)?;
         // 3. Advance canonical tip LAST — this is the atomic commit point.
-        self.set_canonical_tip(height, block_hash_bytes)
+        self.set_canonical_tip_typed(height, block_hash_bytes)
     }
 
     /// Cheap header consistency check — length + computed hash equals
@@ -338,13 +357,23 @@ impl BlockStore {
         header_bytes: &[u8],
         block_bytes: &[u8],
     ) -> Result<(), String> {
-        self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
+        self.persist_block_bytes_typed(block_hash_bytes, header_bytes, block_bytes)
+            .map_err(|error| error.to_string())
+    }
+    fn persist_block_bytes_typed(
+        &self,
+        block_hash_bytes: [u8; 32],
+        header_bytes: &[u8],
+        block_bytes: &[u8],
+    ) -> Result<(), AtomicWriteError> {
         let hash_hex = hex::encode(block_hash_bytes);
-        write_file_if_absent(
-            &self.blocks_dir.join(format!("{hash_hex}.bin")),
-            block_bytes,
-        )?;
-        write_file_if_absent(
+        let block_path = self.blocks_dir.join(format!("{hash_hex}.bin"));
+        self.validate_header_matches_hash(header_bytes, block_hash_bytes)
+            .map_err(|error| {
+                atomic_write_error_before(&block_path, AtomicWriteOperation::CreateIfAbsent, error)
+            })?;
+        write_file_if_absent_typed(&block_path, block_bytes)?;
+        write_file_if_absent_typed(
             &self.headers_dir.join(format!("{hash_hex}.bin")),
             header_bytes,
         )
@@ -352,38 +381,44 @@ impl BlockStore {
 
     /// Set or replace the canonical tip at `height`.
     ///
-    /// Hot path (called per connected block via `put_block`): mutate
-    /// in-memory then save; on save failure best-effort
-    /// `reload_index_from_disk` to restore in-memory consistency.
-    /// Avoids the O(chain_height) clone that out-of-place transactions
-    /// would cost on every block.
+    /// Precommit restores suffix; postcommit standalone retains local state, while typed SyncEngine reloads index/cache and latches.
     pub fn set_canonical_tip(
         &mut self,
         height: u64,
         block_hash_bytes: [u8; 32],
     ) -> Result<(), String> {
+        self.set_canonical_tip_typed(height, block_hash_bytes)
+            .map_err(|error| error.to_string())
+    }
+    fn set_canonical_tip_typed(
+        &mut self,
+        height: u64,
+        block_hash_bytes: [u8; 32],
+    ) -> Result<(), AtomicWriteError> {
         let hash_hex = hex::encode(block_hash_bytes);
         let current_len = self.index.canonical.len() as u64;
         if height > current_len {
-            return Err(format!(
-                "height gap: got {height}, expected <= {current_len}"
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                format!("height gap: got {height}, expected <= {current_len}"),
             ));
         }
         // No-op if in-memory already holds this exact hash at this height.
         if height < current_len && self.index.canonical[height as usize] == hash_hex {
             return Ok(());
         }
-        if height == current_len {
-            self.index.canonical.push(hash_hex);
-            self.canonical_hash_by_height.push(block_hash_bytes);
-        } else {
-            self.index.canonical.truncate(height as usize);
-            self.canonical_hash_by_height.truncate(height as usize);
-            self.index.canonical.push(hash_hex);
-            self.canonical_hash_by_height.push(block_hash_bytes);
-        }
-        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
-            self.reload_index_from_disk();
+        let displaced_canonical = self.index.canonical.split_off(height as usize);
+        let displaced_cache = self.canonical_hash_by_height.split_off(height as usize);
+        self.index.canonical.push(hash_hex);
+        self.canonical_hash_by_height.push(block_hash_bytes);
+        if let Err(e) = save_blockstore_index_typed(&self.index_path, &self.index) {
+            if e.stage == crate::io_utils::AtomicWriteStage::BeforeNamespaceCommit {
+                self.index.canonical.truncate(height as usize);
+                self.index.canonical.extend(displaced_canonical);
+                self.canonical_hash_by_height.truncate(height as usize);
+                self.canonical_hash_by_height.extend(displaced_cache);
+            }
             return Err(e);
         }
         Ok(())
@@ -391,9 +426,6 @@ impl BlockStore {
 
     /// Rewind canonical to (height + 1) entries.
     ///
-    /// Same hot-path strategy as `set_canonical_tip`: mutate-then-save
-    /// with reload on failure (avoids per-call clone of the canonical
-    /// vector).
     pub fn rewind_to_height(&mut self, height: u64) -> Result<(), String> {
         if self.index.canonical.is_empty() {
             return Ok(());
@@ -401,13 +433,17 @@ impl BlockStore {
         if height >= self.index.canonical.len() as u64 {
             return Err(format!("rewind height out of range: {height}"));
         }
-        self.index.canonical.truncate(height as usize + 1);
-        self.canonical_hash_by_height.truncate(height as usize + 1);
-        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
-            self.reload_index_from_disk();
-            return Err(e);
+        let new_len = height as usize + 1;
+        match self.truncate_canonical_typed(new_len) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                if error.stage == crate::io_utils::AtomicWriteStage::AfterNamespaceCommit {
+                    self.index.canonical.truncate(new_len);
+                    self.canonical_hash_by_height.truncate(new_len);
+                }
+                Err(error.to_string())
+            }
         }
-        Ok(())
     }
 
     /// E.7: O(1) hot lookup served from `canonical_hash_by_height`
@@ -607,11 +643,20 @@ impl BlockStore {
         header_bytes: &[u8],
         block_bytes: &[u8],
     ) -> Result<(), String> {
+        self.store_block_typed(block_hash_bytes, header_bytes, block_bytes)
+            .map_err(|error| error.to_string())
+    }
+    pub(crate) fn store_block_typed(
+        &self,
+        block_hash_bytes: [u8; 32],
+        header_bytes: &[u8],
+        block_bytes: &[u8],
+    ) -> Result<(), AtomicWriteError> {
         // Delegate to the shared helper so header validation and
         // block/header file writes stay in one place across all
         // entry points (`put_block`, `commit_canonical_block`,
         // `store_block`).
-        self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)
+        self.persist_block_bytes_typed(block_hash_bytes, header_bytes, block_bytes)
     }
 
     // ----- Chain work -----
@@ -650,19 +695,34 @@ impl BlockStore {
     /// A standalone `put_undo` paired with `set_canonical_tip` in the
     /// opposite order would reintroduce the E.4 atomicity gap this task
     /// is closing.
+    #[cfg(test)]
     pub(crate) fn put_undo(
         &self,
         block_hash_bytes: [u8; 32],
         undo: &BlockUndo,
     ) -> Result<(), String> {
-        #[cfg(test)]
-        if self.force_undo_error {
-            return Err("forced undo error (test)".to_string());
-        }
-        let raw = marshal_block_undo(undo)?;
+        self.put_undo_typed(block_hash_bytes, undo)
+            .map_err(|error| error.to_string())
+    }
+    fn put_undo_typed(
+        &self,
+        block_hash_bytes: [u8; 32],
+        undo: &BlockUndo,
+    ) -> Result<(), AtomicWriteError> {
         let path = self
             .undo_dir
             .join(format!("{}.json", hex::encode(block_hash_bytes)));
+        #[cfg(test)]
+        if self.force_undo_error {
+            return Err(atomic_write_error_before(
+                &path,
+                AtomicWriteOperation::Overwrite,
+                "forced undo error (test)",
+            ));
+        }
+        let raw = marshal_block_undo(undo).map_err(|error| {
+            atomic_write_error_before(&path, AtomicWriteOperation::Overwrite, error)
+        })?;
         // Undo files intentionally stay on the raw `write_file_atomic`
         // path (no `lexical_clean`). Writer and readers share one
         // dir-resolution strategy:
@@ -691,8 +751,11 @@ impl BlockStore {
             &path.display().to_string(),
             raw.len(),
             UNDO_FILE_MAX_BYTES,
-        )?;
-        write_file_atomic(&path, &raw)
+        )
+        .map_err(|error| {
+            atomic_write_error_before(&path, AtomicWriteOperation::Overwrite, error)
+        })?;
+        write_file_atomic_typed(&path, &raw)
     }
 
     pub fn get_undo(&self, block_hash_bytes: [u8; 32]) -> Result<BlockUndo, String> {
@@ -738,16 +801,27 @@ impl BlockStore {
     ///
     /// Atomic via out-of-place transaction: build the next index as a
     /// clone, save to disk, then commit to in-memory only on success.
-    /// A failed call leaves the in-memory canonical exactly as it was
-    /// before, so callers can rely on `Err` meaning "no state change".
+    /// Precommit preserves disk and memory; postcommit may replace disk while standalone memory stays old; typed SyncEngine reloads index/cache and latches.
     pub fn rollback_canonical(
         &mut self,
         base_len: usize,
         suffix: Vec<String>,
     ) -> Result<(), String> {
+        self.rollback_canonical_typed(base_len, suffix)
+            .map_err(|error| error.to_string())
+    }
+    pub(crate) fn rollback_canonical_typed(
+        &mut self,
+        base_len: usize,
+        suffix: Vec<String>,
+    ) -> Result<(), AtomicWriteError> {
         #[cfg(test)]
         if self.force_rollback_error {
-            return Err("forced rollback error (test inject)".into());
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                "forced rollback error (test inject)",
+            ));
         }
         // Build the target canonical once (owning only `suffix` + a
         // slice clone of `base_len` prefix entries).  No clone of the
@@ -758,15 +832,15 @@ impl BlockStore {
         next_canonical.extend(suffix);
         // Build the next height->hash cache BEFORE the disk write so a
         // malformed entry in `suffix` (e.g. non-hex hash string) fails
-        // closed without touching disk. Documented atomicity contract
-        // ("Err means no state change") requires every fallible step to
-        // run before `save_blockstore_index_serializable`.
-        let next_cache = build_canonical_hash_cache(&next_canonical)?;
+        // closed without touching disk. Precommit preserves disk/memory; postcommit may replace disk while memory stays old; typed SyncEngine reloads index/cache and latches.
+        let next_cache = build_canonical_hash_cache(&next_canonical).map_err(|error| {
+            atomic_write_error_before(&self.index_path, AtomicWriteOperation::Overwrite, error)
+        })?;
         let view = BlockStoreIndexView {
             version: self.index.version,
             canonical: &next_canonical,
         };
-        save_blockstore_index_serializable(&self.index_path, &view)?;
+        save_blockstore_index_serializable_typed(&self.index_path, &view)?;
         // Disk save succeeded — commit to in-memory (E.7 parity: mirror
         // Go's `replaceCanonicalState` rebuild after rollback).
         self.index.canonical = next_canonical;
@@ -776,20 +850,29 @@ impl BlockStore {
 
     /// Truncate canonical index to exactly `new_len` entries.
     ///
-    /// Atomic: in-memory state is updated ONLY after the disk write
-    /// succeeds.  A failed call leaves the in-memory canonical exactly
-    /// as it was before, so callers can rely on `Err` meaning "no
-    /// state change".  Writes a borrowed slice-backed view of the
-    /// target prefix instead of cloning all canonical strings.
+    /// Precommit preserves disk/memory; postcommit may advance disk while standalone memory stays old; typed SyncEngine reloads index/cache and latches. Uses a borrowed slice view.
     pub fn truncate_canonical(&mut self, new_len: usize) -> Result<(), String> {
+        self.truncate_canonical_typed(new_len)
+            .map_err(|error| error.to_string())
+    }
+    pub(crate) fn truncate_canonical_typed(
+        &mut self,
+        new_len: usize,
+    ) -> Result<(), AtomicWriteError> {
         #[cfg(test)]
         if self.force_truncate_error {
-            return Err("forced truncate error (test inject)".into());
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                "forced truncate error (test inject)",
+            ));
         }
         let current_len = self.index.canonical.len();
         if new_len > current_len {
-            return Err(format!(
-                "truncate_canonical new_len {new_len} > current {current_len}"
+            return Err(atomic_write_error_before(
+                &self.index_path,
+                AtomicWriteOperation::Overwrite,
+                format!("truncate_canonical new_len {new_len} > current {current_len}"),
             ));
         }
         // Fast-path: already at target length, skip the disk write.
@@ -800,7 +883,7 @@ impl BlockStore {
             version: self.index.version,
             canonical: &self.index.canonical[..new_len],
         };
-        save_blockstore_index_serializable(&self.index_path, &view)?;
+        save_blockstore_index_serializable_typed(&self.index_path, &view)?;
         // Save succeeded — now apply O(1) in-memory truncate.
         self.index.canonical.truncate(new_len);
         // E.7: keep height->hash cache coherent with the canonical
@@ -811,26 +894,15 @@ impl BlockStore {
         Ok(())
     }
 
-    /// Reload the blockstore index from disk to restore in-memory
-    /// consistency after a failed save in a hot-path mutator
-    /// (`set_canonical_tip`, `rewind_to_height`).  Best-effort: if the
-    /// reload itself fails the in-memory state is stale, but we have
-    /// already returned the original error to the caller — the engine
-    /// is in an unrecoverable state and needs repair.  Not used by
-    /// `truncate_canonical` / `rollback_canonical`, which use the
-    /// out-of-place transaction pattern instead.
-    fn reload_index_from_disk(&mut self) {
-        if let Ok(disk) = load_blockstore_index(&self.index_path) {
-            // E.7: canonical hash decoding/validation happens in
-            // `build_canonical_hash_cache` (not in `load_blockstore_index`).
-            // If disk canonical entries are malformed, keep the prior
-            // in-memory state untouched to preserve the documented
-            // unrecoverable-state contract.
-            if let Ok(cache) = build_canonical_hash_cache(&disk.canonical) {
-                self.canonical_hash_by_height = cache;
-                self.index = disk;
-            }
-        }
+    pub(crate) fn reload_persistence_state(&mut self) -> Result<(), String> {
+        let disk = load_blockstore_index(&self.index_path)?;
+        let cache = build_canonical_hash_cache(&disk.canonical)?;
+        self.canonical_hash_by_height = cache;
+        self.index = disk;
+        Ok(())
+    }
+    pub(crate) fn is_index_destination(&self, path: &Path) -> bool {
+        self.index_path == path
     }
 }
 
@@ -946,8 +1018,25 @@ fn save_blockstore_index_serializable<S: serde::Serialize + ?Sized>(
     path: &Path,
     index: &S,
 ) -> Result<(), String> {
-    let mut raw =
-        serde_json::to_vec_pretty(index).map_err(|e| format!("encode blockstore index: {e}"))?;
+    save_blockstore_index_serializable_typed(path, index).map_err(|error| error.to_string())
+}
+fn save_blockstore_index_typed(
+    path: &Path,
+    index: &BlockStoreIndexDisk,
+) -> Result<(), AtomicWriteError> {
+    save_blockstore_index_serializable_typed(path, index)
+}
+fn save_blockstore_index_serializable_typed<S: serde::Serialize + ?Sized>(
+    path: &Path,
+    index: &S,
+) -> Result<(), AtomicWriteError> {
+    let mut raw = serde_json::to_vec_pretty(index).map_err(|error| {
+        atomic_write_error_before(
+            path,
+            AtomicWriteOperation::Overwrite,
+            format!("encode blockstore index: {error}"),
+        )
+    })?;
     raw.push(b'\n');
     // Keep writer on raw `write_file_atomic` (no `lexical_clean`)
     // so the index file persists to the same physical directory
@@ -955,7 +1044,7 @@ fn save_blockstore_index_serializable<S: serde::Serialize + ?Sized>(
     // `load_blockstore_index` reads back from. See the comment in
     // `load_blockstore_index` for the full blockstore-wide symmetry
     // rationale.
-    write_file_atomic(path, &raw)
+    write_file_atomic_typed(path, &raw)
 }
 
 /// Borrowed view of `BlockStoreIndexDisk` that serializes identically
@@ -966,206 +1055,109 @@ struct BlockStoreIndexView<'a> {
     version: u32,
     canonical: &'a [String],
 }
-
-/// Write `content` to `path` only if the destination is absent
-/// (idempotent replay: a subsequent call with matching bytes is a
-/// silent no-op). Hardened against the TOCTOU race audited as `E.3`:
-/// the previous implementation did `fs::read()` then `write_file_atomic`
-/// which could silently overwrite a file that appeared between the two
-/// syscalls. The new implementation keeps a read-compare fast path for
-/// the idempotent-replay case (matches the Go `writeFileIfAbsent` fast
-/// path) and falls through to `io_utils::write_file_exclusive` (which
-/// uses `hard_link(2)` for atomic create-if-absent) only when the
-/// destination is genuinely absent. On EEXIST from the race window we
-/// read back the destination and preserve the idempotent-same-content
-/// contract; on content mismatch we surface an explicit error.
-///
-/// Read-compare fast path matters for two reasons (Codex review on
-/// PR #1220):
-/// 1. idempotent replay during sync-engine restart is the dominant
-///    caller and must not do unnecessary disk I/O;
-/// 2. it keeps the "dest already has matching bytes" case working even
-///    when the parent directory is temporarily unwritable (for example
-///    chmod 0o500 hardening), because read does not need write
-///    permission but the temp-write path does.
-///
-/// Mirrors the Go `writeFileIfAbsent` helper's `os.Link` flow for
-/// cross-client storage parity.
-///
-/// # Threat model
-///
-/// **Concurrent actors**: Two writers race on `fs::hard_link(tmp, path)`;
-/// exactly one link succeeds. The loser sees `AlreadyExists`, reads the
-/// winner's content, and returns `Ok(())` on match (idempotent replay)
-/// or an explicit error on drift (never overwrite). Per-call
-/// `temp_path_for(path, pid, next_temp_seq())` gives distinct temp
-/// paths so in-process threads never collide.
-///
-/// **Process crash**: A crash between `hard_link` and the best-effort
-/// temp-unlink leaves a stale `<pid>.<seq>` hard-linked to the
-/// destination inode. That is safe: `write_and_sync_temp` uses
-/// `O_CREATE|O_EXCL` (no `O_TRUNC`), so any later call hitting the same
-/// temp path returns `AlreadyExists` via `allocate_and_write_temp` and
-/// retries with a fresh `seq` (16-retry budget). NOTHING removes that
-/// sibling today: a crash between the temp write and the link or rename
-/// leaks one `<dest>.tmp.<pid>.<seq>` file, and there is no startup
-/// sweep. The leak exists only because the name is unique per write; the
-/// fix is a FIXED temp name per destination (which the next write
-/// truncates) plus a datadir lock, not a startup deletion pass — Bitcoin
-/// Core and Monero take the naming route and sweep nothing at startup.
-/// Tracked as RUB-1078. A crash before the final
-/// `sync_dir` leaves the dirent in page cache; the fast-path on retry
-/// re-runs `sync_dir` and PROPAGATES its error so the durability
-/// failure is surfaced.
-///
-/// **Cross-platform**: Unix (Linux, macOS) is the production target:
-/// `fs::hard_link`, `create_new(true)` (O_EXCL), and directory fsync
-/// all honoured. Windows: directory fsync is a no-op at the stdlib
-/// level; `fs::remove_file` on an open fd would fail, which is why
-/// `write_and_sync_temp` explicitly `drop(fd)` before `remove_file`.
-/// Rust does not ship Rubin on Windows as a production target.
-///
-/// **Retry / exhaustion**: `allocate_and_write_temp` retries up to
-/// `MAX_TEMP_ALLOC_RETRIES` (16) on `AlreadyExists` with a fresh
-/// `next_temp_seq()`. Fatal I/O surfaces immediately. Exhaustion
-/// surfaces as `Err` mentioning the destination path.
-///
-/// **Inode / fs-layer**: `hard_link` is refcount-safe — destination
-/// and temp share the inode; unlinking temp drops the name without
-/// affecting bytes visible through `path`. `O_TRUNC` on any path that
-/// could share an inode with a live destination is intentionally
-/// avoided everywhere in the helper stack; see `write_and_sync_temp`
-/// for the explicit O_EXCL contract.
-///
-/// **Durability**: `write_and_sync_temp` fsyncs the temp's bytes + inode
-/// metadata before returning. `fs::hard_link` then exposes the inode
-/// under `path`. `sync_dir` on the parent flushes the directory entry
-/// so the link is itself durable. Both the `Ok` fast-path and the
-/// `AlreadyExists`-retry branches PROPAGATE the final `sync_dir` error
-/// — the previous `let _ = sync_dir(parent)` double-swallowed EIO
-/// through `sync_dir`'s own best-effort wrapper (Copilot P1 wave-7 on
-/// PR #1220).
+#[cfg(test)]
 fn write_file_if_absent(path: &Path, content: &[u8]) -> Result<(), String> {
-    // Both verify reads are bounded by the length of the content being
-    // written: they exist ONLY to compare against `content`, so a
-    // destination of any other size cannot match, and bounding by the
-    // caller's own length means a corrupt multi-gigabyte file at a
-    // 116-byte header destination is refused before allocation instead of
-    // being buffered whole (RUB-1057). The size refusal is mapped onto the
-    // pre-existing content-mismatch error by `existing_content_differs`, so
-    // the caller-visible taxonomy is identical for every mismatch whatever
-    // the existing file's size. The closure is the test seam mirroring Go's
-    // `readFileByPathFn` var.
-    let bound = content.len() as u64;
-    write_file_if_absent_with(path, content, move |p| read_file_by_path(p, bound))
+    write_file_if_absent_typed(path, content).map_err(|error| error.to_string())
 }
-
-/// The one caller-visible verdict for a destination whose bytes are not the
-/// bytes being written — including a destination too large to be them.
+fn write_file_if_absent_typed(path: &Path, content: &[u8]) -> Result<(), AtomicWriteError> {
+    let bound = content.len() as u64;
+    write_file_if_absent_with_typed(path, content, move |candidate| {
+        read_file_by_path(candidate, bound)
+    })
+}
 fn existing_content_differs(path: &Path) -> String {
     format!(
         "file already exists with different content: {}",
         path.display()
     )
 }
-
-/// True when `e` is the bounded reader's size refusal, i.e. the existing
-/// destination is larger than the content being written and therefore cannot
-/// equal it. Go twin: `errors.Is(err, errStoreFileTooLarge)` at the same sites.
-fn is_over_bound_refusal(e: &std::io::Error) -> bool {
-    e.kind() == std::io::ErrorKind::InvalidData
-        && e.to_string()
+fn is_over_bound_refusal(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::InvalidData
+        && error
+            .to_string()
             .starts_with(crate::io_utils::STORE_FILE_TOO_LARGE_PREFIX)
 }
-
+#[cfg(test)]
 fn write_file_if_absent_with(
     path: &Path,
     content: &[u8],
     read_existing: impl Fn(&Path) -> Result<Vec<u8>, std::io::Error>,
 ) -> Result<(), String> {
-    // Fast path: destination already on disk. Same behaviour as the Go
-    // helper's `readFileByPathFn(path)` fast path — short-circuit
-    // before any temp write when the file is already present with the
-    // right bytes (dominant idempotent-replay case).
-    //
-    // Copilot P1 on PR #1220: a previous call may have successfully
-    // created the destination but returned an error from the final
-    // `sync_dir(parent)` step (e.g. transient EIO). If the caller
-    // retries, we hit this fast-path and would silently report Ok
-    // without ever making the directory entry durable. Re-run
-    // `sync_dir` on the idempotent match branch and PROPAGATE its
-    // result — `io_utils::sync_dir` already applies the intended
-    // permission policy internally (execute-only/hardened parents
-    // treated as Ok), so propagating does NOT break the
-    // idempotent-replay-on-hardened-dir contract; it only surfaces
-    // real durability failures (EIO / ENOENT) that would otherwise be
-    // silent.
-    //
-    // Copilot P1 wave-7 on PR #1220: `let _ = sync_dir(parent)`
-    // double-swallowed errors — `sync_dir` is already best-effort,
-    // so the outer `let _` discarded the exact failures that MUST
-    // reach the caller. Propagate via `?` instead.
+    write_file_if_absent_with_typed(path, content, read_existing).map_err(|error| error.to_string())
+}
+fn write_file_if_absent_with_typed(
+    path: &Path,
+    content: &[u8],
+    read_existing: impl Fn(&Path) -> Result<Vec<u8>, std::io::Error>,
+) -> Result<(), AtomicWriteError> {
+    validate_atomic_write_destination(path, AtomicWriteOperation::CreateIfAbsent)?;
     match read_existing(path) {
         Ok(existing) => {
             if existing != content {
-                return Err(existing_content_differs(path));
+                return Err(atomic_write_error_before(
+                    path,
+                    AtomicWriteOperation::CreateIfAbsent,
+                    existing_content_differs(path),
+                ));
             }
-            if let Some(parent) = crate::io_utils::effective_parent(path) {
-                crate::io_utils::sync_dir(parent)?;
-            }
+            let parent = crate::io_utils::effective_parent(path).ok_or_else(|| {
+                atomic_write_error_before(
+                    path,
+                    AtomicWriteOperation::CreateIfAbsent,
+                    "atomic destination has no parent",
+                )
+            })?;
+            sync_atomic_parent(parent).map_err(|error| {
+                atomic_write_error_after(path, AtomicWriteOperation::CreateIfAbsent, error)
+            })?;
             return Ok(());
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Fall through to the race-hardened atomic write.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) if is_over_bound_refusal(&error) => {
+            return Err(atomic_write_error_before(
+                path,
+                AtomicWriteOperation::CreateIfAbsent,
+                existing_content_differs(path),
+            ));
         }
-        Err(e) if is_over_bound_refusal(&e) => {
-            // Larger than the content being written: cannot be a match.
-            return Err(existing_content_differs(path));
-        }
-        Err(e) => {
-            return Err(format!("read existing {}: {e}", path.display()));
+        Err(error) => {
+            return Err(atomic_write_error_before(
+                path,
+                AtomicWriteOperation::CreateIfAbsent,
+                format!("read existing {}: {error}", path.display()),
+            ));
         }
     }
 
-    match write_file_exclusive(path, content) {
-        Ok(()) => Ok(()),
-        Err(AtomicWriteError::AlreadyExists) => handle_link_eexist(path, content, read_existing),
-        Err(AtomicWriteError::Other(msg)) => Err(msg),
-    }
+    write_file_create_if_absent(path, content, move || {
+        handle_link_eexist(path, content, read_existing)
+    })
 }
 
-/// EEXIST verify arm (Go twin: `handleLinkEEXIST`): the destination
-/// appeared between the fast-path read and our link. Re-read it through
-/// the same bounded seam, verify content matches (idempotent retry) or
-/// surface the drift as an error — never silently overwrite, never Ok on
-/// drift.
 fn handle_link_eexist(
     path: &Path,
     content: &[u8],
     read_existing: impl Fn(&Path) -> Result<Vec<u8>, std::io::Error>,
 ) -> Result<(), String> {
-    let existing = read_existing(path).map_err(|e| {
-        if is_over_bound_refusal(&e) {
+    let existing = read_existing(path).map_err(|error| {
+        if is_over_bound_refusal(&error) {
             existing_content_differs(path)
         } else {
-            format!("read existing {}: {e}", path.display())
+            format!("read existing {}: {error}", path.display())
         }
     })?;
     if existing != content {
         return Err(existing_content_differs(path));
-    }
-    // Propagate parent dir-sync result on the EEXIST-retry branch for the
-    // same reason as the Ok fast-path above: `sync_dir` already applies
-    // the permission policy, so `?` surfaces only real durability failures.
-    if let Some(parent) = crate::io_utils::effective_parent(path) {
-        crate::io_utils::sync_dir(parent)?;
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::io_utils::{create_sparse_file, unique_temp_path, STORE_FILE_TOO_LARGE_PREFIX};
+    use crate::io_utils::{
+        create_sparse_file, unique_temp_path, AtomicWriteTestOp, AtomicWriteTestScope,
+        ATOMIC_WRITE_LOCK_LEAF, ATOMIC_WRITE_SCRATCH_LEAF, STORE_FILE_TOO_LARGE_PREFIX,
+    };
     use std::path::{Path, PathBuf};
 
     use super::{
@@ -1332,20 +1324,33 @@ mod tests {
     /// and a subsequent call with matching bytes is an idempotent
     /// no-op. Mirrors the Go `TestWriteFileIfAbsent_Fresh` for
     /// cross-client parity.
+    #[rustfmt::skip]
     #[test]
     fn write_file_if_absent_fresh_then_idempotent() {
-        let dir = unique_temp_path("rubin-wfia-fresh");
-        std::fs::create_dir_all(&dir).expect("create test dir");
-        let path = dir.join("fresh.bin");
-        let content = b"hello E.3".to_vec();
-
-        write_file_if_absent(&path, &content).expect("fresh write");
-        let got = std::fs::read(&path).expect("read back");
-        assert_eq!(got, content);
-
+        let dir = unique_temp_path("rubin-wfia-fresh"); std::fs::create_dir_all(&dir).expect("create test dir");
+        let path = dir.join("fresh.bin"); let content = b"hello E.3".to_vec();
+        let fresh = AtomicWriteTestScope::new(); write_file_if_absent(&path, &content).expect("fresh write");
+        assert!(fresh.operations().contains(&AtomicWriteTestOp::HardLink)); drop(fresh); assert_eq!(std::fs::read(&path).expect("read back"), content);
         // Idempotent replay: same bytes must succeed as a no-op.
-        write_file_if_absent(&path, &content).expect("idempotent replay");
-
+        for leaf in [ATOMIC_WRITE_LOCK_LEAF, ATOMIC_WRITE_SCRATCH_LEAF] { let _ = std::fs::remove_file(dir.join(leaf)); }
+        #[cfg(unix)]
+        let restore_parent = {
+            use std::os::unix::fs::PermissionsExt; struct Restore(std::path::PathBuf); impl Drop for Restore { fn drop(&mut self) { let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700)); } }
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("mode");
+            (unsafe { libc::geteuid() } != 0).then(|| { std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o500)).expect("readonly parent"); Restore(dir.clone()) })
+        };
+        let replay = AtomicWriteTestScope::new(); write_file_if_absent(&path, &content).expect("idempotent replay");
+        assert_eq!(replay.operations(), [AtomicWriteTestOp::ParentSync]); assert!(!dir.join(ATOMIC_WRITE_LOCK_LEAF).exists()); assert!(!dir.join(ATOMIC_WRITE_SCRATCH_LEAF).exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt; assert_eq!(std::fs::metadata(&path).expect("mode").permissions().mode() & 0o777, 0o644); drop(restore_parent);
+        }
+        drop(replay);
+        let reads = std::cell::Cell::new(0); for leaf in [ATOMIC_WRITE_LOCK_LEAF, ATOMIC_WRITE_SCRATCH_LEAF] {
+            let reserved = dir.join(leaf); let err = write_file_if_absent_with(&reserved, b"x", |_| { reads.set(reads.get() + 1); Ok(b"x".to_vec()) }).expect_err("reserved destination");
+            assert!(err.contains("reserved atomic persistence destination"));
+        }
+        assert_eq!(reads.get(), 0, "reserved destination validated before read");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1958,17 +1963,20 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    #[rustfmt::skip]
     #[test]
     fn canonical_hash_cache_coherent_after_replace_at_height() {
         // set_canonical_tip(height < current_len, different hash) is
         // the reorg-replace branch (truncate-then-push). The cache
         // must follow exactly: a stale entry at the replaced height
         // is the rejected case.
-        let dir = unique_temp_path("rubin-blockstore-e7-cache-replace");
-        std::fs::create_dir_all(&dir).expect("create test dir");
-        let root = block_store_path(&dir);
-        let mut store = BlockStore::create(&root).expect("create");
+        let dir = unique_temp_path("rubin-blockstore-e7-cache-replace"); std::fs::create_dir_all(&dir).expect("create test dir");
+        let root = block_store_path(&dir); let mut store = BlockStore::create(&root).expect("create");
 
+        let empty = std::fs::read(&store.index_path).expect("empty index");
+        std::fs::remove_file(&store.index_path).expect("remove index"); std::fs::create_dir(&store.index_path).expect("block index");
+        let err = store.set_canonical_tip(0, [0x42; 32]).unwrap_err(); assert!(err.contains("before_namespace_commit")); assert_eq!((store.canonical_len(), store.tip().unwrap()), (0, None));
+        std::fs::remove_dir(&store.index_path).expect("remove blocker"); std::fs::write(&store.index_path, empty).expect("restore index");
         store.set_canonical_tip(0, [0x10; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x11; 32]).expect("set 1");
         store.set_canonical_tip(2, [0x12; 32]).expect("set 2");
@@ -1984,18 +1992,22 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    #[rustfmt::skip]
     #[test]
     fn canonical_hash_cache_coherent_after_rewind_to_height() {
-        let dir = unique_temp_path("rubin-blockstore-e7-cache-rewind");
-        std::fs::create_dir_all(&dir).expect("create test dir");
-        let root = block_store_path(&dir);
-        let mut store = BlockStore::create(&root).expect("create");
+        let dir = unique_temp_path("rubin-blockstore-e7-cache-rewind"); std::fs::create_dir_all(&dir).expect("create test dir");
+        let root = block_store_path(&dir); let mut store = BlockStore::create(&root).expect("create");
 
         store.set_canonical_tip(0, [0x21; 32]).expect("set 0");
         store.set_canonical_tip(1, [0x22; 32]).expect("set 1");
         store.set_canonical_tip(2, [0x23; 32]).expect("set 2");
 
-        store.rewind_to_height(0).expect("rewind to 0");
+        let prior = std::fs::read(&store.index_path).expect("prior index");
+        std::fs::remove_file(&store.index_path).expect("remove index"); std::fs::create_dir(&store.index_path).expect("block index");
+        let err = store.rewind_to_height(0).unwrap_err(); assert!(err.contains("before_namespace_commit")); assert_eq!((store.canonical_len(), store.tip().unwrap()), (3, Some((2, [0x23; 32]))));
+        std::fs::remove_dir(&store.index_path).expect("remove blocker"); std::fs::write(&store.index_path, prior).expect("restore index");
+        let scope = AtomicWriteTestScope::new(); scope.fail_at(AtomicWriteTestOp::CleanupUnlink, 1, "postcommit");
+        assert!(store.rewind_to_height(0).is_err()); drop(scope);
         assert_cache_matches_index(&store);
         assert_eq!(store.canonical_len(), 1);
         assert_eq!(store.canonical_hash(0).unwrap(), Some([0x21; 32]));

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::genesis::validate_incoming_chain_id;
-use crate::io_utils::{parse_hex32, write_file_atomic};
+use crate::io_utils::{
+    atomic_write_error_before, parse_hex32, reclaim_atomic_write_parent,
+    reclaim_atomic_write_scratch, write_file_atomic_typed, AtomicWriteError, AtomicWriteOperation,
+};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
 const CHAIN_STATE_DISK_VERSION: u32 = 1;
@@ -98,10 +101,21 @@ impl ChainState {
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
+        self.save_atomic(path).map_err(|error| error.to_string())
+    }
+
+    pub(crate) fn save_atomic<P: AsRef<Path>>(&self, path: P) -> Result<(), AtomicWriteError> {
         let path = path.as_ref();
-        let disk = state_to_disk(self)?;
-        let mut raw =
-            serde_json::to_vec_pretty(&disk).map_err(|e| format!("encode chainstate: {e}"))?;
+        let disk = state_to_disk(self).map_err(|error| {
+            atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error)
+        })?;
+        let mut raw = serde_json::to_vec_pretty(&disk).map_err(|error| {
+            atomic_write_error_before(
+                path,
+                AtomicWriteOperation::Overwrite,
+                format!("encode chainstate: {error}"),
+            )
+        })?;
         raw.push(b'\n');
         // Parent creation is delegated to `write_file_atomic`, which
         // runs `fs::create_dir_all(effective_parent(path))` on the
@@ -126,7 +140,7 @@ impl ChainState {
         // combined with `..`. Other callers of `ChainState::save`
         // are responsible for their own path hygiene — see
         // `load_chain_state` for the mirror note.
-        write_file_atomic(path, &raw)
+        write_file_atomic_typed(path, &raw)
     }
 
     pub fn connect_block(
@@ -309,6 +323,16 @@ pub(crate) fn copy_utxo_set(src: &HashMap<Outpoint, UtxoEntry>) -> HashMap<Outpo
 
 pub fn chain_state_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
     data_dir.as_ref().join(CHAIN_STATE_FILE_NAME)
+}
+
+/// Startup scratch reclaim runs after store open/create under the datadir lock.
+pub fn reclaim_atomic_scratch<P: AsRef<Path>>(data_dir: P) -> Result<(), String> {
+    reclaim_atomic_write_scratch(data_dir.as_ref())
+}
+
+/// Fresh-store startup reclaims only its existing datadir parent.
+pub fn reclaim_atomic_scratch_parent<P: AsRef<Path>>(parent: P) -> Result<(), String> {
+    reclaim_atomic_write_parent(parent.as_ref())
 }
 
 pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -233,19 +233,14 @@ pub(crate) const CANONICAL_INDEX_ZERO_COMPLETE_PREFIX_ERR: &str =
 /// file (`E.1`), and the chainstate snapshot is re-saved by the caller
 /// after reconcile returns. Re-entry is idempotent.
 ///
-/// **Cross-platform**: All I/O goes through helpers that already abide
-/// by the storage cluster's OS contracts (`O_EXCL` for temp creates,
-/// `drop(fd)` before unlink on Windows in `write_and_sync_temp`,
-/// best-effort `sync_dir` on permission-hardened parents).
+/// **Cross-platform**: fixed-scratch durability is supported on Linux/macOS only.
 ///
 /// **Retry / exhaustion**: No bounded retry inside reconcile — the
 /// caller (`main.rs`) treats a reconcile error as a fatal startup
 /// failure and exits with non-zero, mirroring Go's `chainstate
 /// reconcile failed: %v` exit path.
 ///
-/// **Inode / fs-layer**: Reconcile reads only — does not create new
-/// files. `truncate_canonical` rewrites the canonical index via the
-/// existing atomic-write helper (no shared-inode hazards).
+/// **Inode / fs-layer**: truncate uses fixed scratch/parent lock; no other files.
 ///
 /// **Durability**: After reconcile returns `Ok(true)`, the caller
 /// MUST persist `chain_state.save(...)` BEFORE starting any sync

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -2179,7 +2179,7 @@ mod tests {
             let path = dir.join(leaf); match make { 0 => fs::write(&path, b"x").expect("regular"), 1 => fs::hard_link(&live, &path).expect("hardlink"), 2 => { let raw = std::ffi::CString::new(path.as_os_str().as_bytes()).expect("path"); assert_eq!(unsafe { libc::mkfifo(raw.as_ptr(), 0o600) }, 0); }, 3 => symlink(&live, &path).expect("symlink"), _ => symlink(dir.join("absent"), &path).expect("dangling") } unlink_atomic_scratch(&path).expect("unlink"); assert!(path.symlink_metadata().is_err()); assert_eq!(fs::read(&live).expect("live intact"), b"live");
         }
         let directory = dir.join("directory"); fs::create_dir(&directory).expect("directory"); assert!(unlink_atomic_scratch(&directory).is_err() && directory.is_dir());
-        for mask in [0, 0o022, 0o077, 0o700] {
+        for mask in [0, 0o022, 0o077] {
             let _umask = Umask::set(mask); let scratch = dir.join(ATOMIC_WRITE_SCRATCH_LEAF); let dst = dir.join(format!("mode-{mask:o}"));
             let scope = AtomicWriteTestScope::new(); scope.fail_at(AtomicWriteTestOp::Write, 1, "write"); scope.fail_at(AtomicWriteTestOp::CleanupUnlink, 1, "keep");
             write_file_atomic_typed(&dst, b"x").expect_err("retain scratch"); assert_eq!(fs::metadata(&scratch).expect("scratch").mode() & 0o777, 0o600); drop(scope); fs::remove_file(&scratch).expect("scratch");

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -1,7 +1,13 @@
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+#[path = "file_lock.rs"]
+#[allow(dead_code)]
+mod atomic_file_lock;
 
 // Per-class local store read bounds (RUB-1057), enforced BEFORE the file's
 // contents are allocated. Every class here holds exactly one wire item whose
@@ -75,24 +81,6 @@ pub(crate) fn check_store_save_bound(name: &str, len: usize, max_bytes: u64) -> 
         ));
     }
     Ok(())
-}
-
-/// Process-wide monotonic sequence counter appended to every temp-file
-/// name so two threads writing to the same destination within the same
-/// process can never collide on a shared `.tmp.<pid>` path (audit
-/// `E.3`). Not a cryptographic nonce — it is a plain uniqueness counter
-/// for filesystem path disambiguation. Name deliberately avoids the
-/// word "nonce" so CodeQL's `Hard-coded cryptographic value` check does
-/// not mis-flag test literals feeding this parameter.
-static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
-
-/// Returns the NEW value (1, 2, 3, ...) — mirrors Go's
-/// `atomic.Uint64.Add(1)` semantics so the cross-client naming
-/// convention for `.tmp.<pid>.<seq>` files starts at the same seq in
-/// both runtimes. Using `fetch_add(1) + 1` instead of `fetch_add(1)`
-/// costs nothing at runtime and removes a cross-client drift class.
-fn next_temp_seq() -> u64 {
-    TEMP_SEQ.fetch_add(1, Ordering::Relaxed) + 1
 }
 
 /// Reject a file name (the leaf component, NOT a full path) that would
@@ -846,291 +834,481 @@ pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
     Ok(out)
 }
 
-/// Atomically write `data` to `path` with an honest fsync durability
-/// contract (audit `E.1`). Sequence (any failure between open and rename
-/// best-effort removes the partially-written
-/// `<dest>.tmp.<pid>.<seq>`):
-///
-/// 1. resolve the target's effective parent (see `effective_parent`),
-///    `create_dir_all` it if missing;
-/// 2. open `<path>.tmp.<pid>.<seq>` with `O_CREATE|O_EXCL|O_WRONLY` —
-///    NO `O_TRUNC`, so a stale temp leftover from a crashed prior
-///    process that happens to be hard-linked to a live destination
-///    inode cannot be truncated through the shared inode
-///    (`allocate_and_write_temp` retries with a fresh `seq` on
-///    `AlreadyExists`). `<seq>` is a process-wide atomic counter
-///    ensuring concurrent writers in the same process get distinct
-///    temp paths (`E.3`);
-/// 3. `write_all` (loops on short writes per stdlib contract);
-/// 4. `sync_all` — flushes data + inode metadata to disk;
-/// 5. close (implicit on scope exit; see `sync_dir` doc on Rust File close
-///    error semantics);
-/// 6. `fs::rename` temp -> destination (atomic on the same filesystem;
-///    OVERWRITES an existing destination — use `write_file_exclusive`
-///    for create-if-absent semantics);
-/// 7. `sync_dir` on the effective parent so the rename itself is durable.
-///
-/// Mirrors the Go `clients/go/node/chainstate.go` `writeFileAtomic` for
-/// cross-client storage parity.
-pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
-    let parent = effective_parent(path);
-    if let Some(parent) = parent {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
+pub(crate) const ATOMIC_WRITE_LOCK_LEAF: &str = ".rubin-atomic-write.lock";
+pub(crate) const ATOMIC_WRITE_SCRATCH_LEAF: &str = ".rubin-atomic-write.tmp";
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AtomicWriteStage {
+    BeforeNamespaceCommit,
+    AfterNamespaceCommit,
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AtomicWriteOperation {
+    Overwrite,
+    CreateIfAbsent,
+}
+#[derive(Clone, Debug)]
+pub(crate) struct AtomicWriteError {
+    pub(crate) stage: AtomicWriteStage,
+    pub(crate) destination: PathBuf,
+    pub(crate) operation: AtomicWriteOperation,
+    pub(crate) primary: String,
+    pub(crate) secondary: Vec<String>,
+}
+impl AtomicWriteError {
+    fn new(
+        stage: AtomicWriteStage,
+        destination: &Path,
+        operation: AtomicWriteOperation,
+        primary: impl Into<String>,
+    ) -> Self {
+        Self {
+            stage,
+            destination: destination.to_path_buf(),
+            operation,
+            primary: primary.into(),
+            secondary: Vec::new(),
+        }
     }
-    let tmp_path = allocate_and_write_temp(path, data)?;
-    // Rename OVERWRITES an existing destination. If the caller requires
-    // create-if-absent semantics, use `write_file_exclusive` instead.
-    fs::rename(&tmp_path, path).map_err(|e| {
-        let _ = fs::remove_file(&tmp_path);
-        format!(
-            "rename temp {} -> {}: {e}",
-            tmp_path.display(),
-            path.display()
+    pub(crate) fn stage(&self) -> AtomicWriteStage {
+        self.stage
+    }
+    fn append_secondary(&mut self, error: impl Into<String>) {
+        self.secondary.push(error.into());
+    }
+}
+impl std::fmt::Display for AtomicWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let stage = match self.stage {
+            AtomicWriteStage::BeforeNamespaceCommit => "before_namespace_commit",
+            AtomicWriteStage::AfterNamespaceCommit => "after_namespace_commit",
+        };
+        let operation = match self.operation {
+            AtomicWriteOperation::Overwrite => "overwrite",
+            AtomicWriteOperation::CreateIfAbsent => "create_if_absent",
+        };
+        write!(
+            f,
+            "{} (atomic write {stage} {operation} for {})",
+            self.primary,
+            self.destination.display()
+        )?;
+        if !self.secondary.is_empty() {
+            write!(f, " (secondary: {})", self.secondary.join("; "))?;
+        }
+        Ok(())
+    }
+}
+impl std::error::Error for AtomicWriteError {}
+pub(crate) fn atomic_write_error_before(
+    destination: &Path,
+    operation: AtomicWriteOperation,
+    primary: impl Into<String>,
+) -> AtomicWriteError {
+    AtomicWriteError::new(
+        AtomicWriteStage::BeforeNamespaceCommit,
+        destination,
+        operation,
+        primary,
+    )
+}
+pub(crate) fn atomic_write_error_after(
+    destination: &Path,
+    operation: AtomicWriteOperation,
+    primary: impl Into<String>,
+) -> AtomicWriteError {
+    AtomicWriteError::new(
+        AtomicWriteStage::AfterNamespaceCommit,
+        destination,
+        operation,
+        primary,
+    )
+}
+pub(crate) fn is_atomic_write_post_commit(error: &AtomicWriteError) -> bool {
+    error.stage() == AtomicWriteStage::AfterNamespaceCommit
+}
+static ATOMIC_WRITE_PROCESS_MUTEX: Mutex<()> = Mutex::new(());
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AtomicWriteTestOp {
+    PreUnlink,
+    CleanupUnlink,
+    ExclusiveOpen,
+    Write,
+    FileSync,
+    Rename,
+    HardLink,
+    EexistDecision,
+    ParentSync,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct AtomicWriteTestState {
+    operations: Vec<AtomicWriteTestOp>,
+    failures: Vec<(AtomicWriteTestOp, usize, String)>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static ATOMIC_WRITE_TEST_STATE: std::cell::RefCell<AtomicWriteTestState> =
+        std::cell::RefCell::new(AtomicWriteTestState::default());
+}
+
+#[cfg(test)]
+pub(crate) struct AtomicWriteTestScope;
+
+#[cfg(test)]
+impl AtomicWriteTestScope {
+    pub(crate) fn new() -> Self {
+        ATOMIC_WRITE_TEST_STATE.with(|state| *state.borrow_mut() = AtomicWriteTestState::default());
+        Self
+    }
+
+    pub(crate) fn fail_at(&self, operation: AtomicWriteTestOp, occurrence: usize, error: &str) {
+        ATOMIC_WRITE_TEST_STATE.with(|state| {
+            state
+                .borrow_mut()
+                .failures
+                .push((operation, occurrence, error.into()));
+        });
+    }
+
+    pub(crate) fn operations(&self) -> Vec<AtomicWriteTestOp> {
+        ATOMIC_WRITE_TEST_STATE.with(|state| state.borrow().operations.clone())
+    }
+}
+
+#[cfg(test)]
+impl Drop for AtomicWriteTestScope {
+    fn drop(&mut self) {
+        ATOMIC_WRITE_TEST_STATE.with(|state| *state.borrow_mut() = AtomicWriteTestState::default());
+    }
+}
+
+#[cfg(test)]
+fn atomic_write_test_step(operation: AtomicWriteTestOp) -> Result<(), String> {
+    ATOMIC_WRITE_TEST_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        state.operations.push(operation);
+        let occurrence = state
+            .operations
+            .iter()
+            .filter(|&&op| op == operation)
+            .count();
+        match state
+            .failures
+            .iter()
+            .position(|(expected, at, _)| *expected == operation && *at == occurrence)
+        {
+            Some(index) => Err(state.failures.remove(index).2),
+            None => Ok(()),
+        }
+    })
+}
+
+pub(crate) fn validate_atomic_write_destination(
+    path: &Path,
+    operation: AtomicWriteOperation,
+) -> Result<(), AtomicWriteError> {
+    let reserved = path.file_name().is_some_and(|leaf| {
+        leaf == std::ffi::OsStr::new(ATOMIC_WRITE_LOCK_LEAF)
+            || leaf == std::ffi::OsStr::new(ATOMIC_WRITE_SCRATCH_LEAF)
+    });
+    if reserved {
+        return Err(atomic_write_error_before(
+            path,
+            operation,
+            format!(
+                "reserved atomic persistence destination: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
+    write_file_atomic_typed(path, data).map_err(|error| error.to_string())
+}
+
+pub(crate) fn write_file_atomic_typed(path: &Path, data: &[u8]) -> Result<(), AtomicWriteError> {
+    write_atomic_file(path, data, AtomicWriteOperation::Overwrite, || Ok(()))
+}
+
+pub(crate) fn write_file_create_if_absent<F>(
+    path: &Path,
+    data: &[u8],
+    resolve_existing: F,
+) -> Result<(), AtomicWriteError>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    write_atomic_file(
+        path,
+        data,
+        AtomicWriteOperation::CreateIfAbsent,
+        resolve_existing,
+    )
+}
+
+fn write_atomic_file<F>(
+    path: &Path,
+    data: &[u8],
+    operation: AtomicWriteOperation,
+    resolve_existing: F,
+) -> Result<(), AtomicWriteError>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    validate_atomic_write_destination(path, operation)?;
+    let parent = effective_parent(path).ok_or_else(|| {
+        atomic_write_error_before(path, operation, "atomic destination has no parent")
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        atomic_write_error_before(
+            path,
+            operation,
+            format!("create parent {}: {error}", parent.display()),
         )
     })?;
-    // Directory fsync makes the rename itself durable. Without this the
-    // destination file's bytes are on disk after the temp `sync_all()` above,
-    // but the directory entry that points the destination name at the new
-    // inode may still live only in the kernel page cache and be lost on
-    // crash. Mirrors the Go `writeFileAtomic` `Sync` on parent directory
-    // for cross-client parity.
-    if let Some(parent) = parent {
-        sync_dir(parent)?;
-    }
-    Ok(())
+
+    let _process_guard = ATOMIC_WRITE_PROCESS_MUTEX.lock().map_err(|_| {
+        atomic_write_error_before(path, operation, "atomic write process mutex is poisoned")
+    })?;
+    let lock_path = parent.join(ATOMIC_WRITE_LOCK_LEAF);
+    let _parent_lock = atomic_file_lock::acquire(&lock_path).map_err(|error| {
+        atomic_write_error_before(
+            path,
+            operation,
+            format!(
+                "atomic write lock failed: {}: {:?}: {}",
+                parent.display(),
+                error.class(),
+                error.cause()
+            ),
+        )
+    })?;
+    write_atomic_file_locked(path, data, parent, operation, resolve_existing)
 }
 
-/// Error returned by [`write_file_exclusive`] distinguishing the
-/// create-if-absent race — caller needs to know "the destination already
-/// exists, read it and verify content" vs "some other I/O failure".
-///
-/// Cross-client parity: matches the error branching in the Go
-/// `writeFileIfAbsent` helper which uses `errors.Is(err, os.ErrExist)`
-/// on the `os.Link` result.
-#[derive(Debug)]
-pub enum AtomicWriteError {
-    /// `path` already exists at link time. Caller must inspect the
-    /// existing content to decide whether this is an idempotent retry
-    /// (content matches) or a corruption/conflict (content differs).
-    AlreadyExists,
-    /// Any other surfaced failure along the atomic-create sequence —
-    /// for example `create_dir_all` on the parent, temp-file exclusive
-    /// open (including exhaustion of the `allocate_and_write_temp`
-    /// retry budget on repeated stale-temp collisions), write,
-    /// file-`sync_all`, `hard_link`, or the parent-directory
-    /// `sync_dir`/directory-fsync durability step that runs after a
-    /// successful link. Best-effort temp-file cleanup failures are not
-    /// reported through this enum (the unlink is run on every exit
-    /// path but its error is intentionally discarded to keep the
-    /// primary error visible).
-    Other(String),
-}
-
-impl From<String> for AtomicWriteError {
-    fn from(msg: String) -> Self {
-        AtomicWriteError::Other(msg)
+fn write_atomic_file_locked<F>(
+    path: &Path,
+    data: &[u8],
+    parent: &Path,
+    operation: AtomicWriteOperation,
+    resolve_existing: F,
+) -> Result<(), AtomicWriteError>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let scratch = parent.join(ATOMIC_WRITE_SCRATCH_LEAF);
+    if let Err(error) = pre_unlink_atomic_scratch(&scratch) {
+        return Err(atomic_write_error_before(path, operation, error));
     }
-}
 
-/// Atomically write `data` to `path` only if `path` does not already
-/// exist (audit `E.3`, the TOCTOU-hardened companion to
-/// `write_file_atomic`). Uses the POSIX `link(2)` primitive to get
-/// create-if-absent semantics at the syscall layer:
-///
-/// 1. resolve effective parent, `create_dir_all` if missing;
-/// 2. allocate a per-call-unique `<path>.tmp.<pid>.<seq>` via
-///    [`allocate_and_write_temp`] and write `data` with the exclusive
-///    `O_CREATE|O_EXCL` contract — same durability semantics as
-///    `write_file_atomic`, retries on stale-temp collisions (PID +
-///    seq reuse after a crash);
-/// 3. `hard_link(temp, path)` — atomic create-if-absent. Fails with
-///    [`AtomicWriteError::AlreadyExists`] if `path` is already on disk
-///    (EEXIST); that race cannot silently overwrite the existing file;
-/// 4. best-effort `unlink(temp)` — the destination (or the pre-existing
-///    file on EEXIST) keeps the inode, so removing the temp name never
-///    drops data. The unlink runs on every exit path, and its error is
-///    intentionally discarded (a leaked temp is operational cleanup,
-///    not a correctness issue) — see [`AtomicWriteError::Other`] doc
-///    for the best-effort cleanup contract;
-/// 5. `sync_dir` on the parent so the new directory entry is durable.
-///
-/// Mirrors the Go `writeFileIfAbsent` hard-link pattern in
-/// `clients/go/node/blockstore.go`. The per-call monotonic `seq`
-/// (filesystem counter, not a cryptographic nonce) closes the thread
-/// race where two concurrent writers in the same process would
-/// otherwise collide on a shared `.tmp.<pid>` path.
-pub fn write_file_exclusive(path: &Path, data: &[u8]) -> Result<(), AtomicWriteError> {
-    let parent = effective_parent(path);
-    if let Some(parent) = parent {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
-    }
-    let tmp_path = allocate_and_write_temp(path, data)?;
-    let link_result = fs::hard_link(&tmp_path, path);
-    // Best-effort unlink of the temp name. On link success the
-    // destination inode keeps its own reference, so the temp name is
-    // redundant. On link failure the temp must not strand on disk. The
-    // unlink error itself is intentionally discarded to keep the
-    // primary link error visible to the caller — see
-    // `AtomicWriteError::Other` doc on the best-effort cleanup
-    // contract.
-    let _ = fs::remove_file(&tmp_path);
-    match link_result {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            return Err(AtomicWriteError::AlreadyExists);
-        }
-        Err(e) => {
-            return Err(AtomicWriteError::Other(format!(
-                "hard_link {} -> {}: {e}",
-                tmp_path.display(),
-                path.display()
-            )));
-        }
-    }
-    if let Some(parent) = parent {
-        sync_dir(parent)?;
-    }
-    Ok(())
-}
-
-/// Bounded retry count for [`allocate_and_write_temp`]. A collision on
-/// `<dest>.tmp.<pid>.<seq>` should be vanishingly rare in practice (it
-/// requires PID reuse PLUS `next_temp_seq` wrapping back over a stale
-/// leftover from a prior process), so 16 attempts is deliberately
-/// generous for the tail case while still bounding pathological loops.
-const MAX_TEMP_ALLOC_RETRIES: u32 = 16;
-/// Internal error from [`write_and_sync_temp`] so callers can
-/// distinguish a stale-temp collision (retry with a new `seq`) from a
-/// fatal I/O failure (surface to the caller).
-enum TempWriteError {
-    /// The `create_new(true)` open failed with `AlreadyExists`, i.e. a
-    /// temp file with this exact `<pid>.<seq>` suffix already exists
-    /// on disk. After a process crash, a leftover temp from the prior
-    /// process can be hard-linked to a live destination inode; if we
-    /// reopened it with `O_TRUNC` we would truncate the destination
-    /// through that shared inode. `O_EXCL` refuses that reuse, and the
-    /// caller retries with a fresh `seq`.
-    AlreadyExists,
-    /// Any other failure along `open → write_all → sync_all`. The temp
-    /// path, if it was created, is best-effort removed by
-    /// `write_and_sync_temp` before returning so callers do not need
-    /// to clean up on the error path.
-    Fatal(String),
-}
-
-/// Internal helper: open a fresh temp file at `tmp_path` with
-/// `O_CREATE | O_EXCL` (Rust's `create_new(true)`) — NO `O_TRUNC`.
-/// Refuses to reuse a pre-existing temp name so a stale leftover from
-/// a crashed prior process cannot be truncated through a shared inode
-/// (Copilot P1 audit on PR #1220). Writes all bytes, `sync_all`,
-/// closes.
-///
-/// Mirrors the Go `writeAndSyncTemp` helper. On any failure this
-/// helper best-effort removes `tmp_path` before returning the error,
-/// so callers do NOT need to perform separate temp cleanup on error;
-/// they may still unlink the temp after success (as
-/// `write_file_exclusive` does after a successful `hard_link`) to
-/// reclaim the redundant name.
-fn write_and_sync_temp(tmp_path: &Path, data: &[u8]) -> Result<(), TempWriteError> {
-    use std::io::Write;
-    let mut tmp = match fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(tmp_path)
-    {
-        Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            return Err(TempWriteError::AlreadyExists);
-        }
-        Err(e) => {
-            return Err(TempWriteError::Fatal(format!(
-                "open temp {}: {e}",
-                tmp_path.display()
-            )));
-        }
+    let mut file = match open_atomic_scratch(&scratch) {
+        Ok(file) => file,
+        Err(error) => return Err(pre_commit_failure(path, operation, parent, &scratch, error)),
     };
     let write_result: Result<(), String> = (|| {
-        tmp.write_all(data)
-            .map_err(|e| format!("write temp {}: {e}", tmp_path.display()))?;
-        tmp.sync_all()
-            .map_err(|e| format!("sync temp {}: {e}", tmp_path.display()))
+        #[cfg(test)]
+        atomic_write_test_step(AtomicWriteTestOp::Write)?;
+        file.write_all(data)
+            .map_err(|error| format!("write atomic scratch {}: {error}", scratch.display()))?;
+        #[cfg(test)]
+        atomic_write_test_step(AtomicWriteTestOp::FileSync)?;
+        file.sync_all()
+            .map_err(|error| format!("sync atomic scratch {}: {error}", scratch.display()))
     })();
-    // Drop the file handle BEFORE attempting to unlink the temp path.
-    // On Windows `fs::remove_file` on an open handle fails with
-    // `PermissionDenied`, which would leak the failed temp and, under
-    // repeated I/O failures, burn through the `MAX_TEMP_ALLOC_RETRIES`
-    // budget with stale `.tmp.<pid>.<seq>` leftovers (Codex P2 on PR
-    // #1220). On Unix the drop is harmless ordering (close-then-unlink
-    // always works, and unlink-then-close leaves the inode alive
-    // through the open fd anyway). Explicit `drop` keeps the semantics
-    // portable.
-    drop(tmp);
-    if let Err(e) = write_result {
-        let _ = fs::remove_file(tmp_path);
-        return Err(TempWriteError::Fatal(e));
+    drop(file);
+    if let Err(primary) = write_result {
+        return Err(pre_commit_failure(
+            path, operation, parent, &scratch, primary,
+        ));
+    }
+
+    match operation {
+        AtomicWriteOperation::Overwrite => {
+            #[cfg(test)]
+            if let Err(error) = atomic_write_test_step(AtomicWriteTestOp::Rename) {
+                return Err(pre_commit_failure(path, operation, parent, &scratch, error));
+            }
+            if let Err(error) = fs::rename(&scratch, path) {
+                return Err(pre_commit_failure(
+                    path,
+                    operation,
+                    parent,
+                    &scratch,
+                    format!(
+                        "rename atomic scratch {} -> {}: {error}",
+                        scratch.display(),
+                        path.display()
+                    ),
+                ));
+            }
+        }
+        AtomicWriteOperation::CreateIfAbsent => {
+            #[cfg(test)]
+            if let Err(error) = atomic_write_test_step(AtomicWriteTestOp::HardLink) {
+                return Err(pre_commit_failure(path, operation, parent, &scratch, error));
+            }
+            match fs::hard_link(&scratch, path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    #[cfg(test)]
+                    if let Err(primary) = atomic_write_test_step(AtomicWriteTestOp::EexistDecision)
+                    {
+                        return Err(pre_commit_failure(
+                            path, operation, parent, &scratch, primary,
+                        ));
+                    }
+                    if let Err(primary) = resolve_existing() {
+                        return Err(pre_commit_failure(
+                            path, operation, parent, &scratch, primary,
+                        ));
+                    }
+                }
+                Err(error) => {
+                    return Err(pre_commit_failure(
+                        path,
+                        operation,
+                        parent,
+                        &scratch,
+                        format!(
+                            "link atomic scratch {} -> {}: {error}",
+                            scratch.display(),
+                            path.display()
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    post_commit_cleanup(path, operation, parent, &scratch)
+}
+
+fn pre_commit_failure(
+    destination: &Path,
+    operation: AtomicWriteOperation,
+    parent: &Path,
+    scratch: &Path,
+    primary: impl Into<String>,
+) -> AtomicWriteError {
+    let mut error = atomic_write_error_before(destination, operation, primary);
+    if let Err(cleanup) = cleanup_atomic_scratch(scratch) {
+        error.append_secondary(cleanup);
+    }
+    if let Err(sync) = sync_atomic_parent(parent) {
+        error.append_secondary(sync);
+    }
+    error
+}
+
+fn post_commit_cleanup(
+    destination: &Path,
+    operation: AtomicWriteOperation,
+    parent: &Path,
+    scratch: &Path,
+) -> Result<(), AtomicWriteError> {
+    let mut result: Option<AtomicWriteError> = None;
+    if let Err(cleanup) = cleanup_atomic_scratch(scratch) {
+        result = Some(atomic_write_error_after(destination, operation, cleanup));
+    }
+    if let Err(sync) = sync_atomic_parent(parent) {
+        match result.as_mut() {
+            Some(error) => error.append_secondary(sync),
+            None => result = Some(atomic_write_error_after(destination, operation, sync)),
+        }
+    }
+    result.map_or(Ok(()), Err)
+}
+
+fn open_atomic_scratch(path: &Path) -> Result<fs::File, String> {
+    #[cfg(test)]
+    atomic_write_test_step(AtomicWriteTestOp::ExclusiveOpen)?;
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| format!("open atomic scratch {}: {error}", path.display()))?;
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("chmod atomic scratch {}: {error}", path.display()))?;
+    }
+    Ok(file)
+}
+
+fn pre_unlink_atomic_scratch(path: &Path) -> Result<(), String> {
+    #[cfg(test)]
+    atomic_write_test_step(AtomicWriteTestOp::PreUnlink)?;
+    unlink_atomic_scratch(path)
+}
+
+fn cleanup_atomic_scratch(path: &Path) -> Result<(), String> {
+    #[cfg(test)]
+    atomic_write_test_step(AtomicWriteTestOp::CleanupUnlink)?;
+    unlink_atomic_scratch(path)
+}
+
+fn unlink_atomic_scratch(path: &Path) -> Result<(), String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("unlink atomic scratch {}: {error}", path.display())),
+    }
+}
+
+pub(crate) fn reclaim_atomic_write_parent(parent: &Path) -> Result<(), String> {
+    let _process_guard = ATOMIC_WRITE_PROCESS_MUTEX
+        .lock()
+        .map_err(|_| reclaim_error(parent, "atomic write process mutex is poisoned"))?;
+    let lock_path = parent.join(ATOMIC_WRITE_LOCK_LEAF);
+    let _parent_lock = atomic_file_lock::acquire(&lock_path).map_err(|error| {
+        reclaim_error(
+            parent,
+            format!(
+                "atomic write lock failed: {:?}: {}",
+                error.class(),
+                error.cause()
+            ),
+        )
+    })?;
+    pre_unlink_atomic_scratch(&parent.join(ATOMIC_WRITE_SCRATCH_LEAF))
+        .map_err(|error| reclaim_error(parent, error))?;
+    sync_atomic_parent(parent).map_err(|error| reclaim_error(parent, error))
+}
+
+pub(crate) fn reclaim_atomic_write_scratch(data_dir: &Path) -> Result<(), String> {
+    let blockstore = data_dir.join("blockstore");
+    let parents = [
+        data_dir.to_path_buf(),
+        blockstore.clone(),
+        blockstore.join("blocks"),
+        blockstore.join("headers"),
+        blockstore.join("undo"),
+    ];
+    for parent in parents {
+        reclaim_atomic_write_parent(&parent)?;
     }
     Ok(())
 }
 
-/// Allocate a unique temp path for `path`, write `data` to it with the
-/// exclusive-create + fsync contract, and return the temp path on
-/// success. Retries up to [`MAX_TEMP_ALLOC_RETRIES`] times with a
-/// fresh `next_temp_seq` on the rare `AlreadyExists` case (stale
-/// leftover temp after PID + seq reuse). Fatal I/O errors surface
-/// immediately without retry.
-fn allocate_and_write_temp(path: &Path, data: &[u8]) -> Result<std::path::PathBuf, String> {
-    let pid = std::process::id();
-    let mut last_collision: Option<String> = None;
-    for _ in 0..MAX_TEMP_ALLOC_RETRIES {
-        let tmp_path = temp_path_for(path, pid, next_temp_seq());
-        match write_and_sync_temp(&tmp_path, data) {
-            Ok(()) => return Ok(tmp_path),
-            Err(TempWriteError::AlreadyExists) => {
-                last_collision = Some(format!("temp path already exists: {}", tmp_path.display()));
-                continue;
-            }
-            Err(TempWriteError::Fatal(msg)) => return Err(msg),
-        }
-    }
-    Err(last_collision.unwrap_or_else(|| {
-        format!(
-            "exhausted {MAX_TEMP_ALLOC_RETRIES} retries allocating temp for {}",
-            path.display()
-        )
-    }))
-}
-
-/// Build the `<dest>.tmp.<pid>.<seq>` companion path for a target
-/// `path` without going through lossy `Path::display()`. The `<seq>`
-/// component is a process-wide monotonic uniqueness counter (see
-/// `next_temp_seq`) that closes the thread race where two concurrent
-/// writers in the same process would otherwise share a `.tmp.<pid>`
-/// filename and one would silently overwrite the other's temp bytes
-/// between write and rename/link (audit `E.3`). Not a cryptographic
-/// nonce — it is a plain counter for filesystem path disambiguation;
-/// named `seq` rather than `nonce` so CodeQL's "Hard-coded
-/// cryptographic value" check does not mis-flag test literals that
-/// feed this parameter.
-///
-/// `display()` replaces non-UTF-8 bytes with `U+FFFD`; on Unix a
-/// `PathBuf` can contain any byte sequence other than `/` and `\0`, so a
-/// lossy conversion would produce a temp at a different location than
-/// the caller's actual target — breaking both the atomic rename and the
-/// failure cleanup. `OsString::push` preserves the original bytes
-/// exactly. Split into its own helper so the byte-preservation contract
-/// is independently testable without going through the filesystem (APFS
-/// on macOS rejects non-UTF-8 filenames with EILSEQ, so a filesystem-
-/// level round-trip test is not portable). Copilot + Codex review
-/// feedback on PR #1218 + the E.3 lane.
-fn temp_path_for(path: &Path, pid: u32, seq: u64) -> PathBuf {
-    let mut tmp_os = path.as_os_str().to_os_string();
-    tmp_os.push(".tmp.");
-    tmp_os.push(pid.to_string());
-    tmp_os.push(".");
-    tmp_os.push(seq.to_string());
-    PathBuf::from(tmp_os)
+fn reclaim_error(parent: &Path, cause: impl std::fmt::Display) -> String {
+    format!(
+        "atomic scratch reclaim failed: {}: {cause}",
+        parent.display()
+    )
 }
 
 /// Compute the directory whose existence we must ensure (and whose entry we
@@ -1147,39 +1325,19 @@ pub(crate) fn effective_parent(path: &Path) -> Option<&Path> {
     }
 }
 
-/// Open the parent directory and call `sync_all()` so any rename or unlink
-/// performed in it is itself durable. Splitting this out keeps
-/// `write_file_atomic` linear and lets storage callers fsync ad-hoc
-/// directory mutations later if they need to.
-///
-/// Cross-client note: the Go counterpart `syncDir` uses
-/// `errors.Join(serr, cerr)` to surface a Close error after a successful
-/// Sync. Rust cannot easily mirror that — `std::fs::File::drop` discards
-/// the close error by design, and there is no stable safe API to surface
-/// it. The Sync error itself is returned, so a kernel-level flush failure
-/// is honestly reported; only the rare close-after-successful-sync error
-/// is silently absorbed by Drop. This is an accepted Rust stdlib
-/// limitation, not a missing fix.
-///
-/// Best-effort on permission-denied open: a parent directory with mode
-/// `0300` (write+execute, no read) permits create/rename but blocks
-/// `OpenOptions::new().read(true).open(dir)` (Codex review feedback on
-/// PR #1218). The rename has already succeeded by the time `sync_dir`
-/// runs, so returning an error would make the caller treat committed
-/// state as failed on hardened directory-permission setups. Return
-/// `Ok(())` instead — the destination bytes are already on disk via
-/// the temp file's `sync_all()`; only the directory-entry fsync is
-/// degraded to best-effort. Any other open error (`NotFound`, `Other`,
-/// etc) still propagates as a real anomaly.
 pub fn sync_dir(dir: &Path) -> Result<(), String> {
-    use std::io::ErrorKind;
-    match fs::OpenOptions::new().read(true).open(dir) {
-        Ok(file) => file
-            .sync_all()
-            .map_err(|e| format!("sync dir {}: {e}", dir.display())),
-        Err(e) if e.kind() == ErrorKind::PermissionDenied => Ok(()),
-        Err(e) => Err(format!("open dir {}: {e}", dir.display())),
-    }
+    fs::OpenOptions::new()
+        .read(true)
+        .open(dir)
+        .map_err(|error| format!("open dir {}: {error}", dir.display()))?
+        .sync_all()
+        .map_err(|error| format!("sync dir {}: {error}", dir.display()))
+}
+
+pub(crate) fn sync_atomic_parent(parent: &Path) -> Result<(), String> {
+    #[cfg(test)]
+    atomic_write_test_step(AtomicWriteTestOp::ParentSync)?;
+    sync_dir(parent)
 }
 
 /// Create a hole-only sparse file of the nominal size (no data blocks
@@ -1212,7 +1370,10 @@ mod tests {
     use super::{
         create_sparse_file, lexical_clean, read_capped, read_config_file_to_string,
         read_file_from_dir, sync_dir, unique_temp_path, volume_prefix_len, write_file_atomic,
-        BLOCK_FILE_MAX_BYTES, CONFIG_FILE_MAX_BYTES, STORE_FILE_TOO_LARGE_PREFIX,
+        write_file_atomic_typed, write_file_create_if_absent, AtomicWriteOperation,
+        AtomicWriteStage, AtomicWriteTestOp, AtomicWriteTestScope, ATOMIC_WRITE_PROCESS_MUTEX,
+        ATOMIC_WRITE_SCRATCH_LEAF, BLOCK_FILE_MAX_BYTES, CONFIG_FILE_MAX_BYTES,
+        STORE_FILE_TOO_LARGE_PREFIX,
     };
     use std::fs;
     use std::io::{Cursor, Read};
@@ -1941,7 +2102,20 @@ mod tests {
         let path = dir.join("payload.bin");
         let data = b"E.1 fsync contract: bytes + dir entry must both be durable";
 
+        let scope = AtomicWriteTestScope::new();
         write_file_atomic(&path, data).expect("write_file_atomic");
+        assert_eq!(
+            scope.operations(),
+            [
+                AtomicWriteTestOp::PreUnlink,
+                AtomicWriteTestOp::ExclusiveOpen,
+                AtomicWriteTestOp::Write,
+                AtomicWriteTestOp::FileSync,
+                AtomicWriteTestOp::Rename,
+                AtomicWriteTestOp::CleanupUnlink,
+                AtomicWriteTestOp::ParentSync,
+            ]
+        );
 
         let read_back = fs::read(&path).expect("read back");
         assert_eq!(read_back, data);
@@ -1966,22 +2140,57 @@ mod tests {
         let read_back = fs::read(&path).expect("read back");
         assert_eq!(read_back, b"second");
 
-        // No leftover .tmp.* sibling — temp must have been renamed away.
-        let leftover_tmps: Vec<_> = fs::read_dir(&dir)
-            .expect("list dir")
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp."))
-            .collect();
         assert!(
-            leftover_tmps.is_empty(),
-            "stale .tmp.* file remained after rename: {:?}",
-            leftover_tmps
-                .iter()
-                .map(|e| e.file_name())
-                .collect::<Vec<_>>()
+            !dir.join(ATOMIC_WRITE_SCRATCH_LEAF).exists(),
+            "fixed atomic scratch remained after rename"
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn atomic_write_typed_failure_matrix_covers_five_destinations() {
+        use AtomicWriteOperation::{CreateIfAbsent, Overwrite}; use AtomicWriteStage::{AfterNamespaceCommit, BeforeNamespaceCommit}; use AtomicWriteTestOp::*;
+        let dir = unique_temp_path("rubin-atomic-typed"); fs::create_dir_all(&dir).expect("mkdir");
+        let classes = [("blockstore/blocks/block.bin", CreateIfAbsent), ("blockstore/headers/header.bin", CreateIfAbsent), ("blockstore/undo/undo.bin", Overwrite), ("blockstore/index.json", Overwrite), ("chainstate.json", Overwrite)];
+        let rows = [(PreUnlink, None), (ExclusiveOpen, Some([CleanupUnlink, ParentSync])), (Write, Some([CleanupUnlink, ParentSync])), (FileSync, Some([CleanupUnlink, ParentSync]))];
+        let run = |path: &std::path::Path, operation, row, secondary: Option<[AtomicWriteTestOp; 2]>| {
+            let scope = AtomicWriteTestScope::new(); scope.fail_at(row, 1, "primary"); if let Some(secondary) = secondary { scope.fail_at(secondary[0], 1, "cleanup"); scope.fail_at(secondary[1], 1, "parent"); } let error = match operation { Overwrite => write_file_atomic_typed(path, b"payload"), CreateIfAbsent => write_file_create_if_absent(path, b"payload", || Ok(())) }.expect_err("scripted error");
+            assert_eq!((error.stage, error.destination, error.operation, error.primary), (BeforeNamespaceCommit, path.to_path_buf(), operation, "primary".into()));
+            assert_eq!(error.secondary, secondary.map_or_else(Vec::new, |_| vec!["cleanup".to_string(), "parent".to_string()])); assert_eq!(scope.operations().first(), Some(&PreUnlink));
+        };
+        for (class, operation) in classes {
+            for (row, secondary) in rows { let path = dir.join(format!("{row:?}/{class}")); run(&path, operation, row, secondary); }
+            for row in match operation { Overwrite => &[Rename][..], CreateIfAbsent => &[HardLink, EexistDecision][..] } { let path = dir.join(format!("{row:?}/{class}")); if *row == EexistDecision { fs::create_dir_all(path.parent().expect("parent")).expect("mkdir parent"); fs::write(&path, b"existing").expect("seed eexist"); } run(&path, operation, *row, Some([CleanupUnlink, ParentSync])); }
+            for (primary, secondary) in [(CleanupUnlink, Some(ParentSync)), (ParentSync, None)] { let path = dir.join(format!("post-{primary:?}/{class}")); let scope = AtomicWriteTestScope::new(); scope.fail_at(primary, 1, "primary"); if let Some(op) = secondary { scope.fail_at(op, 1, "secondary"); } let error = match operation { Overwrite => write_file_atomic_typed(&path, b"payload"), CreateIfAbsent => write_file_create_if_absent(&path, b"payload", || Ok(())) }.expect_err("postcommit error"); assert_eq!((error.stage, error.destination, error.operation, error.primary), (AfterNamespaceCommit, path, operation, "primary".into())); assert_eq!(error.secondary, secondary.map_or_else(Vec::new, |_| vec!["secondary".to_string()])); assert!(scope.operations().contains(&match operation { Overwrite => Rename, CreateIfAbsent => HardLink })); }
+        } let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[rustfmt::skip]
+    #[test]
+    fn atomic_unlink_mode_and_process_serialization() {
+        use super::unlink_atomic_scratch; use std::os::unix::{ffi::OsStrExt, fs::{MetadataExt, PermissionsExt, symlink}};
+        struct Umask(libc::mode_t); impl Umask { fn set(mask: libc::mode_t) -> Self { Self(unsafe { libc::umask(mask) }) } } impl Drop for Umask { fn drop(&mut self) { unsafe { libc::umask(self.0); } } }
+        let dir = unique_temp_path("rubin-atomic-unix"); fs::create_dir_all(&dir).expect("mkdir");
+        let live = dir.join("live"); fs::write(&live, b"live").expect("live");
+        for (leaf, make) in [("regular", 0), ("hardlink", 1), ("fifo", 2), ("symlink", 3), ("dangling", 4)] {
+            let path = dir.join(leaf); match make { 0 => fs::write(&path, b"x").expect("regular"), 1 => fs::hard_link(&live, &path).expect("hardlink"), 2 => { let raw = std::ffi::CString::new(path.as_os_str().as_bytes()).expect("path"); assert_eq!(unsafe { libc::mkfifo(raw.as_ptr(), 0o600) }, 0); }, 3 => symlink(&live, &path).expect("symlink"), _ => symlink(dir.join("absent"), &path).expect("dangling") } unlink_atomic_scratch(&path).expect("unlink"); assert!(path.symlink_metadata().is_err()); assert_eq!(fs::read(&live).expect("live intact"), b"live");
+        }
+        let directory = dir.join("directory"); fs::create_dir(&directory).expect("directory"); assert!(unlink_atomic_scratch(&directory).is_err() && directory.is_dir());
+        for mask in [0, 0o022, 0o077, 0o700] {
+            let _umask = Umask::set(mask); let scratch = dir.join(ATOMIC_WRITE_SCRATCH_LEAF); let dst = dir.join(format!("mode-{mask:o}"));
+            let scope = AtomicWriteTestScope::new(); scope.fail_at(AtomicWriteTestOp::Write, 1, "write"); scope.fail_at(AtomicWriteTestOp::CleanupUnlink, 1, "keep");
+            write_file_atomic_typed(&dst, b"x").expect_err("retain scratch"); assert_eq!(fs::metadata(&scratch).expect("scratch").mode() & 0o777, 0o600); drop(scope); fs::remove_file(&scratch).expect("scratch");
+            write_file_atomic_typed(&dst, b"x").expect("overwrite"); assert_eq!(fs::metadata(&dst).expect("dst").permissions().mode() & 0o777, 0o600);
+            let create = dir.join(format!("create-{mask:o}")); write_file_create_if_absent(&create, b"x", || Ok(())).expect("create"); assert_eq!(fs::metadata(create).expect("create").mode() & 0o777, 0o600);
+        }
+        let guard = ATOMIC_WRITE_PROCESS_MUTEX.lock().expect("mutex"); let barrier = std::sync::Arc::new(std::sync::Barrier::new(3)); let (tx, rx) = std::sync::mpsc::channel(); let mut threads = Vec::new();
+        for (leaf, create) in [("serialized-overwrite", false), ("serialized-create", true)] {
+            let (path, barrier, tx) = (dir.join(leaf), barrier.clone(), tx.clone()); threads.push(std::thread::spawn(move || { barrier.wait(); let result = if create { write_file_create_if_absent(&path, b"x", || Ok(())) } else { write_file_atomic_typed(&path, b"x") }; tx.send(result).expect("send"); }));
+        }
+        barrier.wait(); assert!(matches!(rx.recv_timeout(std::time::Duration::from_millis(100)), Err(std::sync::mpsc::RecvTimeoutError::Timeout))); drop(guard); for _ in 0..2 { rx.recv_timeout(std::time::Duration::from_secs(5)).expect("recv").expect("serialized write"); } for thread in threads { thread.join().expect("join"); } fs::remove_dir_all(dir).expect("cleanup");
     }
 
     /// Standalone `sync_dir` helper accepts an existing directory and
@@ -1996,46 +2205,6 @@ mod tests {
         sync_dir(&dir).expect("sync_dir on existing directory");
 
         let _ = fs::remove_dir_all(&dir);
-    }
-
-    /// Codex P2 fix from PR #1218: `sync_dir` on an execute-only parent
-    /// (mode `0300` — write+execute, no read) must return `Ok(())`
-    /// instead of surfacing `EACCES`, because the rename has already
-    /// succeeded by the time we call it. Without this, hardened
-    /// directory-permission setups would see writes reported as failed
-    /// even though the destination bytes are durably on disk.
-    #[cfg(unix)]
-    #[test]
-    fn sync_dir_is_best_effort_on_execute_only_parent() {
-        use std::os::unix::fs::PermissionsExt;
-        // Skip when running as root — the chmod-based permission check
-        // does not apply (CAP_DAC_READ_SEARCH bypasses it). Detected via
-        // `id -u` (no extra crate dependency on `libc` or `users`).
-        let is_root = std::process::Command::new("id")
-            .arg("-u")
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim() == "0")
-            .unwrap_or(false);
-        if is_root {
-            return;
-        }
-        let dir = unique_temp_path("rubin-io-utils-syncdir-eaccess");
-        fs::create_dir_all(&dir).expect("create test dir");
-        let mut perms = fs::metadata(&dir).expect("stat").permissions();
-        perms.set_mode(0o300);
-        fs::set_permissions(&dir, perms).expect("chmod 0o300");
-
-        let result = sync_dir(&dir);
-
-        // Restore writable mode before any remove call so cleanup works.
-        let mut restore = fs::metadata(&dir).expect("stat").permissions();
-        restore.set_mode(0o700);
-        let _ = fs::set_permissions(&dir, restore);
-        let _ = fs::remove_dir_all(&dir);
-
-        result.expect("sync_dir on execute-only dir must be best-effort (Ok)");
     }
 
     /// Pure-helper unit test for the `path.parent()` edge case: a relative
@@ -2073,86 +2242,9 @@ mod tests {
         );
     }
 
-    /// Copilot P1 regression from PR #1218: the temp path must be built
-    /// via byte-level `OsString::push`, NOT via lossy
-    /// `format!("{}.tmp.{}", path.display(), pid)`. `path.display()`
-    /// replaces non-UTF-8 bytes with `U+FFFD`, so a `PathBuf` containing
-    /// any non-UTF-8 byte would round-trip to a DIFFERENT temp path
-    /// than the caller's actual target.
-    ///
-    /// Tested on the pure helper because APFS on macOS rejects non-UTF-8
-    /// filenames at the syscall layer with `EILSEQ`, which makes a
-    /// filesystem-level round-trip test non-portable. `temp_path_for`
-    /// is the only place where the lossy-vs-exact decision lives, so
-    /// byte-level verification here pins the fix completely.
-    #[cfg(unix)]
-    #[test]
-    fn temp_path_for_preserves_non_utf8_bytes() {
-        use super::temp_path_for;
-        use std::ffi::OsString;
-        use std::os::unix::ffi::{OsStrExt, OsStringExt};
-        use std::path::PathBuf;
-
-        let mut bytes = b"/tmp/bad-".to_vec();
-        bytes.push(0xff);
-        bytes.extend_from_slice(b"-name.bin");
-        let path = PathBuf::from(OsString::from_vec(bytes.clone()));
-
-        let tmp = temp_path_for(&path, 12345, 7);
-
-        let mut expected = bytes.clone();
-        expected.extend_from_slice(b".tmp.12345.7");
-        assert_eq!(tmp.as_os_str().as_bytes(), expected.as_slice());
-
-        // Negative: lossy `format!("{}.tmp.{}.{}", path.display(), ...)`
-        // would replace the 0xff byte with U+FFFD (three bytes
-        // 0xef 0xbf 0xbd), producing DIFFERENT bytes.
-        let lossy = format!("{}.tmp.12345.7", path.display());
-        assert_ne!(
-            tmp.as_os_str().as_bytes(),
-            lossy.as_bytes(),
-            "temp_path_for must not agree with lossy display() on non-UTF-8 input"
-        );
-    }
-
-    /// The seq component is what closes the thread race (`E.3`): two
-    /// consecutive calls within the same process must produce distinct
-    /// temp paths, even though they share the same PID. Without the
-    /// seq, two threads writing to the same destination would overwrite
-    /// each other's temp bytes between open and rename/link.
-    #[test]
-    fn temp_path_for_is_unique_per_seq() {
-        let path = std::path::Path::new("/tmp/shared-dest.bin");
-        let a = super::temp_path_for(path, 42, 0);
-        let b = super::temp_path_for(path, 42, 1);
-        assert_ne!(a, b);
-        // Same pid+seq must remain deterministic for callers that need
-        // to compute the expected temp name in tests.
-        let a_again = super::temp_path_for(path, 42, 0);
-        assert_eq!(a, a_again);
-    }
-
-    /// `next_temp_seq` must never return the same value twice within a
-    /// single process so that concurrent callers pass distinct seq
-    /// values into `temp_path_for`. Verify ordering AND uniqueness in a
-    /// small burst — `AtomicU64::fetch_add` gives strict monotonic
-    /// growth which is stronger than uniqueness and helps diagnose a
-    /// future counter-wrap or reset regression.
-    #[test]
-    fn next_temp_seq_is_monotonic_and_unique() {
-        let a = super::next_temp_seq();
-        let b = super::next_temp_seq();
-        let c = super::next_temp_seq();
-        // Uniqueness.
-        assert!(b != a && c != a && c != b);
-        // Monotonic ordering.
-        assert!(a < b, "seq must be monotonically increasing: a={a} b={b}");
-        assert!(b < c, "seq must be monotonically increasing: b={b} c={c}");
-    }
-
     /// On a sync_all/write_all failure before rename the temp file MUST be
     /// removed, otherwise a real I/O fault (ENOSPC/EIO after data write)
-    /// would strand large `<dest>.tmp.<pid>` siblings on disk while the
+    /// would strand the fixed `.rubin-atomic-write.tmp` scratch on disk while the
     /// caller sees an error.
     ///
     /// We exercise the path indirectly: provoke a `create_parent` failure
@@ -2172,7 +2264,8 @@ mod tests {
         let result = write_file_atomic(&bad_target, b"never-written");
         assert!(result.is_err(), "expected create_parent failure");
 
-        // The directory must contain only the blocker file; no `.tmp.*`
+        // The directory must contain only the blocker file; no fixed
+        // `.rubin-atomic-write.tmp`
         // sibling was created by this failed call.
         let entries: Vec<_> = fs::read_dir(&dir)
             .expect("list dir")
@@ -2183,56 +2276,6 @@ mod tests {
             entries,
             vec!["not-a-dir".to_string()],
             "stranded files present"
-        );
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    /// Copilot P1 regression on PR #1220: a stale
-    /// `<dest>.tmp.<pid>.<seq>` leftover from a crashed prior process
-    /// (potentially hard-linked to a live destination inode) must NOT
-    /// be reopened with O_TRUNC — that would truncate the destination
-    /// through the shared inode. `write_and_sync_temp` uses
-    /// `create_new(true)` (O_EXCL), so reopening the same path
-    /// returns `AlreadyExists` without touching inode data.
-    ///
-    /// Probe `write_and_sync_temp` directly with an explicit temp
-    /// path so the test does not depend on the global `TEMP_SEQ`
-    /// counter — Rust's `cargo test` runs tests in parallel by
-    /// default, and a probe like `stale_seq = next_temp_seq() + 1`
-    /// would race against any other `TEMP_SEQ`-advancing test and
-    /// silently pass under a regression. The `allocate_and_write_temp`
-    /// retry wrapper is just a loop on top of this primitive, so
-    /// validating the primitive's EEXIST-without-truncate contract is
-    /// sufficient for the retry path. Go-side integration coverage
-    /// (`TestWriteFileAtomic_SkipsStaleTempViaExclusiveCreate`) runs
-    /// in a serial test binary by default and exercises the full
-    /// allocate-then-link flow for end-to-end confidence.
-    #[test]
-    fn write_and_sync_temp_refuses_to_reopen_existing_temp() {
-        use super::{write_and_sync_temp, TempWriteError};
-        let dir = unique_temp_path("rubin-io-utils-excl-temp");
-        fs::create_dir_all(&dir).expect("create test dir");
-        let tmp_path = dir.join("seeded.tmp");
-        let stale_bytes = b"STALE BYTES - must not be truncated";
-        fs::write(&tmp_path, stale_bytes).expect("seed stale temp");
-
-        match write_and_sync_temp(&tmp_path, b"attempted new bytes") {
-            Err(TempWriteError::AlreadyExists) => {}
-            Ok(()) => {
-                panic!("write_and_sync_temp accepted a pre-existing path — O_EXCL is not in effect")
-            }
-            Err(TempWriteError::Fatal(msg)) => {
-                panic!("expected AlreadyExists, got Fatal({msg}) — unexpected error kind")
-            }
-        }
-
-        // The existing temp file must be byte-identical to the seed:
-        // O_EXCL refused the open, so the inode was never touched.
-        assert_eq!(
-            fs::read(&tmp_path).expect("read after"),
-            stale_bytes,
-            "pre-existing temp was truncated — O_TRUNC regression",
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -10,6 +10,7 @@ use rubin_consensus::{
     canonical_rotation_network_name_normalized, normalized_rotation_network_name,
     SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
 };
+use rubin_node::chainstate::{reclaim_atomic_scratch, reclaim_atomic_scratch_parent};
 use rubin_node::devnet_rpc::{
     attach_shutdown_signal_to_devnet_rpc_state, RPC_READINESS_TRANSITION_FAILED,
 };
@@ -150,11 +151,11 @@ fn create_or_open_block_store(
     cfg: &CliConfig,
     chain_state_file: &Path,
     stderr: &mut dyn Write,
-) -> Result<(BlockStore, Option<datadir_lock::HeldDatadirLock>), i32> {
+) -> Result<(BlockStore, Option<datadir_lock::HeldDatadirLock>, bool), i32> {
     let root_path = block_store_path(&cfg.data_dir);
     if !cfg.create_store {
         if cfg.dry_run {
-            return open_block_store(&root_path, stderr).map(|store| (store, None));
+            return open_block_store(&root_path, stderr).map(|store| (store, None, false));
         }
         if let Some(error) = missing_block_store_open_error(&cfg.data_dir, &root_path) {
             let _ = writeln!(stderr, "blockstore open failed: {error}");
@@ -162,7 +163,7 @@ fn create_or_open_block_store(
         }
         let lock = datadir_lock::acquire(&cfg.data_dir, stderr)?;
         return match open_block_store(&root_path, stderr) {
-            Ok(store) => Ok((store, Some(lock))),
+            Ok(store) => Ok((store, Some(lock), false)),
             Err(code) => {
                 lock.release();
                 Err(code)
@@ -188,7 +189,7 @@ fn create_or_open_block_store(
         return Err(2);
     }
     match BlockStore::create(root_path) {
-        Ok(store) => Ok((store, Some(lock))),
+        Ok(store) => Ok((store, Some(lock), true)),
         Err(err) => {
             lock.release();
             let _ = writeln!(stderr, "blockstore create failed: {err}");
@@ -317,11 +318,22 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     // Storage lifecycle runs BEFORE the chainstate load: an uninitialized or
     // half-initialized store must reject before anything reads or writes
     // chainstate. Ordinary startup performs no mkdir at all.
-    let (mut block_store, _datadir_lock) =
+    let (mut block_store, _datadir_lock, fresh_store) =
         match create_or_open_block_store(&cfg, &chain_state_file, stderr) {
             Ok(block_store_and_lock) => block_store_and_lock,
             Err(code) => return code,
         };
+    if !cfg.dry_run {
+        let reclaim = if fresh_store {
+            reclaim_atomic_scratch_parent(&cfg.data_dir)
+        } else {
+            reclaim_atomic_scratch(&cfg.data_dir)
+        };
+        if let Err(err) = reclaim {
+            let _ = writeln!(stderr, "{err}");
+            return 2;
+        }
+    }
     let mut chain_state = match load_chain_state(&chain_state_file) {
         Ok(chain_state) => chain_state,
         Err(err) => {
@@ -4048,7 +4060,7 @@ mod tests {
         let cfg = parse_args(&args).expect("parse strict-open config");
         let chain_state_file = chain_state_path(&dir);
 
-        let (store, lock) =
+        let (store, lock, _) =
             super::create_or_open_block_store(&cfg, &chain_state_file, &mut Vec::new())
                 .expect("mutating strict open");
         assert_eq!(store.root_dir(), block_store_path(&dir).as_path());
@@ -4064,7 +4076,7 @@ mod tests {
 
         let mut dry_run = cfg;
         dry_run.dry_run = true;
-        let (store, lock) =
+        let (store, lock, _) =
             super::create_or_open_block_store(&dry_run, &chain_state_file, &mut Vec::new())
                 .expect("dry-run strict open");
         assert_eq!(store.root_dir(), block_store_path(&dir).as_path());

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -9,10 +9,13 @@ use rubin_consensus::{block_hash, parse_block_bytes, parse_block_header_bytes};
 use rubin_consensus::{RotationProvider, SuiteRegistry};
 
 use crate::blockstore::BlockStore;
-use crate::chainstate::{CanonicalAppliedBlock, ChainState, ChainStateConnectSummary};
+use crate::chainstate::{
+    load_chain_state, CanonicalAppliedBlock, ChainState, ChainStateConnectSummary,
+};
 use crate::chainstate_recovery::should_persist_chainstate_snapshot;
 use crate::da_relay::complete_da_set_ids_from_parsed_block;
 use crate::genesis::devnet_genesis_chain_id;
+use crate::io_utils::{is_atomic_write_post_commit, AtomicWriteError};
 use crate::sync_reorg::PARENT_BLOCK_NOT_FOUND_ERR;
 use crate::target_schedule::{expected_target_for_candidate, TargetScheduleError};
 use crate::undo::build_block_undo;
@@ -21,6 +24,7 @@ pub const DEFAULT_IBD_LAG_SECONDS: u64 = 24 * 60 * 60;
 const DEFAULT_HEADER_BATCH_LIMIT: u64 = 512;
 const DEFAULT_PV_SHADOW_MAX_SAMPLES: u64 = 3;
 const MAX_PV_SHADOW_MAX_SAMPLES: u64 = 10_000;
+const STORAGE_PERSISTENCE_FAULT_ERR: &str = "storage persistence fault; restart required";
 
 #[derive(Clone, Debug)]
 pub struct SyncConfig {
@@ -471,7 +475,6 @@ pub struct HeaderRequest {
     pub has_from: bool,
     pub limit: u64,
 }
-
 #[derive(Debug)]
 pub struct SyncEngine {
     pub(crate) chain_state: ChainState,
@@ -486,12 +489,27 @@ pub struct SyncEngine {
     pv_shadow_mismatches: u64,
     pv_shadow_samples: Vec<String>,
     pv_telemetry: PVTelemetry,
+    persistence_fault: Option<StoragePersistenceFault>,
     /// Test-only: drop block_store after canonical truncate (between
     /// truncate and save) to exercise the otherwise-unreachable
     /// blockstore-missing branch in disconnect_tip's save-failure
     /// recovery.
     #[cfg(test)]
     pub(crate) drop_block_store_after_truncate: bool,
+}
+#[derive(Debug)]
+struct StoragePersistenceFault {
+    cause: AtomicWriteError,
+    reload_error: Option<String>,
+}
+impl std::fmt::Display for StoragePersistenceFault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.cause)?;
+        if let Some(reload_error) = &self.reload_error {
+            write!(f, "; persistence reload failed: {reload_error}")?;
+        }
+        Ok(())
+    }
 }
 
 /// Captured state for rollback on failure during reorg.
@@ -632,8 +650,59 @@ pub(crate) fn target_schedule_error_message(err: TargetScheduleError) -> String 
         TargetScheduleError::LocalIo(cause) => format!("target schedule local I/O: {cause}"),
     }
 }
-
 impl SyncEngine {
+    pub(crate) fn mutation_allowed(&self) -> Result<(), String> {
+        if self.persistence_fault.is_some() {
+            return Err(STORAGE_PERSISTENCE_FAULT_ERR.to_string());
+        }
+        Ok(())
+    }
+    pub(crate) fn handle_persistence_error(
+        &mut self,
+        error: AtomicWriteError,
+        reload_store: bool,
+        reload_chainstate: bool,
+    ) -> String {
+        if !is_atomic_write_post_commit(&error) {
+            return error.to_string();
+        }
+        if let Some(fault) = &self.persistence_fault {
+            return fault.to_string();
+        }
+        self.persistence_fault = Some(StoragePersistenceFault {
+            cause: error,
+            reload_error: None,
+        });
+        let reload_error = self
+            .reload_visible_persistence_state(reload_store, reload_chainstate)
+            .err();
+        let fault = self
+            .persistence_fault
+            .as_mut()
+            .expect("persistence fault was just installed");
+        fault.reload_error = reload_error;
+        fault.to_string()
+    }
+    fn reload_visible_persistence_state(
+        &mut self,
+        reload_store: bool,
+        reload_chainstate: bool,
+    ) -> Result<(), String> {
+        let mut first_error = reload_store
+            .then(|| self.block_store.as_mut()?.reload_persistence_state().err())
+            .flatten();
+        if reload_chainstate {
+            let Some(path) = self.cfg.chain_state_path.as_ref() else {
+                return first_error.map_or(Ok(()), Err);
+            };
+            match load_chain_state(path) {
+                Ok(state) => self.chain_state = state,
+                Err(error) if first_error.is_none() => first_error = Some(error),
+                Err(_) => {}
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
     /// The stock predicate on this engine's own config.
     pub(crate) fn stock_devnet_target_schedule(&self) -> bool {
         stock_devnet_target_schedule(&self.cfg.network, self.cfg.chain_id)
@@ -724,6 +793,7 @@ impl SyncEngine {
             pv_shadow_mismatches: 0,
             pv_shadow_samples: Vec::new(),
             pv_telemetry: PVTelemetry::new(pv_mode),
+            persistence_fault: None,
             #[cfg(test)]
             drop_block_store_after_truncate: false,
         })
@@ -896,6 +966,7 @@ impl SyncEngine {
         prev_timestamps: Option<&[u64]>,
         target: Option<CanonicalApplyTarget>,
     ) -> Result<ChainStateConnectSummary, String> {
+        self.mutation_allowed()?;
         let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
         let block_hash_bytes = block_hash(&parsed.header_bytes).map_err(|e| e.to_string())?;
         // Height and target context are acquired BEFORE the MTP window and
@@ -1068,17 +1139,7 @@ impl SyncEngine {
         }];
 
         let commit_start = Instant::now();
-        // `canonical_len_before` is the rewind target for the ONLY remaining
-        // post-commit failure point: `chain_state.save` below. If
-        // `commit_canonical_block` itself returns `Err`, the persisted
-        // canonical tip has not advanced: the tip write is the last step
-        // inside the atomic API, so an earlier failure leaves the prior
-        // on-disk tip in place. Note that a save failure inside
-        // `set_canonical_tip` mutates in-memory state before a best-effort
-        // reload of the on-disk length; if that reload also fails, the
-        // in-memory length may still be ahead of disk and the blockstore
-        // would require repair. No rewind is needed here for the normal
-        // `commit_canonical_block` error path.
+        // Rewind target only for later precommit chainstate-save failure; canonical precommit preserves tip, while postcommit may advance disk and is reloaded/latched below.
         let canonical_len_before = self.block_store.as_ref().map_or(0, |bs| bs.canonical_len());
         if let Some(block_store) = self.block_store.as_mut() {
             // Atomic canonical commit — Go parity
@@ -1087,17 +1148,25 @@ impl SyncEngine {
             // -> canonical tip (last). A failure before the tip advance
             // leaves the canonical tip at its prior height, so no rewind
             // is required on block/header/undo write failure.
-            if let Err(err) = block_store.commit_canonical_block(
+            if let Err(error) = block_store.commit_canonical_block_typed(
                 summary.block_height,
                 block_hash_bytes,
                 &parsed.header_bytes,
                 block_bytes,
                 &undo,
             ) {
+                if is_atomic_write_post_commit(&error) {
+                    let reload_store = block_store.is_index_destination(&error.destination);
+                    let error = self.handle_persistence_error(error, reload_store, false);
+                    if !reload_store {
+                        self.chain_state = snapshot;
+                    }
+                    return Err(error);
+                }
                 self.chain_state = snapshot;
                 self.tip_timestamp = old_tip_timestamp;
                 self.best_known_height = old_best_known_height;
-                return Err(err);
+                return Err(error.to_string());
             }
         }
 
@@ -1122,24 +1191,28 @@ impl SyncEngine {
             let persist_snapshot = self.block_store.is_none()
                 || should_persist_chainstate_snapshot(Some(&self.chain_state), Some(&summary));
             if persist_snapshot {
-                if let Err(err) = self.chain_state.save(chain_state_path) {
+                if let Err(error) = self.chain_state.save_atomic(chain_state_path) {
+                    if is_atomic_write_post_commit(&error) {
+                        return Err(self.handle_persistence_error(error, false, true));
+                    }
+                    let err = error.to_string();
                     // Canonical commit MAY have advanced the tip. The
                     // same-hash replay path returns Ok(()) without advancing
                     // the canonical index/tip (canonical_len unchanged),
                     // though it may still back-fill missing undo data on
                     // disk, so only rewind when the canonical length
                     // actually grew past the pre-commit snapshot.
-                    let rewind_err = self.block_store.as_mut().and_then(|bs| {
-                        if bs.canonical_len() > canonical_len_before {
-                            bs.truncate_canonical(canonical_len_before).err()
-                        } else {
-                            None
-                        }
+                    let rewind_result = self.block_store.as_mut().and_then(|bs| {
+                        (bs.canonical_len() > canonical_len_before)
+                            .then(|| bs.truncate_canonical_typed(canonical_len_before))
                     });
                     self.chain_state = snapshot;
                     self.tip_timestamp = old_tip_timestamp;
                     self.best_known_height = old_best_known_height;
-                    if let Some(rewind_err) = rewind_err {
+                    if let Some(Err(rewind_err)) = rewind_result {
+                        if is_atomic_write_post_commit(&rewind_err) {
+                            return Err(self.handle_persistence_error(rewind_err, true, false));
+                        }
                         return Err(format!(
                             "{err}; failed to rewind canonical index after chain_state save failure: {rewind_err}; blockstore may require repair"
                         ));
@@ -1209,17 +1282,29 @@ impl SyncEngine {
     /// Returns an error description if persistence failed — callers
     /// should surface this as a repair hint.
     pub(crate) fn rollback_apply_block(&mut self, rb: SyncRollbackState) -> Option<String> {
+        if self.persistence_fault.is_some() {
+            return None;
+        }
         // Phase 1: canonical index rollback (IO) — fail-fast before
         // mutating any in-memory state.
         if let Some(bs) = self.block_store.as_mut() {
             let res = if let Some(suffix) = rb.canonical_removed_suffix {
                 // Reorg path: truncate to base, re-append removed suffix.
-                bs.rollback_canonical(rb.canonical_len, suffix)
+                bs.rollback_canonical_typed(rb.canonical_len, suffix)
             } else {
                 // Light rollback: truncate to saved length (disconnect_tip).
-                bs.truncate_canonical(rb.canonical_len)
+                bs.truncate_canonical_typed(rb.canonical_len)
             };
             if let Err(e) = res {
+                if is_atomic_write_post_commit(&e) {
+                    let error = self.handle_persistence_error(e, true, false);
+                    self.chain_state = rb.chain_state;
+                    self.tip_timestamp = rb.tip_timestamp;
+                    self.best_known_height = rb.best_known_height;
+                    self.last_reorg_depth = rb.last_reorg_depth;
+                    self.reorg_count = rb.reorg_count;
+                    return Some(error);
+                }
                 return Some(format!("canonical rollback failed: {e}"));
             }
         }
@@ -1232,7 +1317,10 @@ impl SyncEngine {
         self.reorg_count = rb.reorg_count;
 
         if let Some(path) = self.cfg.chain_state_path.as_ref() {
-            if let Err(e) = self.chain_state.save(path) {
+            if let Err(e) = self.chain_state.save_atomic(path) {
+                if is_atomic_write_post_commit(&e) {
+                    return Some(self.handle_persistence_error(e, false, true));
+                }
                 return Some(format!(
                     "chain_state save on rollback failed \
                      (canonical already rolled back, may require repair): {e}"
@@ -1545,7 +1633,10 @@ mod tests {
     use crate::chainstate::{chain_state_path, load_chain_state, ChainState};
     use crate::coinbase::{build_coinbase_tx, default_mine_address};
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
-    use crate::io_utils::unique_temp_path;
+    use crate::io_utils::{
+        atomic_write_error_after, unique_temp_path, AtomicWriteOperation, AtomicWriteStage,
+        AtomicWriteTestOp, AtomicWriteTestScope,
+    };
     use crate::sync::{
         boundary_chain_for_test, default_sync_config, next_candidate_block_for_test,
         retarget_block_for_test, run_pv_shadow_validation_guarded, stock_devnet_engine_for_test,
@@ -1679,6 +1770,35 @@ mod tests {
         assert_eq!(tip.0, 0);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+    #[rustfmt::skip]
+    #[test]
+    fn postcommit_faults_latch_real_engine_before_further_mutation() {
+        use AtomicWriteOperation::{CreateIfAbsent, Overwrite}; use AtomicWriteTestOp::{CleanupUnlink, HardLink, ParentSync, Rename};
+        let genesis = devnet_genesis_block_bytes(); let parsed = parse_block_bytes(&genesis).expect("parse genesis");
+        let hash = hex::encode(block_hash(&parsed.header_bytes).expect("genesis hash"));
+        let rows = [("blockstore/blocks", format!("{hash}.bin"), CreateIfAbsent, HardLink, false, false), ("blockstore/headers", format!("{hash}.bin"), CreateIfAbsent, HardLink, false, false), ("blockstore/undo", format!("{hash}.json"), Overwrite, Rename, false, false), ("blockstore", "index.json".into(), Overwrite, Rename, true, true), ("", "chainstate.json".into(), Overwrite, Rename, true, true)];
+        for (index, (parent, leaf, operation, commit, disk_index, chainstate)) in rows.into_iter().enumerate() {
+            let dir = unique_temp_path("rubin-postcommit-engine"); std::fs::create_dir_all(&dir).expect("mkdir");
+            let store = BlockStore::create(block_store_path(&dir)).expect("store"); let mut cfg = default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), Some(chain_state_path(&dir))); if index == 0 { cfg.chain_state_path = None; }
+            let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("engine"); let scope = AtomicWriteTestScope::new();
+            scope.fail_at(CleanupUnlink, index + 1, "cleanup-primary"); scope.fail_at(ParentSync, index + 1, "parent-secondary");
+            let error = engine.apply_block(&genesis, None).expect_err("postcommit fault"); let fault = engine.persistence_fault.as_ref().expect("latched fault");
+            assert_eq!((fault.cause.stage, &fault.cause.destination, fault.cause.operation, fault.cause.primary.as_str(), fault.cause.secondary.as_slice()), (AtomicWriteStage::AfterNamespaceCommit, &dir.join(parent).join(leaf), operation, "cleanup-primary", &["parent-secondary".to_string()][..]));
+            assert!(error.contains("cleanup-primary"));
+            assert_eq!((engine.block_store.as_ref().expect("store").canonical_len() > 0, engine.chain_state.has_tip), (disk_index, chainstate));
+            assert_eq!(scope.operations().iter().filter(|&&op| op == commit).count(), if commit == HardLink { index + 1 } else { index - 1 });
+            for blocked in [engine.apply_block(&genesis, None).unwrap_err(), engine.apply_block_with_reorg(&genesis, None).unwrap_err(), engine.disconnect_tip().unwrap_err()] { assert_eq!(blocked, "storage persistence fault; restart required"); }
+            drop(scope); std::fs::remove_dir_all(dir).expect("cleanup");
+        }
+        let path = unique_temp_path("rubin-reload-error"); std::fs::create_dir_all(&path).expect("dir"); let cfg = default_sync_config(None, [0; 32], Some(path.clone())); let mut engine = SyncEngine::new(ChainState::new(), None, cfg).expect("engine");
+        engine.handle_persistence_error(atomic_write_error_after(&path, Overwrite, "postcommit"), false, true); assert!(engine.persistence_fault.expect("fault").reload_error.is_some()); std::fs::remove_dir_all(path).expect("cleanup");
+        let dir = unique_temp_path("rubin-precommit-engine"); std::fs::create_dir_all(&dir).expect("dir");
+        let index = block_store_path(&dir).join("index.json"); let store = BlockStore::create(block_store_path(&dir)).expect("store"); let empty = std::fs::read(&index).expect("index");
+        let cfg = default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), Some(chain_state_path(&dir))); let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("engine");
+        std::fs::remove_file(&index).expect("remove"); std::fs::create_dir(&index).expect("block"); let err = engine.apply_block(&genesis, None).unwrap_err(); assert!(err.contains("before_namespace_commit")); assert!(engine.persistence_fault.is_none()); assert_eq!((engine.chain_state.has_tip, engine.block_store.as_ref().expect("store").canonical_len()), (false, 0));
+        std::fs::remove_dir(&index).expect("unblock"); std::fs::write(&index, empty).expect("restore"); engine.apply_block(&genesis, None).expect("retry");
+        std::fs::remove_dir_all(dir).expect("cleanup");
     }
 
     /// B.1 sub-issue #1246: when `cfg.chain_state_path == None`,

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -1,6 +1,7 @@
 use rubin_consensus::{parse_block_bytes, parse_block_header_bytes};
 
 use crate::chainstate::ChainState;
+use crate::io_utils::is_atomic_write_post_commit;
 use crate::sync::SyncEngine;
 use crate::undo::ChainStateDisconnectSummary;
 
@@ -8,6 +9,7 @@ impl SyncEngine {
     /// Disconnect the current canonical tip block, restoring the chain state
     /// to the parent. Returns a summary of the disconnection.
     pub fn disconnect_tip(&mut self) -> Result<ChainStateDisconnectSummary, String> {
+        self.mutation_allowed()?;
         let block_store = self
             .block_store
             .as_ref()
@@ -48,11 +50,15 @@ impl SyncEngine {
         // truncate and save leaves the canonical index short while chainstate
         // still has the old tip; the mismatch guard at the top of this
         // function detects and rejects this on restart.
-        let bs = self
+        let truncate_result = self
             .block_store
             .as_mut()
-            .ok_or("sync engine has no blockstore")?;
-        if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
+            .ok_or("sync engine has no blockstore")?
+            .truncate_canonical_typed(rollback.canonical_len.saturating_sub(1));
+        if let Err(error) = truncate_result {
+            if is_atomic_write_post_commit(&error) {
+                return Err(self.handle_persistence_error(error, true, false));
+            }
             // truncate_canonical leaves the canonical index unchanged on
             // failure because BlockStore::truncate_canonical updates its
             // in-memory canonical only after the disk write succeeds.
@@ -64,7 +70,7 @@ impl SyncEngine {
             self.chain_state = rollback.chain_state;
             self.tip_timestamp = rollback.tip_timestamp;
             self.best_known_height = rollback.best_known_height;
-            return Err(err);
+            return Err(error.to_string());
         }
 
         // Test-only seam to exercise the otherwise-unreachable
@@ -75,7 +81,11 @@ impl SyncEngine {
         }
 
         if let Some(path) = self.cfg.chain_state_path.as_ref() {
-            if let Err(err) = self.chain_state.save(path) {
+            if let Err(error) = self.chain_state.save_atomic(path) {
+                if is_atomic_write_post_commit(&error) {
+                    return Err(self.handle_persistence_error(error, false, true));
+                }
+                let err = error.to_string();
                 // Restore canonical tip directly, then restore in-memory
                 // state inline.  Going through rollback_apply_block here
                 // would trigger a second canonical write (light-rollback
@@ -88,14 +98,22 @@ impl SyncEngine {
                 // above proves it still is), but we propagate a normal
                 // error if it's somehow missing rather than panic in a
                 // sync hot path.
-                let canonical_rb = match self.block_store.as_mut() {
-                    Some(bs) => bs
-                        .rollback_canonical(
-                            rollback.canonical_len.saturating_sub(1),
-                            vec![hex::encode(tip_hash)],
-                        )
-                        .err()
-                        .map(|e| format!("canonical restore failed: {e}")),
+                let canonical_restore = self.block_store.as_mut().map(|bs| {
+                    bs.rollback_canonical_typed(
+                        rollback.canonical_len.saturating_sub(1),
+                        vec![hex::encode(tip_hash)],
+                    )
+                });
+                let canonical_rb = match canonical_restore {
+                    Some(Ok(())) => None,
+                    Some(Err(error)) if is_atomic_write_post_commit(&error) => {
+                        let error = self.handle_persistence_error(error, true, false);
+                        self.chain_state = rollback.chain_state;
+                        self.tip_timestamp = rollback.tip_timestamp;
+                        self.best_known_height = rollback.best_known_height;
+                        return Err(error);
+                    }
+                    Some(Err(error)) => Some(format!("canonical restore failed: {error}")),
                     None => {
                         // Canonical restore cannot be attempted; align the
                         // in-memory tip with the disconnected parent and
@@ -138,6 +156,7 @@ impl SyncEngine {
         &mut self,
         common_ancestor_height: u64,
     ) -> Result<Vec<Vec<u8>>, String> {
+        self.mutation_allowed()?;
         let (mut current_height, _) = self
             .block_store
             .as_ref()

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use crate::blockstore::BlockStore;
 use crate::chainstate::{CanonicalAppliedBlock, ChainStateConnectSummary};
+use crate::io_utils::is_atomic_write_post_commit;
 use crate::sync::SyncEngine;
 use crate::txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxSource};
 
@@ -394,6 +395,7 @@ impl SyncEngine {
         block_bytes: &[u8],
         prev_timestamps: Option<&[u64]>,
     ) -> Result<ApplyBlockWithReorgOutcome, String> {
+        self.mutation_allowed()?;
         let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
         let bh = block_hash(&parsed.header_bytes).map_err(|e| e.to_string())?;
 
@@ -452,11 +454,16 @@ impl SyncEngine {
 
             // Validation passed — now persist the side-chain block.
             if !block_store.has_block(candidate.hash) {
-                block_store.store_block(
+                if let Err(error) = block_store.store_block_typed(
                     candidate.hash,
                     &candidate.header_bytes,
                     &candidate.block_bytes,
-                )?;
+                ) {
+                    if is_atomic_write_post_commit(&error) {
+                        return Err(self.handle_persistence_error(error, false, false));
+                    }
+                    return Err(error.to_string());
+                }
             }
 
             return Ok(ApplyBlockWithReorgOutcome {

--- a/scripts/node-runtime-total-parity-gate.sh
+++ b/scripts/node-runtime-total-parity-gate.sh
@@ -15,25 +15,28 @@ run_stage() {
   "$@"
 }
 
-run_stage "Stage 1/7: dry-run storage parity" \
+run_stage "Stage 1/8: dry-run storage parity" \
   "${DEV_ENV}" -- bash -lc "cd '${REPO_ROOT}' && bash scripts/test_node_dry_run_parity.sh"
 
-run_stage "Stage 2/7: storage writer-lock parity" \
+run_stage "Stage 2/8: storage writer-lock parity" \
   "${DEV_ENV}" -- bash -lc "cd '${REPO_ROOT}' && bash scripts/test_node_storage_lock_parity.sh datadir"
 
-run_stage "Stage 3/7: live Go↔Rust devnet RPC parity smoke" \
+run_stage "Stage 3/8: atomic parent writer-lock parity" \
+  "${DEV_ENV}" -- bash -lc "cd '${REPO_ROOT}' && bash scripts/test_node_storage_lock_parity.sh atomic-parent"
+
+run_stage "Stage 4/8: live Go↔Rust devnet RPC parity smoke" \
   "${REPO_ROOT}/scripts/devnet-rpc-parity-smoke.sh"
 
-run_stage "Stage 4/7: live Go↔Rust P2P interop coverage" \
+run_stage "Stage 5/8: live Go↔Rust P2P interop coverage" \
   "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop_(GoDialRustServerHandshake|RustClientDialGoServerHandshake|RustServerPingGoClientPong|RustClientReceivesTxFromGo|RustClientSyncsFiveBlocksFromGo)$' -count=1"
 
-run_stage "Stage 5/7: Go relay + txpool lifecycle parity checks" \
+run_stage "Stage 6/8: Go relay + txpool lifecycle parity checks" \
   "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && go test ./node/p2p -run '^(TestAnnounceTx|TestAnnounceTxMetadataError)$' -count=1 && go test ./node -run '^TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool$' -count=1"
 
-run_stage "Stage 6/7: Rust relay + txpool lifecycle parity checks" \
+run_stage "Stage 7/8: Rust relay + txpool lifecycle parity checks" \
   "${DEV_ENV}" -- bash -lc "cd '${RUST_MODULE_ROOT}' && cargo test -p rubin-node handle_received_tx_with_valid_fixture_stores_and_relays -- --test-threads=1 && cargo test -p rubin-node announce_tx_uses_real_metadata_for_relay_pool_priority -- --test-threads=1 && cargo test -p rubin-node apply_block_with_reorg_tip_extension_with_pool -- --test-threads=1 && cargo test -p rubin-node apply_block_with_reorg_tip_extension_removes_conflicting_pool_spends -- --test-threads=1"
 
-run_stage "Stage 7/7: PV/shadow parity soak gate" \
+run_stage "Stage 8/8: PV/shadow parity soak gate" \
   "${REPO_ROOT}/scripts/pv-soak-ci-gate.sh" --report "${PV_REPORT_PATH}"
 
 HEAD_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
@@ -67,6 +70,10 @@ report = {
         {
             "name": "storage_lock_parity",
             "command": "bash scripts/test_node_storage_lock_parity.sh datadir",
+        },
+        {
+            "name": "atomic_parent_storage_lock_parity",
+            "command": "bash scripts/test_node_storage_lock_parity.sh atomic-parent",
         },
         {
             "name": "live_devnet_rpc_smoke",

--- a/scripts/test_node_storage_lock_parity.sh
+++ b/scripts/test_node_storage_lock_parity.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
-[[ $# == 1 && "$1" == datadir ]] || { printf 'usage: %s datadir\n' "${0##*/}" >&2; exit 2; }
+MODE="${1:-}"
+[[ $# == 1 && ( "${MODE}" == datadir || "${MODE}" == atomic-parent ) ]] || {
+  printf 'usage: %s {datadir|atomic-parent}\n' "${0##*/}" >&2
+  exit 2
+}
 for tool in cmp cp grep ln mkfifo python3 tr; do
   command -v "${tool}" >/dev/null 2>&1 || { printf 'missing required tool: %s\n' "${tool}" >&2; exit 1; }
 done
@@ -75,6 +79,25 @@ PY
 }
 take_snapshot() { snapshot_datadir "$2" >"$3" || fail "$1: snapshot failed for $2"; }
 assert_same_snapshot() { cmp -s "$2" "$3" || fail "$1: datadir snapshot changed (before=$2 after=$3)"; }
+assert_same_atomic_semantic_snapshot() {
+  python3 - "$2" "$3" <<'PY' || fail "$1: authoritative snapshot changed (before=$2 after=$3)"
+import sys
+
+def semantic_rows(path):
+    rows = set()
+    with open(path, encoding="utf-8") as source:
+        for raw in source:
+            fields = raw.rstrip("\n").split("\t")
+            if len(fields) != 9:
+                raise SystemExit(f"malformed snapshot row in {path}: {raw!r}")
+            rows.add(tuple(fields[index] for index in (0, 1, 2, 3, 4, 7)))
+    return rows
+
+before, after = semantic_rows(sys.argv[1]), semantic_rows(sys.argv[2])
+if before != after:
+    raise SystemExit("semantic snapshot rows differ")
+PY
+}
 assert_exact_file() {
   local expected="${ART}/markers/$1.expected"
   printf '%s\n' "$3" >"${expected}"
@@ -100,15 +123,32 @@ import sys
 
 path, want_test = sys.argv[1], sys.argv[2] == "test"
 found = None
-with open(path, encoding="utf-8") as source:
-    for raw in source:
-        event = json.loads(raw)
-        target = event.get("target") or {}
-        profile = event.get("profile") or {}
+try:
+    with open(path, encoding="utf-8") as source:
+        lines = list(source)
+except (OSError, UnicodeError) as exc:
+    raise SystemExit(f"cannot read Cargo JSONL: {exc}")
+for line_number, raw in enumerate(lines, 1):
+        try:
+            event = json.loads(raw)
+        except (json.JSONDecodeError, RecursionError) as exc:
+            raise SystemExit(f"malformed Cargo JSONL at line {line_number}: {exc}")
+        if not isinstance(event, dict):
+            raise SystemExit(f"Cargo JSONL event at line {line_number} is not an object")
+        target = event.get("target", {})
+        profile = event.get("profile", {})
+        if not isinstance(target, dict) or not isinstance(profile, dict):
+            raise SystemExit(f"Cargo JSONL event at line {line_number} has invalid target/profile")
+        kind, is_test, executable = target.get("kind", []), profile.get("test"), event.get("executable")
+        if not isinstance(kind, list) or any(not isinstance(value, str) for value in kind):
+            raise SystemExit(f"Cargo JSONL event at line {line_number} has invalid target.kind")
+        if is_test is not None and not isinstance(is_test, bool):
+            raise SystemExit(f"Cargo JSONL event at line {line_number} has invalid profile.test")
+        if executable is not None and not isinstance(executable, str):
+            raise SystemExit(f"Cargo JSONL event at line {line_number} has invalid executable")
         if (event.get("reason") == "compiler-artifact" and target.get("name") == "rubin-node"
-                and "bin" in target.get("kind", []) and bool(profile.get("test")) == want_test
-                and event.get("executable")):
-            found = event["executable"]
+                and "bin" in kind and bool(is_test) == want_test and executable):
+            found = executable
 if found is None:
     raise SystemExit("no rubin-node binary artifact")
 print(found)
@@ -281,6 +321,7 @@ assert_invalid missing-parent "${MISSING_PARENT}/.rubin.lock"
 [[ ! -e "${ART}/fixtures/missing-parent" ]] || fail 'strict missing lock parent was created'
 
 LIVE_PID=""
+LIVE_RPC=""
 start_live() {
   local impl="$1" datadir="$2" label="$3" create="${4:-}" bin rpc log="${ART}/${3}.${1}.live.log"
   bin="$(node_bin "${impl}")"
@@ -293,6 +334,7 @@ start_live() {
   rubin_process_wait_for_log "${log}" 'rpc: listening=' 30 "${LIVE_PID}" || fail "${label}: RPC banner"
   rpc="$(rubin_process_extract_rpc_addr "${log}")" || fail "${label}: RPC address"
   rubin_process_wait_for_rpc_ready "${rpc}" 30 || fail "${label}: RPC readiness"
+  LIVE_RPC="${rpc}"
 }
 stop_live() {
   rubin_process_stop_pid "${LIVE_PID}" || fail "$1: live stop failed"
@@ -303,6 +345,14 @@ initialize_store() {
   start_live "$1" "$2" "$3" create
   stop_live "$3"
   [[ -f "$2/.rubin.lock" && ! -s "$2/.rubin.lock" ]] || fail "$3: initialized store has no valid persistent lock"
+}
+assert_fresh_create_reclaims_datadir_scratch() {
+  local impl="$1" label="fresh-create-${1}" datadir="${ART}/fixtures/fresh-create-${1}"
+  mkdir -p "${datadir}"
+  printf 'stale datadir scratch\n' >"${datadir}/${ATOMIC_SCRATCH_LEAF}"
+  initialize_store "${impl}" "${datadir}" "${label}"
+  assert_absent "${label}: stale datadir scratch" "${datadir}/${ATOMIC_SCRATCH_LEAF}"
+  assert_store_readable "${label}" "${datadir}"
 }
 RUN_RC=0
 RUN_OUT=""
@@ -459,6 +509,209 @@ assert_readers_without_lock() {
   for mode in dry-run legacy; do for reader in go rust; do assert_reader "${reader}" "${mode}" "${label}.${reader}-${mode}" "${datadir}"; done; done
   assert_absent "${label}: readers created a lock" "${lock}"
 }
+
+ATOMIC_LOCK_LEAF='.rubin-atomic-write.lock'
+ATOMIC_SCRATCH_LEAF='.rubin-atomic-write.tmp'
+ATOMIC_PARENTS=()
+set_atomic_parents() {
+  local datadir="$1" leaf
+  ATOMIC_PARENTS=("${datadir}")
+  for leaf in blockstore blockstore/blocks blockstore/headers blockstore/undo; do
+    ATOMIC_PARENTS+=("${datadir}/${leaf}")
+  done
+}
+assert_atomic_reserved_state() {
+  local label="$1" want_scratch="$2" want_lock="$3" parent scratch_count=0 lock_count=0
+  for parent in "${ATOMIC_PARENTS[@]}"; do
+    [[ -d "${parent}" ]] || fail "${label}: fixed atomic parent is absent: ${parent}"
+    if [[ -e "${parent}/${ATOMIC_SCRATCH_LEAF}" || -L "${parent}/${ATOMIC_SCRATCH_LEAF}" ]]; then (( scratch_count += 1 )); fi
+    if [[ -e "${parent}/${ATOMIC_LOCK_LEAF}" || -L "${parent}/${ATOMIC_LOCK_LEAF}" ]]; then (( lock_count += 1 )); fi
+  done
+  [[ "${scratch_count}" == "${want_scratch}" ]] || fail "${label}: atomic scratch count=${scratch_count}, want=${want_scratch} across five fixed parents"
+  [[ "${lock_count}" == "${want_lock}" ]] || fail "${label}: atomic lock count=${lock_count}, want=${want_lock} across five fixed parents"
+}
+canonical_live_block_path() {
+  python3 - "$1/blockstore/index.json" "$1/blockstore/blocks" <<'PY'
+import json, pathlib, sys
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+try:
+    index = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+    raise SystemExit(f"cannot read canonical block index: {exc}")
+require(isinstance(index, dict), "canonical block index root is not an object")
+canonical = index.get("canonical")
+require(isinstance(canonical, list) and canonical, "canonical block index has no live block")
+block_hash = canonical[-1]
+require(isinstance(block_hash, str) and len(block_hash) == 64 and all(ch in "0123456789abcdef" for ch in block_hash), "canonical block index has an invalid final hash")
+path = pathlib.Path(sys.argv[2]) / f"{block_hash}.bin"
+require(path.is_file(), f"canonical block destination is absent: {path}")
+print(path)
+PY
+}
+seed_atomic_residues() {
+  local label="$1" datadir="$2" live_block="$3" parent
+  set_atomic_parents "${datadir}"
+  [[ -f "${live_block}" ]] || fail "${label}: live block for hardlink residue is absent"
+  for parent in "${ATOMIC_PARENTS[@]}"; do
+    assert_absent "${label}: preseed scratch" "${parent}/${ATOMIC_SCRATCH_LEAF}"
+    rm -f -- "${parent}/${ATOMIC_LOCK_LEAF}" || fail "${label}: cannot remove exact test lock leaf"
+    assert_absent "${label}: cleared lock" "${parent}/${ATOMIC_LOCK_LEAF}"
+  done
+  ln -- "${live_block}" "${ATOMIC_PARENTS[0]}/${ATOMIC_SCRATCH_LEAF}" || fail "${label}: root hardlink residue"
+  [[ "${live_block}" -ef "${ATOMIC_PARENTS[0]}/${ATOMIC_SCRATCH_LEAF}" ]] ||
+    fail "${label}: root scratch is not a hardlink to the live destination"
+  for parent in "${ATOMIC_PARENTS[@]:1}"; do
+    printf '%s\n' "${label}: residue" >"${parent}/${ATOMIC_SCRATCH_LEAF}"
+  done
+  assert_atomic_reserved_state "${label}: seeded exact residues" 5 0
+}
+RPC_RESULT=""
+rpc_result() {
+  local label="$1" rpc="$2" method="$3" route="$4"
+  RPC_RESULT="${ART}/${label}.${route#/}.json"
+  python3 - "${rpc}" "${method}" "${route}" >"${RPC_RESULT}" <<'PY'
+import json, socket, sys, time, urllib.error, urllib.request
+started, method, route = time.monotonic(), sys.argv[2], sys.argv[3]
+data = b"{}" if method == "POST" else None
+request = urllib.request.Request(f"http://{sys.argv[1]}{route}", data=data, method=method)
+if data is not None:
+    request.add_header("Content-Type", "application/json")
+try:
+    with urllib.request.urlopen(request, timeout=10) as response:
+        status, raw = response.status, response.read()
+except urllib.error.HTTPError as exc:
+    status, raw = exc.code, exc.read()
+except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as exc:
+    raise SystemExit(f"HTTP transport failed for {route}: {exc}")
+try:
+    text = raw.decode("utf-8")
+except UnicodeError as exc:
+    raise SystemExit(f"HTTP body for {route} is not UTF-8: {exc}")
+try:
+    body = json.loads(text)
+except (json.JSONDecodeError, RecursionError) as exc:
+    raise SystemExit(f"HTTP body for {route} is malformed JSON: {exc}")
+print(json.dumps({"body": body, "elapsed_ms": int((time.monotonic() - started) * 1000), "status": status}, sort_keys=True))
+PY
+}
+validate_atomic_rpc() {
+  local label="$1" mode="$2" result="$3" arg1="${4:-}" arg2="${5:-}" output="${6:-/dev/null}"
+  python3 - "${mode}" "${result}" "${arg1}" "${arg2}" >"${output}" <<'PY' || fail "${label}: ${mode} RPC contract"
+import json, pathlib, re, sys
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+def load(path, label):
+    try:
+        value = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise SystemExit(f"{label} is unreadable: {exc}")
+    require(isinstance(value, dict), f"{label} root is not an object")
+    return value
+mode, record = sys.argv[1], load(sys.argv[2], f"{sys.argv[1]} response")
+require(set(record) == {"body", "elapsed_ms", "status"}, f"{mode} transport keys changed")
+require(type(record["elapsed_ms"]) is int and 0 <= record["elapsed_ms"] <= 10000, f"{mode} response was not bounded")
+body = record["body"]
+if mode == "tip":
+    require(record["status"] == 200 and isinstance(body, dict) and set(body) == {"has_tip", "height", "tip_hash", "best_known_height", "in_ibd"}, "tip HTTP disposition/root/keys changed")
+    require(body["has_tip"] is True and type(body["height"]) is int and body["height"] >= 0, "tip has invalid has_tip/height")
+    tip_hash = body["tip_hash"]
+    require(isinstance(tip_hash, str) and len(tip_hash) == 64 and all(ch in "0123456789abcdef" for ch in tip_hash), "tip has invalid tip_hash")
+    print(json.dumps({key: body[key] for key in ("has_tip", "height", "tip_hash")}, sort_keys=True))
+elif mode == "refusal":
+    require(record["status"] == 422 and isinstance(body, dict) and set(body) == {"mined", "error"} and body["mined"] is False, "refusal HTTP disposition/root/keys changed")
+    error = body["error"]
+    markers = ("atomic write lock failed", sys.argv[3], "before_namespace_commit", "create_if_absent")
+    require(isinstance(error, str) and all(marker in error for marker in markers), "atomic refusal is missing stable markers")
+    require(re.search(re.escape(sys.argv[3]) + r"/[^/\s]+\.bin(?:\b|:)", error), "atomic refusal has no .bin child destination")
+    require(re.search(r"(contend|would[ _-]?block|temporar(?:ily)? unavailable|resource busy)", error, re.I), "atomic refusal has no contention class")
+    require("datadir is already in use" not in error and "persistence fault" not in error, "atomic writer took the wrong refusal path")
+elif mode == "success":
+    before, after = load(sys.argv[3], "pre-refusal tip"), load(sys.argv[4], "post-retry tip")
+    keys = {"mined", "height", "block_hash", "timestamp", "nonce", "tx_count"}
+    require(record["status"] == 200 and isinstance(body, dict) and set(body) == keys, "retry success HTTP disposition/root/keys changed")
+    require(body["mined"] is True and all(type(body[key]) is int for key in ("height", "timestamp", "nonce", "tx_count")), "retry success types changed")
+    require(isinstance(body["block_hash"], str) and len(body["block_hash"]) == 64 and all(ch in "0123456789abcdef" for ch in body["block_hash"]), "retry block_hash type changed")
+    require(set(before) == {"has_tip", "height", "tip_hash"} and set(after) == set(before), "tip projection keys changed")
+    require(before["has_tip"] is True and after["has_tip"] is True, "tip projection has no tip")
+    require(body["height"] == before["height"] + 1 and after["height"] == body["height"] and after["tip_hash"] == body["block_hash"], "retry is not exactly one bound transition")
+else:
+    raise SystemExit(f"unknown validator mode: {mode}")
+PY
+}
+tip_projection() {
+  rpc_result "$1" "$2" GET /get_tip || fail "$1: get_tip request"
+  validate_atomic_rpc "$1" tip "${RPC_RESULT}" "" "" "$3"
+}
+assert_atomic_writer_contention() {
+  local holder="$1" writer="$2" label="$3" route="$4" physical="${ART}/fixtures/${3}-physical" alias="" before="${ART}/${3}.before" after="${ART}/${3}.after" pre_tip="${ART}/${3}.tip.before" refused_tip="${ART}/${3}.tip.refused" success_tip="${ART}/${3}.tip.success" holder_parent writer_parent
+  local datadir="${physical}"
+  mkdir -p "${physical}"
+  case "${route}" in
+    direct) ;;
+    alias)
+      alias="${ART}/fixtures/${3}-alias"
+      ln -s "${physical}" "${alias}" || fail "${label}: cannot create stable datadir alias"
+      datadir="${alias}"
+      ;;
+    *) fail "${label}: unknown atomic writer route ${route}" ;;
+  esac
+  initialize_store "${writer}" "${datadir}" "${label}.init"
+  start_live "${writer}" "${datadir}" "${label}.writer"
+  holder_parent="${physical}/blockstore/blocks"
+  writer_parent="${datadir}/blockstore/blocks"
+  [[ "${holder_parent}" == /* && "${writer_parent}" == /* ]] || fail "${label}: atomic lock paths must be absolute"
+  start_holder "${holder}" "${label}.atomic-holder" "${holder_parent}/${ATOMIC_LOCK_LEAF}"
+  tip_projection "${label}.pre-refusal" "${LIVE_RPC}" "${pre_tip}"
+  take_snapshot "${label}.before" "${physical}" "${before}"
+  rpc_result "${label}.refusal" "${LIVE_RPC}" POST /mine_next || fail "${label}: refused mine_next request"
+  validate_atomic_rpc "${label}" refusal "${RPC_RESULT}" "${writer_parent}"
+  rubin_process_is_alive "${LIVE_PID}" || fail "${label}: ordinary writer did not survive pre-commit refusal"
+  take_snapshot "${label}.after" "${physical}" "${after}"
+  assert_same_atomic_semantic_snapshot "${label}: same-parent different-destination writer mutated state" "${before}" "${after}"
+  tip_projection "${label}.post-refusal" "${LIVE_RPC}" "${refused_tip}"
+  cmp -s "${pre_tip}" "${refused_tip}" || fail "${label}: tip changed across refused mine_next"
+  release_holder "${label}.atomic-holder"
+  rpc_result "${label}.retry" "${LIVE_RPC}" POST /mine_next || fail "${label}: retry mine_next request"
+  local retry_result="${RPC_RESULT}"
+  tip_projection "${label}.post-retry" "${LIVE_RPC}" "${success_tip}"
+  validate_atomic_rpc "${label}" success "${retry_result}" "${pre_tip}" "${success_tip}"
+  stop_live "${label}.writer"
+}
+assert_atomic_reclaim() {
+  local seed_impl="$1" reclaim_impl="$2" label="$3" datadir="${ART}/fixtures/${3}" live_block backup mode reader
+  initialize_store "${seed_impl}" "${datadir}" "${label}.init"
+  live_block="$(canonical_live_block_path "${datadir}")" || fail "${label}: canonical live block lookup"
+  backup="${ART}/${label}.live-block.before"
+  cp -- "${live_block}" "${backup}" || fail "${label}: capture live block before hardlink residue"
+  seed_atomic_residues "${label}" "${datadir}" "${live_block}"
+  for mode in dry-run legacy; do for reader in go rust; do
+    assert_reader "${reader}" "${mode}" "${label}.${reader}-${mode}" "${datadir}"
+    assert_atomic_reserved_state "${label}: ${reader} ${mode} changed a reserved leaf" 5 0
+  done; done
+  start_live "${reclaim_impl}" "${datadir}" "${label}.reclaim"
+  assert_atomic_reserved_state "${label}: mutating startup did not reclaim five exact residues" 0 5
+  cmp -s "${backup}" "${live_block}" || fail "${label}: unlinking hardlink scratch changed live destination bytes"
+  stop_live "${label}.reclaim"
+}
+run_atomic_parent() {
+  assert_fresh_create_reclaims_datadir_scratch go
+  assert_fresh_create_reclaims_datadir_scratch rust
+  assert_atomic_writer_contention go rust atomic-go-holder-rust-writer direct
+  assert_atomic_writer_contention rust go atomic-rust-holder-go-writer direct
+  assert_atomic_writer_contention go rust atomic-go-holder-rust-writer-alias alias
+  assert_atomic_writer_contention rust go atomic-rust-holder-go-writer-alias alias
+  assert_atomic_reclaim go rust atomic-reclaim-go-rust
+  assert_atomic_reclaim rust go atomic-reclaim-rust-go
+}
+
+if [[ "${MODE}" == atomic-parent ]]; then
+  run_atomic_parent
+  echo 'PASS: storage lock parity (atomic-parent)'
+  exit 0
+fi
 
 echo 'Checking create-path lock acquisition before store creation'
 assert_create_path_contention go rust create-lock-go-holds-rust


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1084
- GitHub Issue mirror (non-authoritative): #2765

Refs: Q-XCLIENT-ATOMIC-SCRATCH-BOUND-01

## Summary
Bound the Go and Rust node atomic-write paths to one reserved scratch entry per storage parent under the existing parent lock. Mutating startup now reclaims only that exact entry, and post-commit persistence failures reload engine-owned visible state and reject later mutation until restart. The total parity gate now exercises the mixed-client atomic-parent path.

## Invariant
On supported production hosts, each production storage parent uses at most one exact atomic-write scratch entry serialized under the existing lock; new scratch and committed destination inodes are created with mode `0600`, startup performs bounded exact-name reclaim before mutation, and a post-commit failure never triggers a compensating write.

## Scope
- Changed files: 28
- Surfaces: clients/go, clients/rust, tooling
- Non-scope: consensus, wire encoding, storage formats, Windows production guarantees, broad cleanup, and datadir-lock semantics
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./node -run 'TestAtomicWriteExactMatchIsLockAndScratchFreeButStrictlyResyncs|TestAtomicWritePostCommitUnlinkThenSyncPrecedence|TestSyncEnginePostCommitFailuresReloadVisibleStateWithoutCompensation' -count=1 -timeout=90s"` — PASS; `scripts/dev-env.sh -- bash -lc "cd clients/go && go test -race ./node -run '^TestSyncEngineQueuesMutatorsUntilPostCommitFaultIsPublished$' -count=5 -timeout=90s"` — PASS; `scripts/dev-env.sh -- bash -lc "cd clients/rust && cargo test -p rubin-node --lib -- --test-threads=16"` — PASS; `scripts/dev-env.sh -- bash scripts/node-runtime-total-parity-gate.sh` — PASS

## Follow-ups / Waivers
- None