### PR TITLE
RUB-1050: verify stored block identity before reorg, disconnect, or requeue

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -112,6 +112,24 @@ func ParseBlockBytes(b []byte) (*ParsedBlock, error) {
 	}, nil
 }
 
+// ValidateStoredBlockCommitments verifies only the stored-block coinbase, txid, and witness commitments.
+func ValidateStoredBlockCommitments(pb *ParsedBlock) error {
+	if pb == nil {
+		return txerr(BLOCK_ERR_PARSE, "nil parsed block")
+	}
+	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
+	}
+	root, err := MerkleRootTxids(pb.Txids)
+	if err != nil {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "failed to compute merkle root")
+	}
+	if root != pb.Header.MerkleRoot {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
+	}
+	return validateCoinbaseWitnessCommitment(pb)
+}
+
 // parseBlockTx parses a single transaction from b at the given offset,
 // advances off past the consumed bytes, and returns the parsed tx.
 func parseBlockTx(b []byte, off *int) (*Tx, [32]byte, [32]byte, int, error) {

--- a/clients/go/consensus/block_basic_test.go
+++ b/clients/go/consensus/block_basic_test.go
@@ -1,1 +1,92 @@
 package consensus
+
+import "testing"
+
+func parseStoredCommitmentTestBlock(t *testing.T, txs ...[]byte) *ParsedBlock {
+	t.Helper()
+	if len(txs) == 0 {
+		t.Fatal("test block needs a coinbase")
+	}
+	txids := make([][32]byte, 0, len(txs))
+	for _, tx := range txs {
+		txids = append(txids, testTxID(t, tx))
+	}
+	root, err := MerkleRootTxids(txids)
+	if err != nil {
+		t.Fatalf("MerkleRootTxids: %v", err)
+	}
+	block := buildBlockBytes(t, hashWithPrefix(0x51), root, filledHash(0xff), 1, txs)
+	pb, err := ParseBlockBytes(block)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes: %v", err)
+	}
+	return pb
+}
+
+func requireStoredCommitmentError(t *testing.T, pb *ParsedBlock, want ErrorCode) {
+	t.Helper()
+	err := ValidateStoredBlockCommitments(pb)
+	if err == nil {
+		t.Fatal("ValidateStoredBlockCommitments unexpectedly succeeded")
+	}
+	if got := mustTxErrCode(t, err); got != want {
+		t.Fatalf("code=%s, want %s (err=%v)", got, want, err)
+	}
+}
+
+func TestValidateStoredBlockCommitments(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		pb := parseStoredCommitmentTestBlock(t, coinbaseWithWitnessCommitment(t))
+		if err := ValidateStoredBlockCommitments(pb); err != nil {
+			t.Fatalf("ValidateStoredBlockCommitments(valid): %v", err)
+		}
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		requireStoredCommitmentError(t, nil, BLOCK_ERR_PARSE)
+	})
+
+	t.Run("coinbase witness or DA slot precedes commitments", func(t *testing.T) {
+		for _, mutate := range []func(*ParsedBlock){
+			func(pb *ParsedBlock) { pb.Txs[0].Witness = []WitnessItem{{}} },
+			func(pb *ParsedBlock) { pb.Txs[0].DaPayload = []byte{0x01} },
+		} {
+			pb := parseStoredCommitmentTestBlock(t, coinbaseWithWitnessCommitment(t))
+			pb.Txids[0][0] ^= 0xff // Coinbases must reject before the later Merkle check.
+			mutate(pb)
+			requireStoredCommitmentError(t, pb, BLOCK_ERR_COINBASE_INVALID)
+		}
+	})
+
+	t.Run("txid Merkle mismatch", func(t *testing.T) {
+		pb := parseStoredCommitmentTestBlock(t, coinbaseWithWitnessCommitment(t))
+		pb.Txids[0][0] ^= 0xff
+		requireStoredCommitmentError(t, pb, BLOCK_ERR_MERKLE_INVALID)
+	})
+
+	t.Run("witness-only mismatch", func(t *testing.T) {
+		spend := txWithOneOutput(1, COV_TYPE_P2PK, validP2PKCovenantData())
+		pb := parseStoredCommitmentTestBlock(t, coinbaseWithWitnessCommitment(t, spend), spend)
+		pb.Wtxids[1][0] ^= 0xff
+		requireStoredCommitmentError(t, pb, BLOCK_ERR_WITNESS_COMMITMENT)
+	})
+
+	wroot, err := WitnessMerkleRootWtxids([][32]byte{{}})
+	if err != nil {
+		t.Fatalf("WitnessMerkleRootWtxids: %v", err)
+	}
+	commitment := WitnessCommitmentHash(wroot)
+	t.Run("missing witness commitment", func(t *testing.T) {
+		coinbase := coinbaseTxWithOutputs(0, []testOutput{{
+			value: 1, covenantType: COV_TYPE_P2PK, covenantData: validP2PKCovenantData(),
+		}})
+		requireStoredCommitmentError(t, parseStoredCommitmentTestBlock(t, coinbase), BLOCK_ERR_WITNESS_COMMITMENT)
+	})
+	t.Run("duplicated witness commitment", func(t *testing.T) {
+		coinbase := coinbaseTxWithOutputs(0, []testOutput{
+			{value: 0, covenantType: COV_TYPE_ANCHOR, covenantData: commitment[:]},
+			{value: 0, covenantType: COV_TYPE_ANCHOR, covenantData: commitment[:]},
+		})
+		requireStoredCommitmentError(t, parseStoredCommitmentTestBlock(t, coinbase), BLOCK_ERR_WITNESS_COMMITMENT)
+	})
+}

--- a/clients/go/consensus/block_basic_test.go
+++ b/clients/go/consensus/block_basic_test.go
@@ -61,6 +61,7 @@ func TestValidateStoredBlockCommitments(t *testing.T) {
 	t.Run("txid Merkle mismatch", func(t *testing.T) {
 		pb := parseStoredCommitmentTestBlock(t, coinbaseWithWitnessCommitment(t))
 		pb.Txids[0][0] ^= 0xff
+		pb.Wtxids[0][0] ^= 0xff
 		requireStoredCommitmentError(t, pb, BLOCK_ERR_MERKLE_INVALID)
 	})
 

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -1319,9 +1319,7 @@ func TestFaultAttributionSplitConsensusVsIO(t *testing.T) {
 }
 
 func TestRelayedCandidateWithCorruptStoredAncestorIsPeerNeutral(t *testing.T) {
-	// The relayed height-2 block is honest. Only the sink's local file for its
-	// unknown height-1 parent is corrupt, so blockstore verification must return
-	// a local error rather than letting p2p attribute a consensus error to peer.
+	// An honest relay with a corrupt local parent must stay peer-neutral.
 	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	b1Hash, _ := testHarnessBlockAtHeight(t, source, 1)

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -1318,6 +1318,49 @@ func TestFaultAttributionSplitConsensusVsIO(t *testing.T) {
 	}
 }
 
+func TestRelayedCandidateWithCorruptStoredAncestorIsPeerNeutral(t *testing.T) {
+	// The relayed height-2 block is honest. Only the sink's local file for its
+	// unknown height-1 parent is corrupt, so blockstore verification must return
+	// a local error rather than letting p2p attribute a consensus error to peer.
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	b1Hash, _ := testHarnessBlockAtHeight(t, source, 1)
+	_, b2Bytes := testHarnessBlockAtHeight(t, source, 2)
+	b2Parsed, b2Hash, err := parseRelayedBlock(b2Bytes)
+	if err != nil || b2Parsed == nil {
+		t.Fatalf("parseRelayedBlock(B2): parsed=%v err=%v", b2Parsed, err)
+	}
+
+	storePath := filepath.Join(node.BlockStorePath(sink.dataDir), "blocks", hex.EncodeToString(b1Hash[:])+".bin")
+	if err := os.WriteFile(storePath, []byte("corrupt stored parent"), 0o600); err != nil {
+		t.Fatalf("WriteFile(corrupt parent): %v", err)
+	}
+	peer := testPeerForService(sink.service, "remote", 2)
+	beforeHeight, beforeTip, beforeOK, err := sink.blockStore.Tip()
+	if err != nil || !beforeOK {
+		t.Fatalf("sink tip before: height=%d hash=%x ok=%v err=%v", beforeHeight, beforeTip, beforeOK, err)
+	}
+
+	summary, err := peer.processRelayedBlock(b2Bytes)
+	if err == nil || summary != nil {
+		t.Fatalf("processRelayedBlock(corrupt stored parent): summary=%v err=%v", summary, err)
+	}
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) {
+		t.Fatalf("local stored corruption leaked consensus error: %v", err)
+	}
+	if state := peer.snapshotState(); state.BanScore != 0 || state.LastError == "" {
+		t.Fatalf("peer state=%+v, want peer-neutral local diagnostic", state)
+	}
+	if sink.service.blockSeen.Has(b2Hash) {
+		t.Fatal("locally failed relayed candidate must not be marked seen")
+	}
+	afterHeight, afterTip, afterOK, err := sink.blockStore.Tip()
+	if err != nil || afterOK != beforeOK || afterHeight != beforeHeight || afterTip != beforeTip {
+		t.Fatalf("sink tip after: height=%d hash=%x ok=%v err=%v", afterHeight, afterTip, afterOK, err)
+	}
+}
+
 func TestFaultAttributionSplitLocalApplyErrorDoesNotHardBan(t *testing.T) {
 	// Source has genesis+block1. Sink has genesis only, but we replace the
 	// sync engine with an uninitialized zero-value to force a local/runtime

--- a/clients/go/node/sync_disconnect.go
+++ b/clients/go/node/sync_disconnect.go
@@ -2,9 +2,6 @@ package node
 
 import (
 	"errors"
-	"fmt"
-
-	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 type disconnectTipContext struct {
@@ -192,107 +189,34 @@ func (s *SyncEngine) previewDisconnectCanonicalToAncestor(previewState *ChainSta
 	currentTipHeight := previewState.Height
 	reorgDepth := currentTipHeight - commonAncestorHeight
 	disconnectedBlocks := make([]verifiedStoredBlock, 0, reorgDepth)
-	for currentTipHeight > commonAncestorHeight {
-		tipHash := previewState.TipHash
+	tipHash := previewState.TipHash
+	for height := currentTipHeight; height > commonAncestorHeight; height-- {
 		storedBlock, err := s.loadVerifiedStoredBlock(tipHash)
 		if err != nil {
 			return nil, 0, err
 		}
-		undo, err := s.blockStore.GetUndo(tipHash)
+		disconnectedBlocks = append(disconnectedBlocks, storedBlock)
+		tipHash = storedBlock.parsed.Header.PrevBlockHash
+	}
+	for _, storedBlock := range disconnectedBlocks {
+		undo, err := s.blockStore.GetUndo(storedBlock.lookupHash)
 		if err != nil {
 			return nil, 0, err
 		}
 		if _, err := previewState.disconnectVerifiedStoredBlock(storedBlock, undo); err != nil {
 			return nil, 0, err
 		}
-		disconnectedBlocks = append(disconnectedBlocks, storedBlock)
-		currentTipHeight--
 	}
 	return disconnectedBlocks, reorgDepth, nil
 }
 
-// fetchDisconnectBlockAndUndo returns one verified stored block and its undo.
 func (s *SyncEngine) fetchDisconnectBlockAndUndo(tipHash [32]byte) (verifiedStoredBlock, *BlockUndo, error) {
 	storedBlock, err := s.loadVerifiedStoredBlock(tipHash)
 	if err != nil {
 		return verifiedStoredBlock{}, nil, err
 	}
 	undo, err := s.blockStore.GetUndo(tipHash)
-	if err != nil {
-		return verifiedStoredBlock{}, nil, err
-	}
-	return storedBlock, undo, nil
-}
-
-// disconnectVerifiedStoredBlock mirrors ChainState.DisconnectBlock after the
-// shared loader has already parsed and verified the exact stored bytes. It
-// preserves its lock, validation, copy-before-mutation, and summary ordering
-// without a second ParseBlockBytes call.
-func (s *ChainState) disconnectVerifiedStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo) (*ChainStateDisconnectSummary, error) {
-	if s == nil {
-		return nil, errors.New("nil chainstate")
-	}
-	s.admissionMu.Lock()
-	defer s.admissionMu.Unlock()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.HasTip {
-		return nil, errors.New("chainstate has no tip")
-	}
-	if undo == nil {
-		return nil, errors.New("nil block undo")
-	}
-	pb, err := validateVerifiedDisconnectStoredBlock(storedBlock, undo, s.TipHash, s.Height)
-	if err != nil {
-		return nil, err
-	}
-
-	work := copyUtxoSet(s.Utxos)
-	if err := applyDisconnectUndo(work, pb, undo); err != nil {
-		return nil, err
-	}
-
-	s.Utxos = work
-	s.AlreadyGenerated = undo.PreviousAlreadyGenerated
-	if s.Height == 0 {
-		s.HasTip = false
-		s.Height = 0
-		s.TipHash = [32]byte{}
-	} else {
-		s.Height--
-		s.TipHash = pb.Header.PrevBlockHash
-		s.HasTip = true
-	}
-
-	return &ChainStateDisconnectSummary{
-		DisconnectedHeight: undo.BlockHeight,
-		BlockHash:          storedBlock.lookupHash,
-		NewHeight:          s.Height,
-		NewTipHash:         s.TipHash,
-		HasTip:             s.HasTip,
-		AlreadyGenerated:   s.AlreadyGenerated,
-		UtxoCount:          uint64(len(s.Utxos)),
-	}, nil
-}
-
-func validateVerifiedDisconnectStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo, tipHash [32]byte, height uint64) (*consensus.ParsedBlock, error) {
-	if storedBlock.parsed == nil {
-		return nil, errors.New("nil verified stored block")
-	}
-	pb := storedBlock.parsed
-	if len(pb.Txs) != len(pb.Txids) {
-		return nil, errors.New("parsed block txid length mismatch")
-	}
-	if len(undo.Txs) != len(pb.Txs) {
-		return nil, errors.New("undo tx count mismatch")
-	}
-	if tipHash != storedBlock.lookupHash {
-		return nil, errors.New("disconnect block is not current tip")
-	}
-	if height != undo.BlockHeight {
-		return nil, fmt.Errorf("disconnect height mismatch: chainstate=%d undo=%d", height, undo.BlockHeight)
-	}
-	return pb, nil
+	return storedBlock, undo, err
 }
 
 // getParentTimestamp returns the timestamp of the parent block, or 0 at height 0.
@@ -300,15 +224,8 @@ func (s *SyncEngine) getParentTimestamp(tipHeight uint64, prevBlockHash [32]byte
 	if tipHeight == 0 {
 		return 0, nil
 	}
-	parentHeaderBytes, err := s.blockStore.GetHeaderByHash(prevBlockHash)
-	if err != nil {
-		return 0, err
-	}
-	parentHeader, err := consensus.ParseBlockHeaderBytes(parentHeaderBytes)
-	if err != nil {
-		return 0, err
-	}
-	return parentHeader.Timestamp, nil
+	parentHeader, err := s.blockStore.chainWorkHeader(prevBlockHash)
+	return parentHeader.Timestamp, err
 }
 
 // finalizeDisconnectState updates chain state after disconnect.

--- a/clients/go/node/sync_disconnect.go
+++ b/clients/go/node/sync_disconnect.go
@@ -2,12 +2,13 @@ package node
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 type disconnectTipContext struct {
-	blockBytes      []byte
+	storedBlock     verifiedStoredBlock
 	undo            *BlockUndo
 	rollbackState   syncRollbackState
 	newTipTimestamp uint64
@@ -27,7 +28,11 @@ func (s *SyncEngine) disconnectTip() (*ChainStateDisconnectSummary, error) {
 	if err != nil {
 		return nil, err
 	}
-	summary, err := s.chainState.DisconnectBlock(ctx.blockBytes, ctx.undo)
+	return s.disconnectPreparedTip(ctx)
+}
+
+func (s *SyncEngine) disconnectPreparedTip(ctx disconnectTipContext) (*ChainStateDisconnectSummary, error) {
+	summary, err := s.chainState.disconnectVerifiedStoredBlock(ctx.storedBlock, ctx.undo)
 	if err != nil {
 		return nil, err
 	}
@@ -41,9 +46,36 @@ func (s *SyncEngine) prepareDisconnectTip() (disconnectTipContext, error) {
 	if err := s.validateDisconnectTipReady(); err != nil {
 		return disconnectTipContext{}, err
 	}
-	tipHeight, tipHash, err := s.currentCanonicalTip()
+	tipHeight, tipHash, err := s.currentDisconnectTip()
 	if err != nil {
 		return disconnectTipContext{}, err
+	}
+	storedBlock, undo, err := s.fetchDisconnectBlockAndUndo(tipHash)
+	if err != nil {
+		return disconnectTipContext{}, err
+	}
+	return s.prepareDisconnectTipContext(tipHeight, tipHash, storedBlock, undo)
+}
+
+func (s *SyncEngine) prepareDisconnectTipFromVerified(storedBlock verifiedStoredBlock) (disconnectTipContext, error) {
+	if err := s.validateDisconnectTipReady(); err != nil {
+		return disconnectTipContext{}, err
+	}
+	tipHeight, tipHash, err := s.currentDisconnectTip()
+	if err != nil {
+		return disconnectTipContext{}, err
+	}
+	undo, err := s.blockStore.GetUndo(tipHash)
+	if err != nil {
+		return disconnectTipContext{}, err
+	}
+	return s.prepareDisconnectTipContext(tipHeight, tipHash, storedBlock, undo)
+}
+
+func (s *SyncEngine) currentDisconnectTip() (uint64, [32]byte, error) {
+	tipHeight, tipHash, err := s.currentCanonicalTip()
+	if err != nil {
+		return 0, [32]byte{}, err
 	}
 	view := s.chainState.view()
 	gotTip := struct {
@@ -57,22 +89,28 @@ func (s *SyncEngine) prepareDisconnectTip() (disconnectTipContext, error) {
 		hash   [32]byte
 	}{hasTip: true, height: tipHeight, hash: tipHash}
 	if gotTip != wantTip {
-		return disconnectTipContext{}, errors.New("chainstate tip does not match blockstore tip")
+		return 0, [32]byte{}, errors.New("chainstate tip does not match blockstore tip")
 	}
-	pb, blockBytes, undo, err := s.fetchDisconnectBlockAndUndo(tipHash)
-	if err != nil {
-		return disconnectTipContext{}, err
+	return tipHeight, tipHash, nil
+}
+
+func (s *SyncEngine) prepareDisconnectTipContext(tipHeight uint64, tipHash [32]byte, storedBlock verifiedStoredBlock, undo *BlockUndo) (disconnectTipContext, error) {
+	if storedBlock.lookupHash != tipHash {
+		return disconnectTipContext{}, errors.New("disconnect block is not current canonical tip")
+	}
+	if storedBlock.parsed == nil {
+		return disconnectTipContext{}, errors.New("nil verified stored block")
 	}
 	rollbackState, err := s.captureRollbackState()
 	if err != nil {
 		return disconnectTipContext{}, err
 	}
-	newTipTimestamp, err := s.getParentTimestamp(tipHeight, pb.Header.PrevBlockHash)
+	newTipTimestamp, err := s.getParentTimestamp(tipHeight, storedBlock.parsed.Header.PrevBlockHash)
 	if err != nil {
 		return disconnectTipContext{}, err
 	}
 	return disconnectTipContext{
-		blockBytes:      blockBytes,
+		storedBlock:     storedBlock,
 		undo:            undo,
 		rollbackState:   rollbackState,
 		newTipTimestamp: newTipTimestamp,
@@ -89,41 +127,74 @@ func (s *SyncEngine) validateDisconnectTipReady() error {
 	return nil
 }
 
-func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64) ([][]byte, uint64, error) {
-	currentTipHeight, _, err := s.currentCanonicalTip()
-	if err != nil {
-		return nil, 0, err
+func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64, preparedBlocks []verifiedStoredBlock) error {
+	if err := s.validatePreparedDisconnectBlocks(commonAncestorHeight, preparedBlocks); err != nil {
+		return err
 	}
-	reorgDepth := currentTipHeight - commonAncestorHeight
-	disconnectedBlocks := make([][]byte, 0, reorgDepth)
-	for currentTipHeight > commonAncestorHeight {
-		_, tipHash, err := s.currentCanonicalTip()
+	for _, storedBlock := range preparedBlocks {
+		ctx, err := s.prepareDisconnectTipFromVerified(storedBlock)
 		if err != nil {
-			return nil, 0, err
+			return err
 		}
-		disconnectedBlockBytes, err := s.blockStore.GetBlockByHash(tipHash)
-		if err != nil {
-			return nil, 0, err
+		if _, err := s.disconnectPreparedTip(ctx); err != nil {
+			return err
 		}
-		disconnectedBlocks = append(disconnectedBlocks, append([]byte(nil), disconnectedBlockBytes...))
-		if _, err := s.disconnectTip(); err != nil {
-			return nil, 0, err
-		}
-		currentTipHeight--
 	}
-	return disconnectedBlocks, reorgDepth, nil
+	return nil
 }
 
-func (s *SyncEngine) previewDisconnectCanonicalToAncestor(previewState *ChainState, commonAncestorHeight uint64) ([][]byte, uint64, error) {
+func (s *SyncEngine) validatePreparedDisconnectBlocks(commonAncestorHeight uint64, preparedBlocks []verifiedStoredBlock) error {
+	if err := s.validateDisconnectTipReady(); err != nil {
+		return err
+	}
+	currentTipHeight, _, err := s.currentCanonicalTip()
+	if err != nil {
+		return err
+	}
+	if commonAncestorHeight > currentTipHeight {
+		return errors.New("common ancestor is above canonical tip")
+	}
+	if uint64(len(preparedBlocks)) != currentTipHeight-commonAncestorHeight {
+		return errors.New("prepared disconnect block count mismatch")
+	}
+	for index, storedBlock := range preparedBlocks {
+		if err := s.validatePreparedDisconnectBlock(storedBlock, currentTipHeight-uint64(index)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SyncEngine) validatePreparedDisconnectBlock(storedBlock verifiedStoredBlock, canonicalHeight uint64) error {
+	if storedBlock.parsed == nil {
+		return errors.New("invalid prepared disconnect block")
+	}
+	if len(storedBlock.parsed.Txs) != len(storedBlock.parsed.Txids) {
+		return errors.New("invalid prepared disconnect block")
+	}
+	expectedHash, ok, err := s.blockStore.CanonicalHash(canonicalHeight)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("prepared disconnect block is not canonical")
+	}
+	if storedBlock.lookupHash != expectedHash {
+		return errors.New("prepared disconnect block is not canonical")
+	}
+	return nil
+}
+
+func (s *SyncEngine) previewDisconnectCanonicalToAncestor(previewState *ChainState, commonAncestorHeight uint64) ([]verifiedStoredBlock, uint64, error) {
 	if previewState == nil {
 		return nil, 0, nil
 	}
 	currentTipHeight := previewState.Height
 	reorgDepth := currentTipHeight - commonAncestorHeight
-	disconnectedBlocks := make([][]byte, 0, reorgDepth)
+	disconnectedBlocks := make([]verifiedStoredBlock, 0, reorgDepth)
 	for currentTipHeight > commonAncestorHeight {
 		tipHash := previewState.TipHash
-		blockBytes, err := s.blockStore.GetBlockByHash(tipHash)
+		storedBlock, err := s.loadVerifiedStoredBlock(tipHash)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -131,30 +202,97 @@ func (s *SyncEngine) previewDisconnectCanonicalToAncestor(previewState *ChainSta
 		if err != nil {
 			return nil, 0, err
 		}
-		if _, err := previewState.DisconnectBlock(blockBytes, undo); err != nil {
+		if _, err := previewState.disconnectVerifiedStoredBlock(storedBlock, undo); err != nil {
 			return nil, 0, err
 		}
-		disconnectedBlocks = append(disconnectedBlocks, append([]byte(nil), blockBytes...))
+		disconnectedBlocks = append(disconnectedBlocks, storedBlock)
 		currentTipHeight--
 	}
 	return disconnectedBlocks, reorgDepth, nil
 }
 
-// fetchDisconnectBlockAndUndo fetches block bytes, undo data, and parses the block.
-func (s *SyncEngine) fetchDisconnectBlockAndUndo(tipHash [32]byte) (*consensus.ParsedBlock, []byte, *BlockUndo, error) {
-	blockBytes, err := s.blockStore.GetBlockByHash(tipHash)
+// fetchDisconnectBlockAndUndo returns one verified stored block and its undo.
+func (s *SyncEngine) fetchDisconnectBlockAndUndo(tipHash [32]byte) (verifiedStoredBlock, *BlockUndo, error) {
+	storedBlock, err := s.loadVerifiedStoredBlock(tipHash)
 	if err != nil {
-		return nil, nil, nil, err
+		return verifiedStoredBlock{}, nil, err
 	}
 	undo, err := s.blockStore.GetUndo(tipHash)
 	if err != nil {
-		return nil, nil, nil, err
+		return verifiedStoredBlock{}, nil, err
 	}
-	pb, err := consensus.ParseBlockBytes(blockBytes)
+	return storedBlock, undo, nil
+}
+
+// disconnectVerifiedStoredBlock mirrors ChainState.DisconnectBlock after the
+// shared loader has already parsed and verified the exact stored bytes. It
+// preserves its lock, validation, copy-before-mutation, and summary ordering
+// without a second ParseBlockBytes call.
+func (s *ChainState) disconnectVerifiedStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo) (*ChainStateDisconnectSummary, error) {
+	if s == nil {
+		return nil, errors.New("nil chainstate")
+	}
+	s.admissionMu.Lock()
+	defer s.admissionMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.HasTip {
+		return nil, errors.New("chainstate has no tip")
+	}
+	if undo == nil {
+		return nil, errors.New("nil block undo")
+	}
+	pb, err := validateVerifiedDisconnectStoredBlock(storedBlock, undo, s.TipHash, s.Height)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
-	return pb, blockBytes, undo, nil
+
+	work := copyUtxoSet(s.Utxos)
+	if err := applyDisconnectUndo(work, pb, undo); err != nil {
+		return nil, err
+	}
+
+	s.Utxos = work
+	s.AlreadyGenerated = undo.PreviousAlreadyGenerated
+	if s.Height == 0 {
+		s.HasTip = false
+		s.Height = 0
+		s.TipHash = [32]byte{}
+	} else {
+		s.Height--
+		s.TipHash = pb.Header.PrevBlockHash
+		s.HasTip = true
+	}
+
+	return &ChainStateDisconnectSummary{
+		DisconnectedHeight: undo.BlockHeight,
+		BlockHash:          storedBlock.lookupHash,
+		NewHeight:          s.Height,
+		NewTipHash:         s.TipHash,
+		HasTip:             s.HasTip,
+		AlreadyGenerated:   s.AlreadyGenerated,
+		UtxoCount:          uint64(len(s.Utxos)),
+	}, nil
+}
+
+func validateVerifiedDisconnectStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo, tipHash [32]byte, height uint64) (*consensus.ParsedBlock, error) {
+	if storedBlock.parsed == nil {
+		return nil, errors.New("nil verified stored block")
+	}
+	pb := storedBlock.parsed
+	if len(pb.Txs) != len(pb.Txids) {
+		return nil, errors.New("parsed block txid length mismatch")
+	}
+	if len(undo.Txs) != len(pb.Txs) {
+		return nil, errors.New("undo tx count mismatch")
+	}
+	if tipHash != storedBlock.lookupHash {
+		return nil, errors.New("disconnect block is not current tip")
+	}
+	if height != undo.BlockHeight {
+		return nil, fmt.Errorf("disconnect height mismatch: chainstate=%d undo=%d", height, undo.BlockHeight)
+	}
+	return pb, nil
 }
 
 // getParentTimestamp returns the timestamp of the parent block, or 0 at height 0.

--- a/clients/go/node/sync_disconnect_test.go
+++ b/clients/go/node/sync_disconnect_test.go
@@ -117,6 +117,7 @@ func TestDisconnectPreparedTipUsesRetainedVerifiedBlock(t *testing.T) {
 func TestPreparedCanonicalDisconnectRetainsPreviewedBlocks(t *testing.T) {
 	engine, store, target := newReorgTestEngine(t)
 	var hashes [][32]byte
+	blocks := make([][]byte, 0, 2)
 	prevHash := devnetGenesisBlockHash
 	alreadyGenerated := uint64(0)
 	for height := uint64(1); height <= 2; height++ {
@@ -127,9 +128,18 @@ func TestPreparedCanonicalDisconnectRetainsPreviewedBlocks(t *testing.T) {
 			t.Fatalf("ApplyBlock(A%d): %v", height, err)
 		}
 		hashes = append(hashes, summary.BlockHash)
+		blocks = append(blocks, block)
 		prevHash = summary.BlockHash
 		alreadyGenerated += subsidy
 	}
+
+	undoDir := store.undoDir
+	store.undoDir = t.TempDir()
+	writeRawStoreBlockFile(t, store, hashes[0], corruptStoredMerkleBody(t, blocks[0]))
+	_, _, err := engine.previewDisconnectCanonicalToAncestor(cloneChainState(engine.chainState), 0)
+	assertBranchStoreCorruption(t, err)
+	store.undoDir = undoDir
+	writeRawStoreBlockFile(t, store, hashes[0], blocks[0])
 
 	prepared, depth, err := engine.previewDisconnectCanonicalToAncestor(cloneChainState(engine.chainState), 0)
 	if err != nil || depth != 2 || len(prepared) != 2 {

--- a/clients/go/node/sync_disconnect_test.go
+++ b/clients/go/node/sync_disconnect_test.go
@@ -1,0 +1,202 @@
+package node
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestDisconnectTipRejectsCorruptStoredCommitmentsBeforeMutation(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	subsidy := consensus.BlockSubsidy(1, 0)
+	block := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy))
+	summary, err := engine.ApplyBlock(block, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock: %v", err)
+	}
+	beforeState, err := stateToDisk(engine.chainState)
+	if err != nil {
+		t.Fatalf("stateToDisk(before): %v", err)
+	}
+	beforeIndex, err := store.CanonicalIndexSnapshot()
+	if err != nil {
+		t.Fatalf("CanonicalIndexSnapshot(before): %v", err)
+	}
+	writeRawStoreBlockFile(t, store, summary.BlockHash, corruptStoredMerkleBody(t, block))
+
+	_, err = engine.DisconnectTip()
+	assertBranchStoreCorruption(t, err)
+	if got, err := stateToDisk(engine.chainState); err != nil || !reflect.DeepEqual(got, beforeState) {
+		t.Fatalf("chainstate after corrupt disconnect: state=%+v err=%v", got, err)
+	}
+	if got, err := store.CanonicalIndexSnapshot(); err != nil || !reflect.DeepEqual(got, beforeIndex) {
+		t.Fatalf("canonical index after corrupt disconnect: index=%v err=%v", got, err)
+	}
+}
+
+func TestReorgPreviewRejectsCorruptCanonicalStoredCommitmentsBeforeMutation(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	subsidy1 := consensus.BlockSubsidy(1, 0)
+	canonical := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	canonicalSummary, err := engine.ApplyBlock(canonical, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(canonical): %v", err)
+	}
+
+	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	b1Parsed, b1Hash := mustParseReorgBlockForTest(t, sideB1)
+	if err := store.StoreBlock(b1Hash, b1Parsed.HeaderBytes, sideB1); err != nil {
+		t.Fatalf("StoreBlock(B1): %v", err)
+	}
+	sideB2 := buildSingleTxBlock(t, b1Hash, target, reorgTestTimestamp(3), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, consensus.BlockSubsidy(2, subsidy1)))
+
+	mempool, err := NewMempool(engine.chainState, store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	engine.SetMempool(mempool)
+	beforeState, err := stateToDisk(engine.chainState)
+	if err != nil {
+		t.Fatalf("stateToDisk(before): %v", err)
+	}
+	beforeIndex, err := store.CanonicalIndexSnapshot()
+	if err != nil {
+		t.Fatalf("CanonicalIndexSnapshot(before): %v", err)
+	}
+	beforeCounts := engine.BlockApplyCounts()
+	beforeMempoolLen := mempool.Len()
+	writeRawStoreBlockFile(t, store, canonicalSummary.BlockHash, corruptStoredMerkleBody(t, canonical))
+
+	_, err = engine.ApplyBlockWithReorg(sideB2, nil)
+	assertBranchStoreCorruption(t, err)
+	if got, err := stateToDisk(engine.chainState); err != nil || !reflect.DeepEqual(got, beforeState) {
+		t.Fatalf("chainstate after corrupt preview: state=%+v err=%v", got, err)
+	}
+	if got, err := store.CanonicalIndexSnapshot(); err != nil || !reflect.DeepEqual(got, beforeIndex) {
+		t.Fatalf("canonical index after corrupt preview: index=%v err=%v", got, err)
+	}
+	if got := engine.BlockApplyCounts(); got != beforeCounts {
+		t.Fatalf("BlockApplyCounts=%+v, want %+v", got, beforeCounts)
+	}
+	if got := mempool.Len(); got != beforeMempoolLen {
+		t.Fatalf("mempool len=%d, want %d", got, beforeMempoolLen)
+	}
+}
+
+func TestDisconnectPreparedTipUsesRetainedVerifiedBlock(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	subsidy := consensus.BlockSubsidy(1, 0)
+	block := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy))
+	summary, err := engine.ApplyBlock(block, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock: %v", err)
+	}
+	ctx, err := engine.prepareDisconnectTip()
+	if err != nil {
+		t.Fatalf("prepareDisconnectTip: %v", err)
+	}
+	if ctx.storedBlock.lookupHash != summary.BlockHash || !reflect.DeepEqual(ctx.storedBlock.blockBytes, block) {
+		t.Fatal("prepared disconnect did not retain the verified canonical block")
+	}
+	writeRawStoreBlockFile(t, store, summary.BlockHash, []byte("not a block"))
+
+	disconnected, err := engine.disconnectPreparedTip(ctx)
+	if err != nil {
+		t.Fatalf("disconnectPreparedTip reread or reparsed the block: %v", err)
+	}
+	if disconnected.BlockHash != summary.BlockHash || engine.chainState.Height != 0 || engine.chainState.TipHash != devnetGenesisBlockHash {
+		t.Fatalf("disconnect summary=%+v state=(%d,%x)", disconnected, engine.chainState.Height, engine.chainState.TipHash)
+	}
+	if _, ok, err := store.CanonicalHash(1); err != nil || ok {
+		t.Fatalf("canonical height 1 after disconnect: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestPreparedCanonicalDisconnectRetainsPreviewedBlocks(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	var hashes [][32]byte
+	prevHash := devnetGenesisBlockHash
+	alreadyGenerated := uint64(0)
+	for height := uint64(1); height <= 2; height++ {
+		subsidy := consensus.BlockSubsidy(height, alreadyGenerated)
+		block := buildSingleTxBlock(t, prevHash, target, reorgTestTimestamp(height), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		summary, err := engine.ApplyBlock(block, nil)
+		if err != nil {
+			t.Fatalf("ApplyBlock(A%d): %v", height, err)
+		}
+		hashes = append(hashes, summary.BlockHash)
+		prevHash = summary.BlockHash
+		alreadyGenerated += subsidy
+	}
+
+	prepared, depth, err := engine.previewDisconnectCanonicalToAncestor(cloneChainState(engine.chainState), 0)
+	if err != nil || depth != 2 || len(prepared) != 2 {
+		t.Fatalf("previewDisconnectCanonicalToAncestor=(%d blocks,%d,%v), want two blocks", len(prepared), depth, err)
+	}
+	for index, storedBlock := range prepared {
+		wantHash := hashes[len(hashes)-1-index]
+		if storedBlock.lookupHash != wantHash || storedBlock.parsed == nil {
+			t.Fatalf("prepared[%d]=(%x,%v), want retained %x", index, storedBlock.lookupHash, storedBlock.parsed, wantHash)
+		}
+		writeRawStoreBlockFile(t, store, storedBlock.lookupHash, []byte("replaced after preview"))
+	}
+
+	if err := engine.disconnectCanonicalToAncestor(0, prepared); err != nil {
+		t.Fatalf("disconnectCanonicalToAncestor reread a prepared block: %v", err)
+	}
+	if engine.chainState.Height != 0 || engine.chainState.TipHash != devnetGenesisBlockHash {
+		t.Fatalf("chainstate after retained disconnect=(%d,%x), want genesis", engine.chainState.Height, engine.chainState.TipHash)
+	}
+	if _, ok, err := store.CanonicalHash(1); err != nil || ok {
+		t.Fatalf("canonical height 1 after retained disconnect: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestPreparedDisconnectValidationErrors(t *testing.T) {
+	engine, _, target := newReorgTestEngine(t)
+	block := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+	if _, err := engine.ApplyBlock(block, nil); err != nil {
+		t.Fatal(err)
+	}
+	prepared, _, err := engine.previewDisconnectCanonicalToAncestor(cloneChainState(engine.chainState), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := prepared[0]
+	badTxids, parsed := stored, *stored.parsed
+	parsed.Txids, badTxids.parsed = nil, &parsed
+	wrongHash := stored
+	wrongHash.lookupHash[0] ^= 1
+	empty, uninitialized := &SyncEngine{chainState: NewChainState(), blockStore: &BlockStore{}}, &SyncEngine{}
+	nilPacket := []verifiedStoredBlock{{lookupHash: stored.lookupHash}}
+	context := func(block verifiedStoredBlock) error {
+		_, err := engine.prepareDisconnectTipContext(1, stored.lookupHash, block, nil)
+		return err
+	}
+	cases := []struct {
+		name, want string
+		run        func() error
+	}{
+		{"prepare uninitialized", "sync engine is not initialized", func() error { _, err := uninitialized.prepareDisconnectTipFromVerified(stored); return err }},
+		{"prepare empty store", "blockstore has no canonical tip", func() error { _, err := empty.prepareDisconnectTipFromVerified(stored); return err }},
+		{"ancestor above tip", "common ancestor is above canonical tip", func() error { return engine.disconnectCanonicalToAncestor(2, prepared) }},
+		{"validate uninitialized", "sync engine is not initialized", func() error { return uninitialized.validatePreparedDisconnectBlocks(0, nil) }},
+		{"validate empty store", "blockstore has no canonical tip", func() error { return empty.validatePreparedDisconnectBlocks(0, nil) }},
+		{"wrong count", "prepared disconnect block count mismatch", func() error { return engine.validatePreparedDisconnectBlocks(0, nil) }},
+		{"nil parsed", "invalid prepared disconnect block", func() error { return engine.validatePreparedDisconnectBlocks(0, nilPacket) }},
+		{"txid length", "invalid prepared disconnect block", func() error { return engine.validatePreparedDisconnectBlocks(0, []verifiedStoredBlock{badTxids}) }},
+		{"missing canonical", "prepared disconnect block is not canonical", func() error { return engine.validatePreparedDisconnectBlock(stored, 2) }},
+		{"lookup mismatch", "prepared disconnect block is not canonical", func() error { return engine.validatePreparedDisconnectBlock(wrongHash, 1) }},
+		{"context lookup mismatch", "disconnect block is not current canonical tip", func() error { return context(wrongHash) }},
+		{"context nil parsed", "nil verified stored block", func() error { return context(nilPacket[0]) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/clients/go/node/sync_helpers_test.go
+++ b/clients/go/node/sync_helpers_test.go
@@ -62,7 +62,7 @@ func TestNoteReorgNilReceiver(t *testing.T) {
 }
 
 func TestFetchDisconnectBlockAndUndoWithMissingBlock(t *testing.T) {
-	_, _, _, err := (&SyncEngine{blockStore: &BlockStore{}}).fetchDisconnectBlockAndUndo([32]byte{0xff})
+	_, _, err := (&SyncEngine{blockStore: &BlockStore{}}).fetchDisconnectBlockAndUndo([32]byte{0xff})
 	if err == nil {
 		t.Fatal("expected error for missing block")
 	}

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -17,6 +17,15 @@ type reorgBranchBlock struct {
 	header     consensus.BlockHeader
 }
 
+// verifiedStoredBlock owns one bounded block-store read and the one parse of
+// those exact bytes. Callers retain this value through their state transition
+// instead of reading or parsing the same logical block again.
+type verifiedStoredBlock struct {
+	lookupHash [32]byte
+	blockBytes []byte
+	parsed     *consensus.ParsedBlock
+}
+
 func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
 	if s == nil {
 		return nil, errors.New("sync engine is not initialized")
@@ -223,11 +232,11 @@ func (s *SyncEngine) applyPreferredBranch(
 	if err != nil {
 		return nil, err
 	}
-	disconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight, rollbackState)
+	preparedDisconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight, rollbackState)
 	if err != nil {
 		return nil, err
 	}
-	if _, _, err := s.disconnectCanonicalToAncestor(commonAncestorHeight); err != nil {
+	if err := s.disconnectCanonicalToAncestor(commonAncestorHeight, preparedDisconnectedBlocks); err != nil {
 		return nil, s.rollbackApplyBlock(err, rollbackState)
 	}
 
@@ -247,7 +256,7 @@ func (s *SyncEngine) applyPreferredBranch(
 			canonicalBlocks = append(canonicalBlocks, summary.CanonicalAppliedBlocks[0])
 		}
 	}
-	s.requeueDisconnectedTransactions(disconnectedBlocks)
+	s.requeueVerifiedDisconnectedTransactions(preparedDisconnectedBlocks)
 	s.noteBlockApplyAcceptedN(pendingAccepted)
 	s.noteReorg(reorgDepth)
 	if summary != nil {
@@ -290,13 +299,13 @@ func (s *SyncEngine) preparePreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
 	rollbackState syncRollbackState,
-) ([][]byte, uint64, error) {
+) ([]verifiedStoredBlock, uint64, error) {
 	previewState := cloneChainState(rollbackState.chainState)
 	if previewState == nil {
 		return nil, 0, errors.New("nil preview chainstate")
 	}
 	var err error
-	disconnectedBlocks, reorgDepth, err := s.previewDisconnectCanonicalToAncestor(previewState, commonAncestorHeight)
+	preparedDisconnectedBlocks, reorgDepth, err := s.previewDisconnectCanonicalToAncestor(previewState, commonAncestorHeight)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -330,7 +339,7 @@ func (s *SyncEngine) preparePreferredBranch(
 		}
 		slidingTs = advancePrevTimestamps(slidingTs, item.header.Timestamp)
 	}
-	return disconnectedBlocks, reorgDepth, nil
+	return preparedDisconnectedBlocks, reorgDepth, nil
 }
 
 // advancePrevTimestamps prepends newTs to prev and keeps at most 11 entries,
@@ -348,9 +357,9 @@ func advancePrevTimestamps(prev []uint64, newTs uint64) []uint64 {
 	return out
 }
 
-// errBranchStoreCorrupt marks a local block-store defect observed while walking
-// a side branch: a stored block whose bytes do not hash to the hash they were
-// looked up by, or an ancestry that revisits a hash already walked.
+// errBranchStoreCorrupt marks a local block-store defect: a stored block whose
+// bytes do not hash to the lookup key or whose block-level commitments do not
+// close. It is also used for the side-branch walk's defense-in-depth cycle.
 //
 // It is deliberately a plain error and NOT a *consensus.TxError, and it is
 // deliberately distinct from ErrParentNotFound. node/p2p classifies an apply
@@ -359,7 +368,7 @@ func advancePrevTimestamps(prev []uint64, newTs uint64) []uint64 {
 // block is never ban-scored for OUR corrupt store; the failure is recorded as a
 // local error instead. Unexported: no caller outside this package should branch
 // on the specific cause, only on "not a consensus fault".
-var errBranchStoreCorrupt = errors.New("block store corruption during side-branch collection")
+var errBranchStoreCorrupt = errors.New("local block-store corruption")
 
 // collectBranchToCanonical walks a candidate's ancestry back to the first block
 // the canonical index knows, returning the branch in canonical (oldest-first)
@@ -435,46 +444,54 @@ func (s *SyncEngine) collectBranchToCanonical(
 	}
 }
 
-// loadVerifiedBranchAncestor reads one stored ancestor and proves it is the
-// block that was asked for. A plain file read cannot: BlockStore.GetBlockByHash
-// returns whatever bytes sit at the path named by the hash. Mirrors the
-// defense-in-depth re-hash verifyReplayBlockHash performs on the startup replay
-// path. A genuinely absent ancestor keeps the pre-existing ErrParentNotFound
-// outcome, which the caller turns into normal orphan handling.
-//
-// EVERY way the stored bytes can fail to be the requested block — unparseable,
-// unhashable, or hashing to something else — is one local-corruption class and
-// is reported as errBranchStoreCorrupt. Bytes that cannot even yield a header
-// certainly do not hash to their lookup key, so parse failure is not a separate
-// verdict. The cause is rendered with %v and deliberately NOT wrapped with %w:
-// consensus.ParseBlockBytes returns a *consensus.TxError, and errors.As unwraps
-// through %w, so a %w-chained cause would still satisfy node/p2p's
-// isConsensusApplyBlockError and bump a relaying peer's ban score by 100 for OUR
-// corrupt datadir. Measured both renderings against that exact predicate: %w =>
-// matched, %v => did not, with identical message text.
+// loadVerifiedStoredBlock reads exactly one bounded block blob and proves that
+// its header key and all block-level commitments match the parsed contents.
+// Underlying consensus errors are rendered, never wrapped, so local corruption
+// cannot satisfy node/p2p's errors.As(*consensus.TxError) peer-penalty check.
+func (s *SyncEngine) loadVerifiedStoredBlock(lookupHash [32]byte) (verifiedStoredBlock, error) {
+	blockBytes, err := s.blockStore.GetBlockByHash(lookupHash)
+	if err != nil {
+		return verifiedStoredBlock{}, storedBlockReadCorruption(lookupHash, err)
+	}
+	parsed, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		return verifiedStoredBlock{}, storedBlockCorruption(lookupHash, "does not parse", err)
+	}
+	observedHash, err := consensus.BlockHash(parsed.HeaderBytes)
+	if err != nil {
+		return verifiedStoredBlock{}, storedBlockCorruption(lookupHash, "does not hash", err)
+	}
+	if observedHash != lookupHash {
+		return verifiedStoredBlock{}, fmt.Errorf(
+			"%w: stored block for %x hashes to %x",
+			errBranchStoreCorrupt, lookupHash, observedHash,
+		)
+	}
+	if err := consensus.ValidateStoredBlockCommitments(parsed); err != nil {
+		return verifiedStoredBlock{}, storedBlockCorruption(lookupHash, "has invalid commitments", err)
+	}
+	return verifiedStoredBlock{lookupHash: lookupHash, blockBytes: blockBytes, parsed: parsed}, nil
+}
+
+func storedBlockCorruption(lookupHash [32]byte, reason string, err error) error {
+	return fmt.Errorf("%w: stored block for %x %s: %v", errBranchStoreCorrupt, lookupHash, reason, err) //nolint:errorlint // %v is required: wrapped consensus.TxError would satisfy p2p's consensus-error predicate for local corruption.
+}
+
+func storedBlockReadCorruption(lookupHash [32]byte, err error) error {
+	return fmt.Errorf("%w: cannot read stored block for %x: %w", errBranchStoreCorrupt, lookupHash, err)
+}
+
+// loadVerifiedBranchAncestor preserves the pre-existing orphan disposition for
+// an absent side ancestor while sharing the exact verified-store ownership path.
 func (s *SyncEngine) loadVerifiedBranchAncestor(parentHash [32]byte) (*consensus.ParsedBlock, []byte, error) {
-	parentBlockBytes, err := s.blockStore.GetBlockByHash(parentHash)
+	stored, err := s.loadVerifiedStoredBlock(parentHash)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil, ErrParentNotFound
 		}
 		return nil, nil, err
 	}
-	parentParsed, err := consensus.ParseBlockBytes(parentBlockBytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: stored block for %x does not parse: %v", errBranchStoreCorrupt, parentHash, err) //nolint:errorlint // %v is required, not %w: errors.As unwraps %w, so a wrapped *consensus.TxError cause would satisfy p2p isConsensusApplyBlockError and bump the relaying peer's ban score 100 for OUR corrupt store (measured)
-	}
-	observedHash, err := consensus.BlockHash(parentParsed.HeaderBytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: stored block for %x does not hash: %v", errBranchStoreCorrupt, parentHash, err) //nolint:errorlint // %v is required, not %w: errors.As unwraps %w, so a wrapped *consensus.TxError cause would satisfy p2p isConsensusApplyBlockError and bump the relaying peer's ban score 100 for OUR corrupt store (measured)
-	}
-	if observedHash != parentHash {
-		return nil, nil, fmt.Errorf(
-			"%w: stored block for %x hashes to %x",
-			errBranchStoreCorrupt, parentHash, observedHash,
-		)
-	}
-	return parentParsed, parentBlockBytes, nil
+	return stored.parsed, stored.blockBytes, nil
 }
 
 func (s *SyncEngine) syntheticSideChainSummary(height uint64, blockHash [32]byte) *ChainStateConnectSummary {
@@ -494,13 +511,36 @@ func (s *SyncEngine) syntheticSideChainSummary(height uint64, blockHash [32]byte
 	}
 }
 
+func (s *SyncEngine) requeueVerifiedDisconnectedTransactions(disconnectedBlocks []verifiedStoredBlock) {
+	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
+	for _, block := range disconnectedBlocks {
+		parsedBlocks = append(parsedBlocks, block.parsed)
+	}
+	s.requeueParsedDisconnectedTransactions(parsedBlocks)
+}
+
+// requeueDisconnectedTransactions remains for direct raw-byte callers. The
+// committed reorg path uses requeueVerifiedDisconnectedTransactions so it
+// retains the already-verified parse rather than parsing again.
 func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte) {
+	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
+	for _, blockBytes := range disconnectedBlocks {
+		parsed, err := consensus.ParseBlockBytes(blockBytes)
+		if err != nil {
+			continue
+		}
+		parsedBlocks = append(parsedBlocks, parsed)
+	}
+	s.requeueParsedDisconnectedTransactions(parsedBlocks)
+}
+
+func (s *SyncEngine) requeueParsedDisconnectedTransactions(disconnectedBlocks []*consensus.ParsedBlock) {
 	if s == nil || s.mempool == nil || len(disconnectedBlocks) == 0 {
 		return
 	}
 	// Disconnect helpers append blocks tip-down, matching h_max -> h_min requeue order.
-	for blockIndex := 0; blockIndex < len(disconnectedBlocks); blockIndex++ {
-		txs, err := nonCoinbaseBlockTransactions(disconnectedBlocks[blockIndex])
+	for _, parsed := range disconnectedBlocks {
+		txs, err := nonCoinbaseParsedBlockTransactions(parsed)
 		if err != nil {
 			continue
 		}
@@ -516,6 +556,13 @@ func nonCoinbaseBlockTransactions(blockBytes []byte) ([][]byte, error) {
 	pb, err := consensus.ParseBlockBytes(blockBytes)
 	if err != nil {
 		return nil, err
+	}
+	return nonCoinbaseParsedBlockTransactions(pb)
+}
+
+func nonCoinbaseParsedBlockTransactions(pb *consensus.ParsedBlock) ([][]byte, error) {
+	if pb == nil {
+		return nil, errors.New("nil parsed block")
 	}
 	if len(pb.Txs) <= 1 {
 		return nil, nil

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -17,9 +17,7 @@ type reorgBranchBlock struct {
 	header     consensus.BlockHeader
 }
 
-// verifiedStoredBlock owns one bounded block-store read and the one parse of
-// those exact bytes. Callers retain this value through their state transition
-// instead of reading or parsing the same logical block again.
+// verifiedStoredBlock retains one verified block-store read and parse.
 type verifiedStoredBlock struct {
 	lookupHash [32]byte
 	blockBytes []byte
@@ -357,9 +355,7 @@ func advancePrevTimestamps(prev []uint64, newTs uint64) []uint64 {
 	return out
 }
 
-// errBranchStoreCorrupt marks a local block-store defect: a stored block whose
-// bytes do not hash to the lookup key or whose block-level commitments do not
-// close. It is also used for the side-branch walk's defense-in-depth cycle.
+// errBranchStoreCorrupt marks failed stored identity/commitments or a branch cycle.
 //
 // It is deliberately a plain error and NOT a *consensus.TxError, and it is
 // deliberately distinct from ErrParentNotFound. node/p2p classifies an apply
@@ -444,10 +440,7 @@ func (s *SyncEngine) collectBranchToCanonical(
 	}
 }
 
-// loadVerifiedStoredBlock reads exactly one bounded block blob and proves that
-// its header key and all block-level commitments match the parsed contents.
-// Underlying consensus errors are rendered, never wrapped, so local corruption
-// cannot satisfy node/p2p's errors.As(*consensus.TxError) peer-penalty check.
+// loadVerifiedStoredBlock verifies identity and commitments as local corruption.
 func (s *SyncEngine) loadVerifiedStoredBlock(lookupHash [32]byte) (verifiedStoredBlock, error) {
 	blockBytes, err := s.blockStore.GetBlockByHash(lookupHash)
 	if err != nil {
@@ -481,8 +474,7 @@ func storedBlockReadCorruption(lookupHash [32]byte, err error) error {
 	return fmt.Errorf("%w: cannot read stored block for %x: %w", errBranchStoreCorrupt, lookupHash, err)
 }
 
-// loadVerifiedBranchAncestor preserves the pre-existing orphan disposition for
-// an absent side ancestor while sharing the exact verified-store ownership path.
+// loadVerifiedBranchAncestor preserves missing-side-ancestor orphan handling.
 func (s *SyncEngine) loadVerifiedBranchAncestor(parentHash [32]byte) (*consensus.ParsedBlock, []byte, error) {
 	stored, err := s.loadVerifiedStoredBlock(parentHash)
 	if err != nil {
@@ -519,9 +511,7 @@ func (s *SyncEngine) requeueVerifiedDisconnectedTransactions(disconnectedBlocks 
 	s.requeueParsedDisconnectedTransactions(parsedBlocks)
 }
 
-// requeueDisconnectedTransactions remains for direct raw-byte callers. The
-// committed reorg path uses requeueVerifiedDisconnectedTransactions so it
-// retains the already-verified parse rather than parsing again.
+// requeueDisconnectedTransactions is for raw-byte callers; reorgs retain parses.
 func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte) {
 	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
 	for _, blockBytes := range disconnectedBlocks {

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -1000,9 +1000,7 @@ func TestRequeueDisconnectedTransactionsUsesTipDownOrderAndContinuesAfterReject(
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(low): %v", err)
 	}
-	// The production reorg path retains these parsed blocks. Deliberately bad
-	// byte fields prove requeue reads the retained parses instead of parsing raw
-	// bytes a second time.
+	// Bad byte fields prove production requeue uses the retained parses.
 	engine.requeueVerifiedDisconnectedTransactions([]verifiedStoredBlock{
 		{blockBytes: []byte("not parsed again"), parsed: highParsed},
 		{blockBytes: []byte("not parsed again"), parsed: lowParsed},
@@ -2534,9 +2532,7 @@ func corruptStoredMerkleBody(t *testing.T, blockBytes []byte) []byte {
 	if len(corrupt) < 3 {
 		t.Fatal("test block too short to change coinbase locktime")
 	}
-	// A coinbase wire block ends in locktime(4), witness_count(0), da_len(0).
-	// Changing a locktime byte keeps parsing and the header hash intact while
-	// changing the first txid, so the stored-body Merkle commitment alone fails.
+	// Mutating coinbase locktime keeps parsing/header identity but breaks Merkle.
 	corrupt[len(corrupt)-3] ^= 0x01
 	pb, err := consensus.ParseBlockBytes(corrupt)
 	if err != nil {

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,6 +25,23 @@ func reorgTestTimestamp(n uint64) uint64 {
 		panic("ParseBlockBytes(genesis): " + err.Error())
 	}
 	return genesisParsed.Header.Timestamp + n
+}
+
+type corruptCanonicalOnCreateRotation struct {
+	overwrite func()
+	fires     int
+}
+
+func (p *corruptCanonicalOnCreateRotation) NativeCreateSuites(height uint64) *consensus.NativeSuiteSet {
+	if p.fires == 0 {
+		p.fires++
+		p.overwrite()
+	}
+	return consensus.DefaultRotationProvider{}.NativeCreateSuites(height)
+}
+
+func (p *corruptCanonicalOnCreateRotation) NativeSpendSuites(height uint64) *consensus.NativeSuiteSet {
+	return consensus.DefaultRotationProvider{}.NativeSpendSuites(height)
 }
 
 func TestReorgTwoMiners(t *testing.T) {
@@ -66,9 +84,16 @@ func TestReorgTwoMiners(t *testing.T) {
 		t.Fatalf("BlockHash(B1): %v", err)
 	}
 	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, reorgTestTimestamp(3), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	rotation := &corruptCanonicalOnCreateRotation{overwrite: func() {
+		writeRawStoreBlockFile(t, store, summaryA1.BlockHash, []byte("corrupt after preview"))
+	}}
+	engine.cfg.RotationProvider = rotation
 	summaryB2, err := engine.ApplyBlockWithReorg(blockB2, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B2): %v", err)
+	}
+	if rotation.fires != 1 {
+		t.Fatalf("post-preview overwrite fired %d times, want 1", rotation.fires)
 	}
 	if summaryB2.BlockHeight != 2 {
 		t.Fatalf("B2 height=%d, want 2", summaryB2.BlockHeight)
@@ -967,7 +992,21 @@ func TestRequeueDisconnectedTransactionsUsesTipDownOrderAndContinuesAfterReject(
 		txLow,
 	)
 
-	engine.requeueDisconnectedTransactions([][]byte{blockHigh, blockLow})
+	highParsed, err := consensus.ParseBlockBytes(blockHigh)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(high): %v", err)
+	}
+	lowParsed, err := consensus.ParseBlockBytes(blockLow)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(low): %v", err)
+	}
+	// The production reorg path retains these parsed blocks. Deliberately bad
+	// byte fields prove requeue reads the retained parses instead of parsing raw
+	// bytes a second time.
+	engine.requeueVerifiedDisconnectedTransactions([]verifiedStoredBlock{
+		{blockBytes: []byte("not parsed again"), parsed: highParsed},
+		{blockBytes: []byte("not parsed again"), parsed: lowParsed},
+	})
 
 	if !strings.Contains(stderr.String(), "mempool: requeue-tx:") {
 		t.Fatalf("expected duplicate requeue rejection to be logged, got %q", stderr.String())
@@ -2489,6 +2528,87 @@ func writeRawStoreBlockFile(t *testing.T, store *BlockStore, hash [32]byte, bloc
 	}
 }
 
+func corruptStoredMerkleBody(t *testing.T, blockBytes []byte) []byte {
+	t.Helper()
+	corrupt := append([]byte(nil), blockBytes...)
+	if len(corrupt) < 3 {
+		t.Fatal("test block too short to change coinbase locktime")
+	}
+	// A coinbase wire block ends in locktime(4), witness_count(0), da_len(0).
+	// Changing a locktime byte keeps parsing and the header hash intact while
+	// changing the first txid, so the stored-body Merkle commitment alone fails.
+	corrupt[len(corrupt)-3] ^= 0x01
+	pb, err := consensus.ParseBlockBytes(corrupt)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(corrupt merkle body): %v", err)
+	}
+	requireConsensusTxErrCode(t, consensus.ValidateStoredBlockCommitments(pb), consensus.BLOCK_ERR_MERKLE_INVALID)
+	return corrupt
+}
+
+func storedWitnessCommitmentTestBlock(t *testing.T, prevHash, target [32]byte, height, timestamp uint64) []byte {
+	t.Helper()
+	spend := &consensus.Tx{
+		Version:  1,
+		TxKind:   0x00,
+		TxNonce:  1,
+		Inputs:   []consensus.TxInput{{PrevTxid: [32]byte{0x91}, PrevVout: 0, Sequence: 0}},
+		Outputs:  []consensus.TxOutput{{Value: 1, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: testP2PKCovenantData(0x77)}},
+		Locktime: 0,
+		Witness:  []consensus.WitnessItem{{SuiteID: 0x7e, Pubkey: []byte{0x01}, Signature: []byte{0x02}}},
+	}
+	spendBytes, err := consensus.MarshalTx(spend)
+	if err != nil {
+		t.Fatalf("MarshalTx(spend): %v", err)
+	}
+	_, _, spendWtxid, _, err := consensus.ParseTx(spendBytes)
+	if err != nil {
+		t.Fatalf("ParseTx(spend): %v", err)
+	}
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueForWtxids(
+		t,
+		height,
+		consensus.BlockSubsidy(height, 0),
+		[][32]byte{{}, spendWtxid},
+	)
+	return buildMultiTxBlock(t, prevHash, target, timestamp, coinbase, spendBytes)
+}
+
+func corruptStoredWitnessOnly(t *testing.T, blockBytes []byte) []byte {
+	t.Helper()
+	pb, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(source): %v", err)
+	}
+	if len(pb.Txs) < 2 || len(pb.Txs[1].Witness) == 0 || len(pb.Txs[1].Witness[0].Signature) == 0 {
+		t.Fatal("test block has no mutable non-coinbase witness")
+	}
+	pb.Txs[1].Witness[0].Signature[0] ^= 0x01
+
+	corrupt := append([]byte(nil), pb.HeaderBytes...)
+	corrupt = consensus.AppendCompactSize(corrupt, uint64(len(pb.Txs)))
+	for _, tx := range pb.Txs {
+		txBytes, err := consensus.MarshalTx(tx)
+		if err != nil {
+			t.Fatalf("MarshalTx(rebuild): %v", err)
+		}
+		corrupt = append(corrupt, txBytes...)
+	}
+	parsed, err := consensus.ParseBlockBytes(corrupt)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(corrupt witness): %v", err)
+	}
+	root, err := consensus.MerkleRootTxids(parsed.Txids)
+	if err != nil {
+		t.Fatalf("MerkleRootTxids(corrupt witness): %v", err)
+	}
+	if root != parsed.Header.MerkleRoot {
+		t.Fatal("witness-only corruption changed the txid Merkle root")
+	}
+	requireConsensusTxErrCode(t, consensus.ValidateStoredBlockCommitments(parsed), consensus.BLOCK_ERR_WITNESS_COMMITMENT)
+	return corrupt
+}
+
 // assertBranchStoreCorruption pins the failure class of a corrupt-store branch
 // walk: a local-corruption error, distinct from ErrParentNotFound, and NOT a
 // *consensus.TxError. That last property is what keeps a peer from being
@@ -2585,6 +2705,14 @@ func TestCollectBranchToCanonicalRejectsCorruptStoreAncestry(t *testing.T) {
 			return truncatedHash
 		},
 	}, {
+		name: "ancestor file with trailing bytes",
+		plant: func(t *testing.T, store *BlockStore, target [32]byte) [32]byte {
+			trailingHash := [32]byte{0x9a, 0x33}
+			full := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(76), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy))
+			writeRawStoreBlockFile(t, store, trailingHash, append(full, 0x00))
+			return trailingHash
+		},
+	}, {
 		// Substitution: a real, well-formed block stored under someone else's
 		// hash. A plain file read cannot tell the difference.
 		name: "ancestor bytes hashing to another value",
@@ -2605,6 +2733,121 @@ func TestCollectBranchToCanonicalRejectsCorruptStoreAncestry(t *testing.T) {
 			_, _, _, err := engine.collectBranchToCanonical(candidateHash, candidate, parsed)
 			assertBranchStoreCorruption(t, err)
 		})
+	}
+}
+
+func TestCollectBranchToCanonicalRejectsStoredCommitmentCorruptionAtEveryDepth(t *testing.T) {
+	corruptions := []struct {
+		name    string
+		block   func(t *testing.T, target [32]byte) []byte
+		corrupt func(t *testing.T, blockBytes []byte) []byte
+	}{
+		{
+			name: "txid Merkle body substitution",
+			block: func(t *testing.T, target [32]byte) []byte {
+				return buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(101), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
+			},
+			corrupt: corruptStoredMerkleBody,
+		},
+		{
+			name: "witness-only substitution",
+			block: func(t *testing.T, target [32]byte) []byte {
+				return storedWitnessCommitmentTestBlock(t, devnetGenesisBlockHash, target, 1, reorgTestTimestamp(102))
+			},
+			corrupt: corruptStoredWitnessOnly,
+		},
+	}
+
+	for _, corruption := range corruptions {
+		for _, depth := range []struct {
+			name string
+			mid  bool
+		}{
+			{name: "branch root"},
+			{name: "branch middle", mid: true},
+		} {
+			t.Run(corruption.name+"/"+depth.name, func(t *testing.T) {
+				engine, store, target := newReorgTestEngine(t)
+				validB1 := corruption.block(t, target)
+				_, b1Hash := mustParseReorgBlockForTest(t, validB1)
+				writeRawStoreBlockFile(t, store, b1Hash, corruption.corrupt(t, validB1))
+
+				parentHash := b1Hash
+				candidateHeight := uint64(2)
+				if depth.mid {
+					b2 := buildSingleTxBlock(t, b1Hash, target, reorgTestTimestamp(103), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, consensus.BlockSubsidy(2, consensus.BlockSubsidy(1, 0))))
+					b2Parsed, b2Hash := mustParseReorgBlockForTest(t, b2)
+					if err := store.StoreBlock(b2Hash, b2Parsed.HeaderBytes, b2); err != nil {
+						t.Fatalf("StoreBlock(B2): %v", err)
+					}
+					parentHash = b2Hash
+					candidateHeight = 3
+				}
+				candidate := buildSingleTxBlock(t, parentHash, target, reorgTestTimestamp(104), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, candidateHeight, consensus.BlockSubsidy(candidateHeight, 0)))
+				parsed, candidateHash := mustParseReorgBlockForTest(t, candidate)
+
+				_, _, _, err := engine.collectBranchToCanonical(candidateHash, candidate, parsed)
+				assertBranchStoreCorruption(t, err)
+			})
+		}
+	}
+}
+
+func TestApplyBlockWithReorgRejectsCorruptLosingStoredBranchBeforeForkChoice(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	prevHash := devnetGenesisBlockHash
+	alreadyGenerated := uint64(0)
+	for height := uint64(1); height <= 3; height++ {
+		subsidy := consensus.BlockSubsidy(height, alreadyGenerated)
+		block := buildSingleTxBlock(t, prevHash, target, reorgTestTimestamp(height), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		summary, err := engine.ApplyBlock(block, nil)
+		if err != nil {
+			t.Fatalf("ApplyBlock(A%d): %v", height, err)
+		}
+		prevHash = summary.BlockHash
+		alreadyGenerated += subsidy
+	}
+	mempool, err := NewMempool(engine.chainState, store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	engine.SetMempool(mempool)
+	beforeState, err := stateToDisk(engine.chainState)
+	if err != nil {
+		t.Fatalf("stateToDisk(before): %v", err)
+	}
+	beforeIndex, err := store.CanonicalIndexSnapshot()
+	if err != nil {
+		t.Fatalf("CanonicalIndexSnapshot(before): %v", err)
+	}
+	beforeCounts := engine.BlockApplyCounts()
+	beforeMempoolLen := mempool.Len()
+
+	subsidy1 := consensus.BlockSubsidy(1, 0)
+	validB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(201), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	_, b1Hash := mustParseReorgBlockForTest(t, validB1)
+	writeRawStoreBlockFile(t, store, b1Hash, corruptStoredMerkleBody(t, validB1))
+	b2 := buildSingleTxBlock(t, b1Hash, target, reorgTestTimestamp(202), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, consensus.BlockSubsidy(2, subsidy1)))
+	_, b2Hash := mustParseReorgBlockForTest(t, b2)
+
+	// A healthy two-block branch loses to the current three-block canonical tip.
+	// Collection must still reject its corrupt stored ancestor before fork choice.
+	_, err = engine.ApplyBlockWithReorg(b2, nil)
+	assertBranchStoreCorruption(t, err)
+	if got, err := stateToDisk(engine.chainState); err != nil || !reflect.DeepEqual(got, beforeState) {
+		t.Fatalf("chainstate after corrupt losing branch: state=%+v err=%v", got, err)
+	}
+	if got, err := store.CanonicalIndexSnapshot(); err != nil || !reflect.DeepEqual(got, beforeIndex) {
+		t.Fatalf("canonical index after corrupt losing branch: index=%v err=%v", got, err)
+	}
+	if got := engine.BlockApplyCounts(); got != beforeCounts {
+		t.Fatalf("BlockApplyCounts=%+v, want %+v", got, beforeCounts)
+	}
+	if got := mempool.Len(); got != beforeMempoolLen {
+		t.Fatalf("mempool len=%d, want %d", got, beforeMempoolLen)
+	}
+	if _, err := store.GetBlockByHash(b2Hash); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("candidate B2 stored despite local failure: %v", err)
 	}
 }
 
@@ -3048,13 +3291,8 @@ func TestCompleteDASetIDsFromParsedBlockIncompleteShapes(t *testing.T) {
 	}
 }
 
-// RUB-1057 hostile row: an over-bound ancestor block file on the branch walk
-// is LOCAL store corruption — never ErrParentNotFound (the orphan path), and
-// never a peer-attributable consensus error. The unreadable arm propagates
-// the typed errStoreFileTooLarge raw (only parse/hash defects are rendered as
-// errBranchStoreCorrupt); the Rust twin renders the same arm through its
-// branch_store_corrupt prefix — same local-corruption verdict class. Rust
-// twin: `branch_walk_over_bound_ancestor_is_local_corruption`.
+// An over-bound ancestor block is local store corruption while retaining its
+// typed size cause for callers that need the operational diagnosis.
 func TestLoadVerifiedBranchAncestorOverBoundBlockIsLocalCorruption(t *testing.T) {
 	dir := t.TempDir()
 	store := mustCreateBlockStore(t, BlockStorePath(dir))
@@ -3067,11 +3305,44 @@ func TestLoadVerifiedBranchAncestorOverBoundBlockIsLocalCorruption(t *testing.T)
 	blockPath := filepath.Join(BlockStorePath(dir), "blocks", hex.EncodeToString(hash[:])+".bin")
 	createSparseFile(t, blockPath, blockFileMaxBytes+1)
 	_, _, err = engine.loadVerifiedBranchAncestor(hash)
-	if !errors.Is(err, errStoreFileTooLarge) || errors.Is(err, ErrParentNotFound) {
-		t.Fatalf("want typed local size error (not ErrParentNotFound), got %v", err)
+	if !errors.Is(err, errBranchStoreCorrupt) || !errors.Is(err, errStoreFileTooLarge) || errors.Is(err, ErrParentNotFound) {
+		t.Fatalf("want local corruption with typed size cause, got %v", err)
 	}
 	var txErr *consensus.TxError
 	if errors.As(err, &txErr) {
 		t.Fatalf("over-bound ancestor must not be peer-attributable: %v", err)
 	}
+}
+
+func TestLoadVerifiedStoredBlockReadFailuresAreLocalCorruption(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		engine, _, _ := newReorgTestEngine(t)
+		hash := [32]byte{0x71}
+		_, err := engine.loadVerifiedStoredBlock(hash)
+		assertBranchStoreCorruption(t, err)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("missing stored block must retain os.ErrNotExist: %v", err)
+		}
+		_, _, err = engine.loadVerifiedBranchAncestor(hash)
+		if !errors.Is(err, ErrParentNotFound) || errors.Is(err, errBranchStoreCorrupt) {
+			t.Fatalf("missing side ancestor=%v, want ErrParentNotFound only", err)
+		}
+	})
+
+	t.Run("wrong kind", func(t *testing.T) {
+		engine, store, _ := newReorgTestEngine(t)
+		hash := [32]byte{0x72}
+		path := filepath.Join(store.blocksDir, hex.EncodeToString(hash[:])+".bin")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatalf("Mkdir(block path): %v", err)
+		}
+		_, err := engine.loadVerifiedStoredBlock(hash)
+		assertBranchStoreCorruption(t, err)
+		var pathErr *fs.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("wrong-kind read must retain a path error: %v", err)
+		}
+		_, _, err = engine.loadVerifiedBranchAncestor(hash)
+		assertBranchStoreCorruption(t, err)
+	})
 }

--- a/clients/go/node/undo.go
+++ b/clients/go/node/undo.go
@@ -145,7 +145,38 @@ func (s *ChainState) DisconnectBlock(blockBytes []byte, undo *BlockUndo) (*Chain
 	if err != nil {
 		return nil, err
 	}
+	return s.disconnectParsedBlockLocked(pb, blockHash, undo)
+}
 
+// disconnectVerifiedStoredBlock mirrors DisconnectBlock after the caller has
+// retained the one parsed, hash-verified stored block. It deliberately keeps
+// the public method's lock and validation order while sharing the mutation
+// path below, so a prepared disconnect does not parse the block a second time.
+func (s *ChainState) disconnectVerifiedStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo) (*ChainStateDisconnectSummary, error) {
+	if s == nil {
+		return nil, errors.New("nil chainstate")
+	}
+	s.admissionMu.Lock()
+	defer s.admissionMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.HasTip {
+		return nil, errors.New("chainstate has no tip")
+	}
+	if undo == nil {
+		return nil, errors.New("nil block undo")
+	}
+	pb, err := validateVerifiedDisconnectStoredBlock(storedBlock, undo, s.TipHash, s.Height)
+	if err != nil {
+		return nil, err
+	}
+	return s.disconnectParsedBlockLocked(pb, storedBlock.lookupHash, undo)
+}
+
+// disconnectParsedBlockLocked performs the common post-parse disconnect
+// transition. Callers hold admissionMu and mu and have checked their distinct
+// raw or retained-block preconditions before entering this method.
+func (s *ChainState) disconnectParsedBlockLocked(pb *consensus.ParsedBlock, blockHash [32]byte, undo *BlockUndo) (*ChainStateDisconnectSummary, error) {
 	work := copyUtxoSet(s.Utxos)
 	if err := applyDisconnectUndo(work, pb, undo); err != nil {
 		return nil, err
@@ -172,6 +203,26 @@ func (s *ChainState) DisconnectBlock(blockBytes []byte, undo *BlockUndo) (*Chain
 		AlreadyGenerated:   s.AlreadyGenerated,
 		UtxoCount:          uint64(len(s.Utxos)),
 	}, nil
+}
+
+func validateVerifiedDisconnectStoredBlock(storedBlock verifiedStoredBlock, undo *BlockUndo, tipHash [32]byte, height uint64) (*consensus.ParsedBlock, error) {
+	if storedBlock.parsed == nil {
+		return nil, errors.New("nil verified stored block")
+	}
+	pb := storedBlock.parsed
+	if len(pb.Txs) != len(pb.Txids) {
+		return nil, errors.New("parsed block txid length mismatch")
+	}
+	if len(undo.Txs) != len(pb.Txs) {
+		return nil, errors.New("undo tx count mismatch")
+	}
+	if tipHash != storedBlock.lookupHash {
+		return nil, errors.New("disconnect block is not current tip")
+	}
+	if height != undo.BlockHeight {
+		return nil, fmt.Errorf("disconnect height mismatch: chainstate=%d undo=%d", height, undo.BlockHeight)
+	}
+	return pb, nil
 }
 
 // parseAndValidateDisconnectBlock parses block bytes and validates undo against chain state.

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -1,6 +1,7 @@
 use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
 use crate::constants::{MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK};
 use crate::error::{ErrorCode, TxError};
+use crate::merkle::merkle_root_txids;
 use crate::suite_registry::RotationProvider;
 use crate::tx::Tx;
 
@@ -55,6 +56,40 @@ pub fn parse_block_bytes(block_bytes: &[u8]) -> Result<ParsedBlock, TxError> {
     #[cfg(test)]
     PARSE_BLOCK_BYTES_CALL_COUNT.with(|c| c.set(c.get() + 1));
     parse_block_bytes_impl(block_bytes)
+}
+
+/// Validate the self-contained commitments required before a block read from
+/// local storage can be used for a disconnect or branch walk. This deliberately
+/// excludes network-context checks (linkage, target, time, fees, and state) so
+/// callers can validate retained historical bytes without changing admission
+/// order. The order closes the coinbase/witness self-reference first, then the
+/// header transaction commitment, then the witness commitment itself.
+pub fn validate_stored_block_commitments(pb: &ParsedBlock) -> Result<(), TxError> {
+    let coinbase = pb
+        .txs
+        .first()
+        .ok_or_else(|| TxError::new(ErrorCode::BlockErrCoinbaseInvalid, "missing coinbase"))?;
+    if !coinbase::is_coinbase_tx(coinbase) {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "first tx is not canonical coinbase",
+        ));
+    }
+
+    let merkle_root = merkle_root_txids(&pb.txids).map_err(|_| {
+        TxError::new(
+            ErrorCode::BlockErrMerkleInvalid,
+            "failed to compute merkle root",
+        )
+    })?;
+    if merkle_root != pb.header.merkle_root {
+        return Err(TxError::new(
+            ErrorCode::BlockErrMerkleInvalid,
+            "merkle_root mismatch",
+        ));
+    }
+
+    coinbase::validate_coinbase_witness_commitment(pb)
 }
 
 pub fn validate_block_basic(

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -46,7 +46,8 @@ pub use block_basic::{
     validate_block_basic_with_context_and_fees_at_height,
     validate_block_basic_with_context_and_fees_at_height_and_rotation,
     validate_block_basic_with_context_at_height,
-    validate_block_basic_with_context_at_height_and_rotation, BlockBasicSummary, ParsedBlock,
+    validate_block_basic_with_context_at_height_and_rotation, validate_stored_block_commitments,
+    BlockBasicSummary, ParsedBlock,
 };
 pub use compact_relay::compact_shortid;
 pub use compactsize::encode_compact_size;

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::tx::{Tx, TxInput, TxOutput, WitnessItem};
+use crate::validate_stored_block_commitments;
 
 #[test]
 fn parse_block_bytes_ok() {
@@ -15,6 +16,45 @@ fn parse_block_bytes_ok() {
     assert_eq!(parsed.tx_count, 1);
     assert_eq!(parsed.txs.len(), 1);
     assert_eq!(parsed.txids.len(), 1);
+}
+
+#[test]
+fn validate_stored_block_commitments_checks_coinbase_merkle_then_witness() {
+    let tx = coinbase_with_witness_commitment(0, &[]);
+    let (_t, txid, _w, _n) = parse_tx(&tx).expect("tx");
+    let root = merkle_root_txids(&[txid]).expect("root");
+    let block = build_block_bytes([0x31; 32], root, [0xff; 32], 8, &[tx]);
+    let parsed = parse_block_bytes(&block).expect("parse block");
+    validate_stored_block_commitments(&parsed).expect("valid stored commitments");
+
+    let mut bad_coinbase = parsed.clone();
+    bad_coinbase.txs[0].tx_kind = 1;
+    bad_coinbase.header.merkle_root = [0; 32];
+    assert_eq!(
+        validate_stored_block_commitments(&bad_coinbase)
+            .expect_err("coinbase must precede merkle")
+            .code,
+        ErrorCode::BlockErrCoinbaseInvalid
+    );
+
+    let mut bad_merkle = parsed.clone();
+    bad_merkle.header.merkle_root[0] ^= 1;
+    bad_merkle.txs[0].outputs[0].covenant_data[0] ^= 1;
+    assert_eq!(
+        validate_stored_block_commitments(&bad_merkle)
+            .expect_err("merkle mismatch")
+            .code,
+        ErrorCode::BlockErrMerkleInvalid
+    );
+
+    let mut bad_witness = parsed;
+    bad_witness.txs[0].outputs[0].covenant_data[0] ^= 1;
+    assert_eq!(
+        validate_stored_block_commitments(&bad_witness)
+            .expect_err("witness mismatch")
+            .code,
+        ErrorCode::BlockErrWitnessCommitment
+    );
 }
 
 #[test]

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -1,49 +1,204 @@
-use rubin_consensus::{parse_block_bytes, parse_block_header_bytes};
+use std::collections::HashSet;
+
+use rubin_consensus::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT};
+use rubin_consensus::{parse_block_header_bytes, Outpoint};
 
 use crate::chainstate::ChainState;
 use crate::io_utils::is_atomic_write_post_commit;
 use crate::sync::SyncEngine;
-use crate::undo::ChainStateDisconnectSummary;
+use crate::sync_reorg::{load_verified_stored_block, VerifiedStoredBlock};
+use crate::undo::{BlockUndo, ChainStateDisconnectSummary};
+
+impl ChainState {
+    /// Disconnect one already-loaded stored block without parsing its bytes a
+    /// second time. This preserves `disconnect_block`'s validation and
+    /// copy-before-mutation order for the retained parsed representation.
+    fn disconnect_verified_stored_block(
+        &mut self,
+        stored: &VerifiedStoredBlock,
+        undo: &BlockUndo,
+    ) -> Result<ChainStateDisconnectSummary, String> {
+        if !self.has_tip {
+            return Err("chainstate has no tip".into());
+        }
+        if self.height != undo.block_height {
+            return Err(format!(
+                "disconnect height mismatch: chainstate={} undo={}",
+                self.height, undo.block_height
+            ));
+        }
+
+        let pb = &stored.parsed;
+        if pb.txs.len() != pb.txids.len() {
+            return Err("parsed block txid length mismatch".into());
+        }
+        if undo.txs.len() != pb.txs.len() {
+            return Err("undo tx count mismatch".into());
+        }
+        if self.tip_hash != stored.lookup_hash {
+            return Err("disconnect block is not current tip".into());
+        }
+
+        let mut created_outpoints = HashSet::new();
+        let mut same_block_spent_outpoints = HashSet::new();
+        for (tx_index, tx) in pb.txs.iter().enumerate() {
+            if tx_index > 0 {
+                for input in &tx.inputs {
+                    let outpoint = Outpoint {
+                        txid: input.prev_txid,
+                        vout: input.prev_vout,
+                    };
+                    if created_outpoints.contains(&outpoint) {
+                        same_block_spent_outpoints.insert(outpoint);
+                    }
+                }
+            }
+            for (output_index, out) in tx.outputs.iter().enumerate() {
+                if out.covenant_type == COV_TYPE_ANCHOR || out.covenant_type == COV_TYPE_DA_COMMIT {
+                    continue;
+                }
+                created_outpoints.insert(Outpoint {
+                    txid: pb.txids[tx_index],
+                    vout: output_index as u32,
+                });
+            }
+        }
+
+        let mut work = self.utxos.clone();
+        let mut restored_outpoints = HashSet::new();
+        for tx_index in (0..pb.txs.len()).rev() {
+            let tx = &pb.txs[tx_index];
+            let txid = pb.txids[tx_index];
+            for (output_index, out) in tx.outputs.iter().enumerate() {
+                if out.covenant_type == COV_TYPE_ANCHOR || out.covenant_type == COV_TYPE_DA_COMMIT {
+                    continue;
+                }
+                let created_outpoint = Outpoint {
+                    txid,
+                    vout: output_index as u32,
+                };
+                if work.remove(&created_outpoint).is_none()
+                    && !same_block_spent_outpoints.contains(&created_outpoint)
+                {
+                    return Err(format!(
+                        "disconnect missing created output for {}:{}",
+                        hex::encode(created_outpoint.txid),
+                        created_outpoint.vout
+                    ));
+                }
+            }
+            for spent in &undo.txs[tx_index].spent {
+                if !restored_outpoints.insert(spent.outpoint.clone()) {
+                    return Err(format!(
+                        "undo duplicate restore entry for {}:{}",
+                        hex::encode(spent.outpoint.txid),
+                        spent.outpoint.vout
+                    ));
+                }
+                if work.contains_key(&spent.outpoint) {
+                    return Err(format!(
+                        "undo restore target already present for {}:{}",
+                        hex::encode(spent.outpoint.txid),
+                        spent.outpoint.vout
+                    ));
+                }
+                work.insert(spent.outpoint.clone(), spent.entry.clone());
+            }
+        }
+
+        self.utxos = work;
+        self.already_generated = undo.previous_already_generated;
+        if self.height == 0 {
+            self.has_tip = false;
+            self.height = 0;
+            self.tip_hash = [0u8; 32];
+        } else {
+            self.height -= 1;
+            self.tip_hash = pb.header.prev_block_hash;
+        }
+
+        Ok(ChainStateDisconnectSummary {
+            disconnected_height: undo.block_height,
+            block_hash: stored.lookup_hash,
+            new_height: self.height,
+            new_tip_hash: self.tip_hash,
+            has_tip: self.has_tip,
+            already_generated: self.already_generated,
+            utxo_count: self.utxos.len() as u64,
+        })
+    }
+}
 
 impl SyncEngine {
     /// Disconnect the current canonical tip block, restoring the chain state
     /// to the parent. Returns a summary of the disconnection.
     pub fn disconnect_tip(&mut self) -> Result<ChainStateDisconnectSummary, String> {
+        let stored = self.prepare_disconnect_tip()?;
+        self.disconnect_prepared_tip(&stored)
+    }
+
+    fn prepare_disconnect_tip(&self) -> Result<VerifiedStoredBlock, String> {
         self.mutation_allowed()?;
+        let (_, tip_hash) = self.current_disconnect_tip()?;
         let block_store = self
             .block_store
             .as_ref()
             .ok_or("sync engine has no blockstore")?;
+        load_verified_stored_block(block_store, tip_hash).map_err(|err| err.render(tip_hash))
+    }
 
-        let (tip_height, tip_hash) = block_store
+    fn current_disconnect_tip(&self) -> Result<(u64, [u8; 32]), String> {
+        let (tip_height, tip_hash) = self
+            .block_store
+            .as_ref()
+            .ok_or("sync engine has no blockstore")?
             .tip()?
             .ok_or("blockstore has no canonical tip")?;
-
         if !self.chain_state.has_tip
             || self.chain_state.height != tip_height
             || self.chain_state.tip_hash != tip_hash
         {
             return Err("chainstate tip does not match blockstore tip".into());
         }
+        Ok((tip_height, tip_hash))
+    }
 
-        let block_bytes = block_store.get_block_by_hash(tip_hash)?;
-        let undo = block_store.get_undo(tip_hash)?;
-        let pb = parse_block_bytes(&block_bytes).map_err(|e| e.to_string())?;
+    fn parent_timestamp(
+        &self,
+        tip_height: u64,
+        stored: &VerifiedStoredBlock,
+    ) -> Result<u64, String> {
+        if tip_height == 0 {
+            return Ok(0);
+        }
+        let parent_header_bytes = self
+            .block_store
+            .as_ref()
+            .ok_or("sync engine has no blockstore")?
+            .get_header_by_hash(stored.parsed.header.prev_block_hash)?;
+        Ok(parse_block_header_bytes(&parent_header_bytes)
+            .map_err(|err| err.to_string())?
+            .timestamp)
+    }
 
+    fn disconnect_prepared_tip(
+        &mut self,
+        stored: &VerifiedStoredBlock,
+    ) -> Result<ChainStateDisconnectSummary, String> {
+        let (tip_height, tip_hash) = self.current_disconnect_tip()?;
+        if tip_hash != stored.lookup_hash {
+            return Err("disconnect block is not current canonical tip".into());
+        }
+        let undo = self
+            .block_store
+            .as_ref()
+            .ok_or("sync engine has no blockstore")?
+            .get_undo(tip_hash)?;
+        let new_tip_timestamp = self.parent_timestamp(tip_height, stored)?;
         let rollback = self.capture_rollback_state();
-
-        // Determine the parent timestamp for updating tip_timestamp after
-        // disconnect. Genesis block disconnect results in timestamp = 0.
-        let new_tip_timestamp = if tip_height > 0 {
-            let parent_header_bytes = block_store.get_header_by_hash(pb.header.prev_block_hash)?;
-            let parent_header =
-                parse_block_header_bytes(&parent_header_bytes).map_err(|e| e.to_string())?;
-            parent_header.timestamp
-        } else {
-            0
-        };
-
-        let summary = self.chain_state.disconnect_block(&block_bytes, &undo)?;
+        let summary = self
+            .chain_state
+            .disconnect_verified_stored_block(stored, &undo)?;
 
         // Truncate canonical index FIRST, then persist chain state — matching
         // Go DisconnectTip ordering (B.7 fix, issue #1170).  A crash between
@@ -156,35 +311,41 @@ impl SyncEngine {
         &mut self,
         common_ancestor_height: u64,
     ) -> Result<Vec<Vec<u8>>, String> {
+        let mut preview_state = self.chain_state.clone();
+        let prepared =
+            self.prepare_canonical_disconnect_packet(&mut preview_state, common_ancestor_height)?;
+        Ok(self
+            .disconnect_prepared_canonical_to_ancestor(prepared)?
+            .into_iter()
+            .map(|stored| stored.block_bytes)
+            .collect())
+    }
+
+    fn prepare_canonical_disconnect_packet(
+        &self,
+        preview_state: &mut ChainState,
+        common_ancestor_height: u64,
+    ) -> Result<Vec<VerifiedStoredBlock>, String> {
         self.mutation_allowed()?;
-        let (mut current_height, _) = self
+        let (tip_height, _) = self.current_disconnect_tip()?;
+        if common_ancestor_height >= tip_height {
+            return Ok(Vec::new());
+        }
+        let block_store = self
             .block_store
             .as_ref()
-            .ok_or("sync engine has no blockstore")?
-            .tip()?
-            .ok_or("blockstore has no canonical tip")?;
-
-        let mut disconnected_blocks = Vec::new();
-        while current_height > common_ancestor_height {
-            let tip_hash = self
-                .block_store
-                .as_ref()
-                .ok_or("sync engine has no blockstore")?
-                .tip()?
-                .ok_or("blockstore has no canonical tip")?
-                .1;
-
-            let block_bytes = self
-                .block_store
-                .as_ref()
-                .ok_or("sync engine has no blockstore")?
-                .get_block_by_hash(tip_hash)?;
-
-            disconnected_blocks.push(block_bytes);
-            self.disconnect_tip()?;
-            current_height -= 1;
+            .ok_or("sync engine has no blockstore")?;
+        let mut packet = Vec::new();
+        for height in ((common_ancestor_height + 1)..=tip_height).rev() {
+            let hash = block_store
+                .canonical_hash(height)?
+                .ok_or("blockstore has no canonical tip")?;
+            let stored =
+                load_verified_stored_block(block_store, hash).map_err(|err| err.render(hash))?;
+            packet.push(stored);
         }
-        Ok(disconnected_blocks)
+        self.preview_disconnect_packet(preview_state, &packet)?;
+        Ok(packet)
     }
 
     /// Non-mutating preview: disconnect a copy of chain state down to a common
@@ -193,36 +354,61 @@ impl SyncEngine {
         &self,
         preview_state: &mut ChainState,
         common_ancestor_height: u64,
-    ) -> Result<Vec<Vec<u8>>, String> {
+    ) -> Result<Vec<VerifiedStoredBlock>, String> {
+        self.prepare_canonical_disconnect_packet(preview_state, common_ancestor_height)
+    }
+
+    fn preview_disconnect_packet(
+        &self,
+        state: &mut ChainState,
+        packet: &[VerifiedStoredBlock],
+    ) -> Result<(), String> {
         let block_store = self
             .block_store
             .as_ref()
             .ok_or("sync engine has no blockstore")?;
-
-        let mut current_height = preview_state.height;
-        let mut disconnected_blocks = Vec::new();
-
-        while current_height > common_ancestor_height {
-            let tip_hash = preview_state.tip_hash;
-            let block_bytes = block_store.get_block_by_hash(tip_hash)?;
-            let undo = block_store.get_undo(tip_hash)?;
-            preview_state.disconnect_block(&block_bytes, &undo)?;
-            disconnected_blocks.push(block_bytes);
-            current_height -= 1;
+        for stored in packet {
+            let undo = block_store.get_undo(stored.lookup_hash)?;
+            state.disconnect_verified_stored_block(stored, &undo)?;
         }
-        Ok(disconnected_blocks)
+        Ok(())
+    }
+
+    pub(crate) fn disconnect_prepared_canonical_to_ancestor(
+        &mut self,
+        packet: Vec<VerifiedStoredBlock>,
+    ) -> Result<Vec<VerifiedStoredBlock>, String> {
+        self.mutation_allowed()?;
+        let mut disconnected = Vec::with_capacity(packet.len());
+        for stored in packet {
+            self.disconnect_prepared_tip(&stored)?;
+            disconnected.push(stored);
+        }
+        Ok(disconnected)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use rubin_consensus::constants::POW_LIMIT;
+    use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
     use crate::blockstore::{block_store_path, BlockStore};
     use crate::chainstate::{chain_state_path, ChainState};
     use crate::io_utils::unique_temp_path;
     use crate::sync::{default_sync_config, SyncEngine};
-    use crate::test_helpers::{genesis_info, height_one_coinbase_only_block};
+    use crate::sync_reorg::BRANCH_STORE_CORRUPT_ERR;
+    use crate::test_helpers::{
+        coinbase_only_block_with_gen, genesis_info, height_one_coinbase_only_block,
+    };
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct DisconnectSnapshot {
+        state: ChainState,
+        tip: Option<(u64, [u8; 32])>,
+        index: Vec<[u8; 32]>,
+        timestamp: u64,
+    }
 
     fn engine_with_store(suffix: &str) -> (SyncEngine, std::path::PathBuf) {
         let dir = unique_temp_path(suffix);
@@ -231,6 +417,23 @@ mod tests {
         let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_path(&dir)));
         let engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("new sync");
         (engine, dir)
+    }
+
+    fn disconnect_snapshot(engine: &SyncEngine) -> DisconnectSnapshot {
+        let store = engine.block_store.as_ref().expect("blockstore");
+        DisconnectSnapshot {
+            state: engine.chain_state.clone(),
+            tip: store.tip().expect("tip"),
+            index: (0..store.canonical_len())
+                .map(|height| {
+                    store
+                        .canonical_hash(height as u64)
+                        .expect("canonical")
+                        .expect("hash")
+                })
+                .collect(),
+            timestamp: engine.tip_timestamp,
+        }
     }
 
     #[test]
@@ -299,6 +502,87 @@ mod tests {
         assert_eq!(engine.chain_state.tip_hash, genesis_hash);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn canonical_disconnect_packet_rejects_later_corruption_before_mutation() {
+        for (name, kind, malformed, want) in [
+            ("body", 'b', None, BRANCH_STORE_CORRUPT_ERR),
+            ("parent header missing", 'h', None, "read header"),
+            (
+                "parent header malformed",
+                'h',
+                Some(b"bad".as_slice()),
+                "block header length mismatch",
+            ),
+            ("tip undo missing", 'u', None, "read undo"),
+            (
+                "tip undo malformed",
+                'u',
+                Some(b"{".as_slice()),
+                "decode undo",
+            ),
+        ] {
+            let (mut engine, dir) = engine_with_store(&format!("rubin-disc-packet-{name}"));
+            let (genesis, genesis_hash, gen_ts) = genesis_info();
+            engine.apply_block(&genesis, None).expect("genesis");
+            let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+            engine.apply_block(&block1, None).expect("block 1");
+            let block1_hash = block_hash(&block1[..BLOCK_HEADER_BYTES]).expect("block 1 hash");
+            let subsidy = rubin_consensus::subsidy::block_subsidy(1, 0);
+            let block2 = coinbase_only_block_with_gen(2, subsidy, block1_hash, gen_ts + 2);
+            let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block 2 hash");
+            engine.apply_block(&block2, None).expect("block 2");
+            let before = disconnect_snapshot(&engine);
+            let packet = if kind != 'b' {
+                let mut preview = engine.chain_state.clone();
+                let packet = engine
+                    .preview_disconnect_canonical_to_ancestor(&mut preview, 0)
+                    .expect("preview");
+                assert_eq!(packet.len(), 2);
+                assert_eq!(preview.tip_hash, genesis_hash);
+                packet
+            } else {
+                Vec::new()
+            };
+            let (sidecar, extension, hash, bytes) = match kind {
+                'h' => ("headers", "bin", block1_hash, malformed.map(Vec::from)),
+                'u' => ("undo", "json", block2_hash, malformed.map(Vec::from)),
+                _ => {
+                    let mut corrupt = block1;
+                    corrupt[36] ^= 1;
+                    ("blocks", "bin", block1_hash, Some(corrupt))
+                }
+            };
+            let path = block_store_path(&dir).join(sidecar).join(format!(
+                "{}.{}",
+                hex::encode(hash),
+                extension
+            ));
+            match bytes {
+                Some(bytes) => std::fs::write(path, bytes).expect("overwrite sidecar"),
+                None => std::fs::remove_file(path).expect("remove sidecar"),
+            }
+            let err = if kind != 'b' {
+                engine
+                    .disconnect_prepared_canonical_to_ancestor(packet)
+                    .expect_err(name)
+            } else {
+                let mut preview = engine.chain_state.clone();
+                let preview_err = engine
+                    .preview_disconnect_canonical_to_ancestor(&mut preview, 0)
+                    .expect_err("preview must reject corrupt lower packet member");
+                assert!(preview_err.starts_with(BRANCH_STORE_CORRUPT_ERR));
+                assert_eq!(
+                    preview, before.state,
+                    "preview must not partially disconnect"
+                );
+                engine.disconnect_canonical_to_ancestor(0).expect_err(name)
+            };
+            assert!(err.contains(want), "{name}: {err}");
+            assert_eq!(disconnect_snapshot(&engine), before, "{name}: mutation");
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -1,7 +1,7 @@
 use rubin_consensus::{
-    block_hash, parse_block_bytes, parse_tx, read_compact_size_bytes,
-    validate_block_basic_with_context_at_height_and_rotation, Outpoint, ParsedBlock,
-    BLOCK_HEADER_BYTES,
+    block_hash, marshal_tx, parse_block_bytes, parse_tx, read_compact_size_bytes,
+    validate_block_basic_with_context_at_height_and_rotation, validate_stored_block_commitments,
+    Outpoint, ParsedBlock, BLOCK_HEADER_BYTES,
 };
 use std::collections::BTreeSet;
 use std::ops::Deref;
@@ -44,6 +44,88 @@ pub(crate) fn branch_store_corrupt(detail: String) -> String {
     format!("{BRANCH_STORE_CORRUPT_ERR}: {detail}")
 }
 
+/// One bounded stored-block read and the single parse of those exact bytes.
+/// The value is retained through canonical preview, commit, and requeue so a
+/// later filesystem change cannot alter an already-validated transition.
+#[derive(Clone, Debug)]
+pub(crate) struct VerifiedStoredBlock {
+    pub(crate) lookup_hash: [u8; 32],
+    pub(crate) block_bytes: Vec<u8>,
+    pub(crate) parsed: ParsedBlock,
+}
+
+pub(crate) enum StoredBlockLoadError {
+    NotFound,
+    Corrupt(String),
+}
+
+impl StoredBlockLoadError {
+    pub(crate) fn render(self, lookup_hash: [u8; 32]) -> String {
+        match self {
+            Self::NotFound => branch_store_corrupt(format!(
+                "stored block for {} is unreadable: not found",
+                hex::encode(lookup_hash)
+            )),
+            Self::Corrupt(err) => err,
+        }
+    }
+}
+
+/// Read, parse, hash-check, and validate one stored block. Every outcome but
+/// raw `NotFound` is rendered as local store corruption; the branch-walk
+/// wrapper below is the sole place that preserves parent-not-found semantics.
+pub(crate) fn load_verified_stored_block(
+    block_store: &BlockStore,
+    lookup_hash: [u8; 32],
+) -> Result<VerifiedStoredBlock, StoredBlockLoadError> {
+    let block_bytes = match block_store.read_block_file_by_hash(lookup_hash) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(StoredBlockLoadError::NotFound);
+        }
+        Err(err) => {
+            return Err(StoredBlockLoadError::Corrupt(branch_store_corrupt(
+                format!(
+                    "stored block for {} is unreadable: {err}",
+                    hex::encode(lookup_hash)
+                ),
+            )));
+        }
+    };
+    let parsed = parse_block_bytes(&block_bytes).map_err(|err| {
+        StoredBlockLoadError::Corrupt(branch_store_corrupt(format!(
+            "stored block for {} does not parse: {err}",
+            hex::encode(lookup_hash)
+        )))
+    })?;
+    let observed_hash = block_hash(&parsed.header_bytes).map_err(|err| {
+        StoredBlockLoadError::Corrupt(branch_store_corrupt(format!(
+            "stored block for {} does not hash: {err}",
+            hex::encode(lookup_hash)
+        )))
+    })?;
+    if observed_hash != lookup_hash {
+        return Err(StoredBlockLoadError::Corrupt(branch_store_corrupt(
+            format!(
+                "stored block for {} hashes to {}",
+                hex::encode(lookup_hash),
+                hex::encode(observed_hash)
+            ),
+        )));
+    }
+    validate_stored_block_commitments(&parsed).map_err(|err| {
+        StoredBlockLoadError::Corrupt(branch_store_corrupt(format!(
+            "stored block for {} has invalid commitments: {err}",
+            hex::encode(lookup_hash)
+        )))
+    })?;
+    Ok(VerifiedStoredBlock {
+        lookup_hash,
+        block_bytes,
+        parsed,
+    })
+}
+
 /// Reads one stored ancestor and PROVES it is the block that was asked for. A
 /// plain file read cannot: [`BlockStore::get_block_by_hash`] returns whatever
 /// bytes sit at the path named by the hash, so a corrupt — or hostile — datadir
@@ -60,39 +142,12 @@ pub(crate) fn branch_store_corrupt(detail: String) -> String {
 fn load_verified_branch_ancestor(
     block_store: &BlockStore,
     parent_hash: [u8; 32],
-) -> Result<(ParsedBlock, Vec<u8>), String> {
-    let parent_bytes = match block_store.read_block_file_by_hash(parent_hash) {
-        Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Err(PARENT_BLOCK_NOT_FOUND_ERR.to_string());
-        }
-        Err(err) => {
-            return Err(branch_store_corrupt(format!(
-                "stored block for {} is unreadable: {err}",
-                hex::encode(parent_hash)
-            )));
-        }
-    };
-    let parent_parsed = parse_block_bytes(&parent_bytes).map_err(|err| {
-        branch_store_corrupt(format!(
-            "stored block for {} does not parse: {err}",
-            hex::encode(parent_hash)
-        ))
-    })?;
-    let observed_hash = block_hash(&parent_parsed.header_bytes).map_err(|err| {
-        branch_store_corrupt(format!(
-            "stored block for {} does not hash: {err}",
-            hex::encode(parent_hash)
-        ))
-    })?;
-    if observed_hash != parent_hash {
-        return Err(branch_store_corrupt(format!(
-            "stored block for {} hashes to {}",
-            hex::encode(parent_hash),
-            hex::encode(observed_hash)
-        )));
+) -> Result<VerifiedStoredBlock, String> {
+    match load_verified_stored_block(block_store, parent_hash) {
+        Ok(stored) => Ok(stored),
+        Err(StoredBlockLoadError::NotFound) => Err(PARENT_BLOCK_NOT_FOUND_ERR.to_string()),
+        Err(err) => Err(err.render(parent_hash)),
     }
-    Ok((parent_parsed, parent_bytes))
 }
 
 /// One collected branch row built from an already-parsed block.
@@ -152,6 +207,11 @@ struct ReorgBranchBlock {
 pub struct TxPoolCleanupPlan {
     confirmed_txids: Vec<[u8; 32]>,
     conflicting_inputs: Vec<Outpoint>,
+    requeue_blocks: Vec<VerifiedStoredBlock>,
+    // Compatibility only for existing crate tests that construct a cleanup
+    // plan without a retained verified block. Production reorgs never use
+    // this hash-only shape and therefore never read the store during requeue.
+    #[cfg(test)]
     requeue_block_hashes: Vec<[u8; 32]>,
 }
 
@@ -220,9 +280,17 @@ impl TxPoolCleanupReport {
 
 impl TxPoolCleanupPlan {
     pub fn is_empty(&self) -> bool {
-        self.confirmed_txids.is_empty()
+        let is_empty = self.confirmed_txids.is_empty()
             && self.conflicting_inputs.is_empty()
-            && self.requeue_block_hashes.is_empty()
+            && self.requeue_blocks.is_empty();
+        #[cfg(test)]
+        {
+            is_empty && self.requeue_block_hashes.is_empty()
+        }
+        #[cfg(not(test))]
+        {
+            is_empty
+        }
     }
 
     pub fn apply(
@@ -258,13 +326,8 @@ impl TxPoolCleanupPlan {
             pool.remove_conflicting_outpoints(&self.conflicting_inputs);
         }
         if let Some(block_store) = block_store {
-            for block_hash in self.requeue_block_hashes.iter().rev() {
-                let Ok(block_bytes) = block_store.get_block_by_hash(*block_hash) else {
-                    report.requeue_blocks_unavailable =
-                        report.requeue_blocks_unavailable.saturating_add(1);
-                    continue;
-                };
-                let Ok(txs) = non_coinbase_tx_bytes(&block_bytes) else {
+            for stored in self.requeue_blocks.iter().rev() {
+                let Ok(txs) = non_coinbase_tx_bytes_from_parsed(&stored.parsed) else {
                     report.requeue_blocks_invalid = report.requeue_blocks_invalid.saturating_add(1);
                     continue;
                 };
@@ -294,10 +357,35 @@ impl TxPoolCleanupPlan {
                     }
                 }
             }
-        } else if !self.requeue_block_hashes.is_empty() {
+            #[cfg(test)]
+            for block_hash in self.requeue_block_hashes.iter().rev() {
+                let Ok(block_bytes) = block_store.get_block_by_hash(*block_hash) else {
+                    report.requeue_blocks_unavailable =
+                        report.requeue_blocks_unavailable.saturating_add(1);
+                    continue;
+                };
+                let Ok(txs) = non_coinbase_tx_bytes(&block_bytes) else {
+                    report.requeue_blocks_invalid = report.requeue_blocks_invalid.saturating_add(1);
+                    continue;
+                };
+                for tx_bytes in txs {
+                    report.record_requeue_attempt();
+                    match pool.add_tx_with_source(
+                        &tx_bytes,
+                        chain_state,
+                        Some(block_store),
+                        chain_id,
+                        TxSource::Reorg,
+                    ) {
+                        Ok(_) => report.record_requeue_accepted(),
+                        Err(err) => report.record_requeue_error(&err),
+                    }
+                }
+            }
+        } else {
             report.requeue_blocks_unavailable = report
                 .requeue_blocks_unavailable
-                .saturating_add(self.requeue_block_hashes.len());
+                .saturating_add(self.requeue_block_count());
         }
         report
     }
@@ -306,9 +394,23 @@ impl TxPoolCleanupPlan {
         self.confirmed_txids.append(&mut other.confirmed_txids);
         self.conflicting_inputs
             .append(&mut other.conflicting_inputs);
+        self.requeue_blocks.append(&mut other.requeue_blocks);
+        #[cfg(test)]
         self.requeue_block_hashes
             .append(&mut other.requeue_block_hashes);
         self
+    }
+
+    fn requeue_block_count(&self) -> usize {
+        let count = self.requeue_blocks.len();
+        #[cfg(test)]
+        {
+            count.saturating_add(self.requeue_block_hashes.len())
+        }
+        #[cfg(not(test))]
+        {
+            count
+        }
     }
 
     /// Build a cleanup plan from an already-parsed block. Crate-private
@@ -366,6 +468,7 @@ impl TxPoolCleanupPlan {
         Self {
             confirmed_txids,
             conflicting_inputs,
+            requeue_blocks: Vec::new(),
             requeue_block_hashes,
         }
     }
@@ -582,16 +685,21 @@ impl SyncEngine {
         let rollback = self.capture_reorg_rollback_state(common_ancestor_height);
 
         // Dry-run: preview the disconnect + reconnect on a cloned state.
-        let disconnected_blocks = self.prepare_preferred_branch(&branch, common_ancestor_height)?;
-        let reorg_depth = u64::try_from(disconnected_blocks.len()).unwrap_or(u64::MAX);
+        let prepared_disconnects =
+            self.prepare_preferred_branch(&branch, common_ancestor_height)?;
+        let reorg_depth = u64::try_from(prepared_disconnects.len()).unwrap_or(u64::MAX);
 
         // Disconnect canonical chain back to the common ancestor.
-        if let Err(err) = self.disconnect_canonical_to_ancestor(common_ancestor_height) {
-            return Err(Self::err_with_rollback(
-                err,
-                self.rollback_apply_block(rollback),
-            ));
-        }
+        let disconnected_blocks =
+            match self.disconnect_prepared_canonical_to_ancestor(prepared_disconnects) {
+                Ok(blocks) => blocks,
+                Err(err) => {
+                    return Err(Self::err_with_rollback(
+                        err,
+                        self.rollback_apply_block(rollback),
+                    ));
+                }
+            };
 
         // Connect the preferred branch.  Pass None so apply_block derives
         // fresh timestamps from the (updated) canonical index for each block,
@@ -647,7 +755,9 @@ impl SyncEngine {
                 .iter()
                 .flat_map(|item| non_coinbase_inputs(&item.block_bytes).unwrap_or_default())
                 .collect(),
-            requeue_block_hashes: collect_disconnected_block_hashes(&disconnected_blocks),
+            requeue_blocks: disconnected_blocks,
+            #[cfg(test)]
+            requeue_block_hashes: Vec::new(),
         };
 
         let mut summary = last_summary.ok_or_else(|| "reorg branch was empty".to_string())?;
@@ -667,7 +777,7 @@ impl SyncEngine {
         &self,
         branch: &[ReorgBranchBlock],
         common_ancestor_height: u64,
-    ) -> Result<Vec<Vec<u8>>, String> {
+    ) -> Result<Vec<VerifiedStoredBlock>, String> {
         let mut preview_state = self.chain_state.clone();
 
         let disconnected_blocks = self
@@ -781,11 +891,14 @@ impl SyncEngine {
 
             // Load the parent block from the side-chain store and prove it is
             // the block that was asked for.
-            let (parent_parsed, parent_bytes) =
-                load_verified_branch_ancestor(block_store, parent_hash)?;
-
-            branch.push(branch_row(parent_hash, &parent_parsed, parent_bytes));
-            parent_hash = parent_parsed.header.prev_block_hash;
+            let parent = load_verified_branch_ancestor(block_store, parent_hash)?;
+            let VerifiedStoredBlock {
+                lookup_hash,
+                block_bytes,
+                parsed,
+            } = parent;
+            parent_hash = parsed.header.prev_block_hash;
+            branch.push(branch_row(lookup_hash, &parsed, block_bytes));
         }
     }
 
@@ -812,19 +925,6 @@ impl SyncEngine {
 // ---------------------------------------------------------------------------
 // Mempool helpers
 // ---------------------------------------------------------------------------
-
-/// Track disconnected blocks by hash and re-load them from blockstore when
-/// applying mempool cleanup, instead of copying every tx into the cleanup plan.
-fn collect_disconnected_block_hashes(disconnected_blocks: &[Vec<u8>]) -> Vec<[u8; 32]> {
-    disconnected_blocks
-        .iter()
-        .filter_map(|block_bytes| {
-            parse_block_bytes(block_bytes)
-                .ok()
-                .and_then(|parsed| block_hash(&parsed.header_bytes).ok())
-        })
-        .collect()
-}
 
 /// Remove transactions confirmed in the given block from the mempool.
 #[cfg(test)]
@@ -861,9 +961,18 @@ fn non_coinbase_inputs(block_bytes: &[u8]) -> Result<Vec<Outpoint>, String> {
     Ok(outpoints)
 }
 
-/// Extract raw bytes for each non-coinbase transaction in a block.
-/// This avoids needing a marshal_tx function — we slice directly from
-/// the block bytes using parse_tx consumed lengths.
+/// Serialize each non-coinbase transaction from a retained parsed block.
+fn non_coinbase_tx_bytes_from_parsed(parsed: &ParsedBlock) -> Result<Vec<Vec<u8>>, String> {
+    parsed
+        .txs
+        .iter()
+        .skip(1)
+        .map(|tx| marshal_tx(tx).map_err(|err| err.to_string()))
+        .collect()
+}
+
+/// Extract non-coinbase transaction bytes from a raw block for test fixtures.
+#[cfg(test)]
 fn non_coinbase_tx_bytes(block_bytes: &[u8]) -> Result<Vec<Vec<u8>>, String> {
     if block_bytes.len() < BLOCK_HEADER_BYTES {
         return Err("block too short".into());
@@ -1643,16 +1752,38 @@ mod tests {
         let missing_parent = [0x5c_u8; 32];
         let second_hop = [0x5d_u8; 32];
         let honest_elsewhere = coinbase_only_block(1, [0x6a; 32], 10_000);
+        let mut bad_merkle = honest_elsewhere.clone();
+        bad_merkle[36] ^= 1;
+        let bad_merkle_hash = block_header_hash(&bad_merkle);
+        let mut parsed = parse_block_bytes(&honest_elsewhere).expect("parse stored block");
+        let mut coinbase = parsed.txs.remove(0);
+        coinbase
+            .outputs
+            .iter_mut()
+            .find(|out| out.covenant_type == rubin_consensus::constants::COV_TYPE_ANCHOR)
+            .expect("witness commitment")
+            .covenant_data[0] ^= 1;
+        let bad_witness_tx = marshal_tx(&coinbase).expect("marshal corrupt witness tx");
+        let (_, bad_witness_txid, _, _) = parse_tx(&bad_witness_tx).expect("parse corrupt tx");
+        let bad_witness = crate::test_helpers::build_block_bytes(
+            parsed.header.prev_block_hash,
+            rubin_consensus::merkle_root_txids(&[bad_witness_txid]).expect("merkle root"),
+            parsed.header.target,
+            parsed.header.timestamp,
+            &[bad_witness_tx],
+        );
+        let bad_witness_hash = block_header_hash(&bad_witness);
 
         // Each row plants files, then the walk is driven through the public
         // reorg entry with a candidate whose prev hash names the first file.
         type PlantedStoreFiles = Vec<([u8; 32], Vec<u8>)>;
-        let rows: Vec<(&str, PlantedStoreFiles)> = vec![
+        let rows: Vec<(&str, [u8; 32], PlantedStoreFiles)> = vec![
             (
                 // The former NON-TERMINATION reproduction: a stored file whose
                 // prev pointer names itself. Without verification the walk
                 // re-reads it forever.
                 "self-referencing stored ancestor",
+                missing_parent,
                 vec![(
                     missing_parent,
                     coinbase_only_block(1, missing_parent, 10_001),
@@ -1660,6 +1791,7 @@ mod tests {
             ),
             (
                 "two-file store cycle",
+                missing_parent,
                 vec![
                     (missing_parent, coinbase_only_block(1, second_hop, 10_002)),
                     (second_hop, coinbase_only_block(1, missing_parent, 10_003)),
@@ -1667,10 +1799,12 @@ mod tests {
             ),
             (
                 "stored ancestor present but unparseable",
+                missing_parent,
                 vec![(missing_parent, b"not a block at all".to_vec())],
             ),
             (
                 "real block truncated mid-encoding",
+                missing_parent,
                 vec![(
                     missing_parent,
                     honest_elsewhere[..honest_elsewhere.len() / 2].to_vec(),
@@ -1678,22 +1812,29 @@ mod tests {
             ),
             (
                 "well-formed block stored under another block's hash",
+                missing_parent,
                 vec![(missing_parent, honest_elsewhere.clone())],
+            ),
+            (
+                "stored ancestor with invalid merkle commitment",
+                bad_merkle_hash,
+                vec![(bad_merkle_hash, bad_merkle)],
+            ),
+            (
+                "stored ancestor with invalid witness commitment",
+                bad_witness_hash,
+                vec![(bad_witness_hash, bad_witness)],
             ),
         ];
 
-        for (index, (name, planted)) in rows.into_iter().enumerate() {
+        for (index, (name, parent_hash, planted)) in rows.into_iter().enumerate() {
             let (mut engine, dir, subsidy1, gen_ts) =
                 engine_with_canonical_tip(&format!("rubin-reorg-corrupt-{index}"));
             for (hash, bytes) in &planted {
                 plant_raw_store_block(&dir, *hash, bytes);
             }
-            let candidate = coinbase_only_block_with_gen(
-                2,
-                subsidy1,
-                missing_parent,
-                gen_ts + 20 + index as u64,
-            );
+            let candidate =
+                coinbase_only_block_with_gen(2, subsidy1, parent_hash, gen_ts + 20 + index as u64);
             let err = engine
                 .apply_block_with_reorg(&candidate, None)
                 .expect_err(name);
@@ -2588,6 +2729,7 @@ mod tests {
         let outcome = engine
             .apply_block_with_reorg(&block2_alt, None)
             .expect("reorg to heavier branch");
+        plant_raw_store_block(&dir, block1_hash, b"replaced after reorg preview");
         let report = outcome.tx_pool_cleanup.apply_with_report(
             &mut pool,
             &engine.chain_state,


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1050
- GitHub Issue mirror (non-authoritative): #2707

Refs: Q-SEC-XCLIENT-BRANCH-BODY-SUBSTITUTION-01

## Summary
- Verify stored-block lookup identity and complete transaction/witness commitment closure in Go and Rust before branch evaluation, canonical preview/disconnect, or requeue.
- Retain the exact verified bytes and parsed block across those paths so each logical body has one bounded read and one storage-integrity parse.

## Invariant
Before any local stored block can influence side ancestry, canonical preview or commit, or production requeue, its lookup hash must match the parsed header and its canonical coinbase shape, txid Merkle root, and witness commitment must validate in that order; failures remain peer-neutral local corruption before production mutation, while committed rows freshly read undo and parent-header sidecars before mutation.

## Scope
- Changed files: 14
- Surfaces: clients/go/consensus, clients/go/node, clients/rust/crates/rubin-consensus, clients/rust/crates/rubin-node
- Non-scope: Network consensus-validation order, persistent formats, fork-choice rules, peer policy, undo-record authentication, and unrelated mempool behavior.
- Consensus rules unchanged: Yes; both helpers reuse existing commitment rules and are not inserted into network admission ordering.
- SECTION_HASHES.json unchanged: Yes.
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "StoredBlock|Commitment|Witness" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "Reorg|Branch|Disconnect|CorruptStore|StoredBlock" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "StoredBlock|CorruptStore|BanScore|RelayedBlock" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus validate_stored_block_commitments -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race -timeout=20m -shuffle=on -count=1 -json ./...'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo nextest run --workspace --all-targets --test-threads num-cpus && cargo test --workspace --doc'` — PASS

## Follow-ups / Waivers
- None.
