### PR TITLE
RUB-1049: verify stored headers against chain-work lookup keys

### DIFF
--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -353,11 +353,11 @@ func (bs *BlockStore) ChainWork(tipHash [32]byte) (*big.Int, error) {
 	seen := make(map[[32]byte]struct{})
 	current := tipHash
 	for current != zero {
+		if _, exists := seen[current]; exists {
+			return nil, fmt.Errorf("%w: chain-work parent cycle at %x", errBranchStoreCorrupt, current)
+		}
 		if cached, ok := bs.cachedChainWork(current); ok {
 			return bs.chainWorkFromCachedBaseErr(tipHash, cached, hashes, targets)
-		}
-		if _, exists := seen[current]; exists {
-			return nil, errors.New("blockstore parent cycle")
 		}
 		seen[current] = struct{}{}
 		header, err := bs.chainWorkHeader(current)
@@ -396,7 +396,7 @@ func (bs *BlockStore) chainWorkFromCachedBase(tipHash [32]byte, cached *big.Int,
 func (bs *BlockStore) chainWorkFromRoot(hashes [][32]byte, targets [][32]byte) (*big.Int, error) {
 	total, err := consensus.ChainWorkFromTargets(targets)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: chain-work targets are invalid: %v", errBranchStoreCorrupt, err) //nolint:errorlint // %v keeps local corruption out of p2p's consensus-error chain.
 	}
 	if _, err := bs.accumulateChainWorkFromTargets(nil, hashes, targets); err != nil {
 		return nil, err
@@ -407,9 +407,27 @@ func (bs *BlockStore) chainWorkFromRoot(hashes [][32]byte, targets [][32]byte) (
 func (bs *BlockStore) chainWorkHeader(blockHash [32]byte) (consensus.BlockHeader, error) {
 	headerBytes, err := bs.GetHeaderByHash(blockHash)
 	if err != nil {
-		return consensus.BlockHeader{}, err
+		return consensus.BlockHeader{}, chainWorkHeaderCorruption(blockHash, "cannot be read", err)
 	}
-	return consensus.ParseBlockHeaderBytes(headerBytes)
+	header, err := consensus.ParseBlockHeaderBytes(headerBytes)
+	if err != nil {
+		return consensus.BlockHeader{}, chainWorkHeaderCorruption(blockHash, "does not parse", err)
+	}
+	observedHash, err := consensus.BlockHash(headerBytes)
+	if err != nil {
+		return consensus.BlockHeader{}, chainWorkHeaderCorruption(blockHash, "does not hash", err)
+	}
+	if observedHash != blockHash {
+		return consensus.BlockHeader{}, fmt.Errorf(
+			"%w: stored header for %x hashes to %x",
+			errBranchStoreCorrupt, blockHash, observedHash,
+		)
+	}
+	return header, nil
+}
+
+func chainWorkHeaderCorruption(blockHash [32]byte, reason string, err error) error {
+	return fmt.Errorf("%w: stored header for %x %s: %v", errBranchStoreCorrupt, blockHash, reason, err) //nolint:errorlint // %v keeps local corruption out of p2p's consensus-error chain.
 }
 
 func buildCanonicalHeightIndex(canonical []string) (map[[32]byte]uint64, error) {
@@ -485,13 +503,17 @@ func (bs *BlockStore) accumulateChainWorkFromTargets(base *big.Int, hashes [][32
 	if running == nil {
 		running = big.NewInt(0)
 	}
+	pending := make([]*big.Int, len(targets))
 	for i := len(targets) - 1; i >= 0; i-- {
 		work, err := consensus.WorkFromTarget(targets[i])
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: chain-work target for %x is invalid: %v", errBranchStoreCorrupt, hashes[i], err) //nolint:errorlint // %v keeps local corruption out of p2p's consensus-error chain.
 		}
 		running.Add(running, work)
-		bs.storeChainWorkIfCanonical(hashes[i], running)
+		pending[i] = cloneBigInt(running)
+	}
+	for i := len(pending) - 1; i >= 0; i-- {
+		bs.storeChainWorkIfCanonical(hashes[i], pending[i])
 	}
 	return cloneBigInt(running), nil
 }

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -423,6 +424,198 @@ func testHeaderBytes(seed byte, nonce uint64) []byte {
 	}
 	binary.LittleEndian.PutUint64(header[108:116], nonce)
 	return header
+}
+
+func putChainWorkHeader(t *testing.T, store *BlockStore, height uint64, prev [32]byte, seed byte, target [32]byte) [32]byte {
+	t.Helper()
+	header := testHeaderBytes(seed, uint64(seed))
+	copy(header[4:36], prev[:])
+	copy(header[76:108], target[:])
+	hash := mustHeaderHash(t, header)
+	if err := store.PutBlock(height, hash, header, []byte("chain-work-test")); err != nil {
+		t.Fatalf("PutBlock(%d): %v", height, err)
+	}
+	return hash
+}
+
+func mustChainWorkTestChain(t *testing.T) (*BlockStore, [3][32]byte) {
+	t.Helper()
+	store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+	var zero [32]byte
+	var hashes [3][32]byte
+	hashes[0] = putChainWorkHeader(t, store, 0, zero, 0x51, consensus.POW_LIMIT)
+	hashes[1] = putChainWorkHeader(t, store, 1, hashes[0], 0x52, consensus.POW_LIMIT)
+	hashes[2] = putChainWorkHeader(t, store, 2, hashes[1], 0x53, consensus.POW_LIMIT)
+	return store, hashes
+}
+
+func mustGetChainWorkHeader(t *testing.T, store *BlockStore, hash [32]byte) []byte {
+	t.Helper()
+	raw, err := store.GetHeaderByHash(hash)
+	if err != nil {
+		t.Fatalf("GetHeaderByHash(%x): %v", hash, err)
+	}
+	return raw
+}
+
+func assertChainWorkLocalCorruption(t *testing.T, work *big.Int, err error) {
+	t.Helper()
+	if work != nil || !errors.Is(err, errBranchStoreCorrupt) {
+		t.Fatalf("ChainWork=(%v,%v), want nil,errBranchStoreCorrupt", work, err)
+	}
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) {
+		t.Fatalf("local chain-work corruption leaked consensus.TxError: %v", err)
+	}
+}
+
+func TestBlockStoreChainWorkCacheRows(t *testing.T) {
+	want := big.NewInt(3) // POW_LIMIT contributes exactly one unit per header.
+	uncached, uncachedHashes := mustChainWorkTestChain(t)
+	if _, ok := uncached.cachedChainWork(uncachedHashes[2]); ok {
+		t.Fatal("fresh chain-work fixture unexpectedly has a cached tip")
+	}
+	got, err := uncached.ChainWork(uncachedHashes[2])
+	if err != nil || got.Cmp(want) != 0 {
+		t.Fatalf("uncached ChainWork=(%v,%v), want %s,nil", got, err, want)
+	}
+	partial, partialHashes := mustChainWorkTestChain(t)
+	if _, err := partial.ChainWork(partialHashes[1]); err != nil {
+		t.Fatalf("ChainWork(cached ancestor): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(partial.headersDir, hex.EncodeToString(partialHashes[1][:])+".bin"), []byte("corrupt cached ancestor"), 0o600); err != nil {
+		t.Fatalf("WriteFile(corrupt cached ancestor): %v", err)
+	}
+	got, err = partial.ChainWork(partialHashes[2])
+	if err != nil || got.Cmp(want) != 0 {
+		t.Fatalf("partial-cache ChainWork=(%v,%v), want %s,nil", got, err, want)
+	}
+	if err := os.WriteFile(filepath.Join(partial.headersDir, hex.EncodeToString(partialHashes[2][:])+".bin"), []byte("corrupt cached tip"), 0o600); err != nil {
+		t.Fatalf("WriteFile(corrupt cached tip): %v", err)
+	}
+	got.SetInt64(0)
+	got, err = partial.ChainWork(partialHashes[2])
+	if err != nil || got.Cmp(want) != 0 {
+		t.Fatalf("complete-cache ChainWork=(%v,%v), want %s,nil", got, err, want)
+	}
+	longStore := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "long-blockstore"))
+	const longCount = 33
+	var longTip [32]byte
+	for i := 0; i < longCount; i++ {
+		longTip = putChainWorkHeader(t, longStore, uint64(i), longTip, byte(i+1), consensus.POW_LIMIT)
+	}
+	longGot, err := longStore.ChainWork(longTip)
+	if err != nil || longGot.Cmp(big.NewInt(longCount)) != 0 {
+		t.Fatalf("long uncached ChainWork=(%v,%v), want %d,nil", longGot, err, longCount)
+	}
+}
+
+func TestBlockStoreChainWorkLocalCorruptionRows(t *testing.T) {
+	t.Run("missing_header", func(t *testing.T) {
+		store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+		work, err := store.ChainWork([32]byte{0x01})
+		assertChainWorkLocalCorruption(t, work, err)
+	})
+	t.Run("unreadable_existing_header", func(t *testing.T) {
+		store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+		hash := [32]byte{0x02}
+		if err := os.Mkdir(filepath.Join(store.headersDir, hex.EncodeToString(hash[:])+".bin"), 0o700); err != nil {
+			t.Fatalf("Mkdir(header leaf): %v", err)
+		}
+		work, err := store.ChainWork(hash)
+		assertChainWorkLocalCorruption(t, work, err)
+		if !strings.Contains(err.Error(), "cannot be read") {
+			t.Fatalf("unreadable header diagnostic=%v", err)
+		}
+	})
+	for _, tc := range []struct {
+		name string
+		at   int
+		raw  func(t *testing.T, store *BlockStore, hashes [3][32]byte) []byte
+	}{
+		{"substituted_head", 2, func(t *testing.T, store *BlockStore, hashes [3][32]byte) []byte {
+			return mustGetChainWorkHeader(t, store, hashes[1])
+		}},
+		{"substituted_middle", 1, func(t *testing.T, store *BlockStore, hashes [3][32]byte) []byte {
+			return mustGetChainWorkHeader(t, store, hashes[0])
+		}},
+		{"short_header", 2, func(t *testing.T, _ *BlockStore, _ [3][32]byte) []byte { return []byte{0x01} }},
+		{"long_header", 2, func(t *testing.T, _ *BlockStore, _ [3][32]byte) []byte {
+			return make([]byte, consensus.BLOCK_HEADER_BYTES+1)
+		}},
+		{"dual_invalid_substitution", 2, func(t *testing.T, _ *BlockStore, _ [3][32]byte) []byte {
+			raw := testHeaderBytes(0x44, 44)
+			clear(raw[76:108])
+			return raw
+		}},
+		{"identity_limited_cycle", 2, func(t *testing.T, store *BlockStore, hashes [3][32]byte) []byte {
+			raw := mustGetChainWorkHeader(t, store, hashes[2])
+			copy(raw[4:36], hashes[2][:])
+			return raw
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, hashes := mustChainWorkTestChain(t)
+			path := filepath.Join(store.headersDir, hex.EncodeToString(hashes[tc.at][:])+".bin")
+			if err := os.WriteFile(path, tc.raw(t, store, hashes), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s): %v", tc.name, err)
+			}
+			work, err := store.ChainWork(hashes[2])
+			assertChainWorkLocalCorruption(t, work, err)
+			if tc.name == "dual_invalid_substitution" && (!strings.Contains(err.Error(), "hashes to") || strings.Contains(err.Error(), "target")) {
+				t.Fatalf("dual-invalid diagnostic=%v, want identity mismatch before target ownership", err)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name   string
+		target [32]byte
+		limit  [32]byte
+	}{
+		{"zero_target", [32]byte{}, consensus.POW_LIMIT},
+		{"above_pow_limit", [32]byte{31: 2}, [32]byte{31: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previousLimit := consensus.POW_LIMIT
+			consensus.POW_LIMIT = tc.limit
+			t.Cleanup(func() { consensus.POW_LIMIT = previousLimit })
+			store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+			var zero [32]byte
+			hash := putChainWorkHeader(t, store, 0, zero, 0x61, tc.target)
+			work, err := store.ChainWork(hash)
+			assertChainWorkLocalCorruption(t, work, err)
+		})
+	}
+	for invalidAt, name := range []string{"rootward", "middle", "tip"} {
+		t.Run("failed_segment_does_not_publish_cache_"+name, func(t *testing.T) {
+			store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+			var zero [32]byte
+			root := putChainWorkHeader(t, store, 0, zero, 0x71, consensus.POW_LIMIT)
+			if _, err := store.ChainWork(root); err != nil {
+				t.Fatalf("ChainWork(root): %v", err)
+			}
+			var segment [3][32]byte
+			prev := root
+			for i := range segment {
+				target := consensus.POW_LIMIT
+				if i == invalidAt {
+					target = zero
+				}
+				segment[i] = putChainWorkHeader(t, store, uint64(i+1), prev, byte(0x72+i), target)
+				prev = segment[i]
+			}
+			work, err := store.ChainWork(segment[2])
+			assertChainWorkLocalCorruption(t, work, err)
+			if _, ok := store.cachedChainWork(root); !ok {
+				t.Fatal("cached ancestor disappeared after failed segment")
+			}
+			for _, hash := range segment {
+				if _, ok := store.cachedChainWork(hash); ok {
+					t.Fatalf("failed segment published cache entry for %x", hash)
+				}
+			}
+		})
+	}
 }
 
 // fresh datadir whose blockstore root does NOT exist yet.

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1346,6 +1347,77 @@ func TestRelayedCandidateWithCorruptStoredAncestorIsPeerNeutral(t *testing.T) {
 	var txErr *consensus.TxError
 	if errors.As(err, &txErr) {
 		t.Fatalf("local stored corruption leaked consensus error: %v", err)
+	}
+	if state := peer.snapshotState(); state.BanScore != 0 || state.LastError == "" {
+		t.Fatalf("peer state=%+v, want peer-neutral local diagnostic", state)
+	}
+	if sink.service.blockSeen.Has(b2Hash) {
+		t.Fatal("locally failed relayed candidate must not be marked seen")
+	}
+	afterHeight, afterTip, afterOK, err := sink.blockStore.Tip()
+	if err != nil || afterOK != beforeOK || afterHeight != beforeHeight || afterTip != beforeTip {
+		t.Fatalf("sink tip after: height=%d hash=%x ok=%v err=%v", afterHeight, afterTip, afterOK, err)
+	}
+}
+
+func TestRelayedHeavierCandidateWithCorruptStoredChainWorkHeaderIsPeerNeutral(t *testing.T) {
+	// The source's B2 is an honest two-block branch above the genesis common
+	// ancestor. Sink stores the valid B1 body/header as a side ancestor so the
+	// P2P relay reaches fork-choice, where the corrupted canonical genesis
+	// HEADER (not its full block body) is consumed by ChainWork.
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	b1Hash, b1Bytes := testHarnessBlockAtHeight(t, source, 1)
+	_, b2Bytes := testHarnessBlockAtHeight(t, source, 2)
+	_, b2Hash, err := parseRelayedBlock(b2Bytes)
+	if err != nil {
+		t.Fatalf("parseRelayedBlock(B2): %v", err)
+	}
+	candidateWork, err := source.blockStore.ChainWork(b2Hash)
+	if err != nil {
+		t.Fatalf("source ChainWork(B2): %v", err)
+	}
+	genesisWork, err := source.blockStore.ChainWork(node.DevnetGenesisBlockHash())
+	if err != nil || candidateWork.Cmp(genesisWork) <= 0 {
+		t.Fatalf("honest candidate work=%v genesis work=%v err=%v, want heavier branch", candidateWork, genesisWork, err)
+	}
+	b1Header, err := source.blockStore.GetHeaderByHash(b1Hash)
+	if err != nil {
+		t.Fatalf("GetHeaderByHash(B1): %v", err)
+	}
+	if err := sink.blockStore.StoreBlock(b1Hash, b1Header, b1Bytes); err != nil {
+		t.Fatalf("StoreBlock(side B1): %v", err)
+	}
+
+	genesisHash := node.DevnetGenesisBlockHash()
+	storedGenesis, err := sink.blockStore.GetBlockByHash(genesisHash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(genesis): %v", err)
+	}
+	parsedGenesis, err := consensus.ParseBlockBytes(storedGenesis)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(stored genesis): %v", err)
+	}
+	if bodyHash, err := consensus.BlockHash(parsedGenesis.HeaderBytes); err != nil || bodyHash != genesisHash {
+		t.Fatalf("stored genesis body identity=(%x,%v), want %x,nil", bodyHash, err, genesisHash)
+	}
+	headerPath := filepath.Join(node.BlockStorePath(sink.dataDir), "headers", hex.EncodeToString(genesisHash[:])+".bin")
+	if err := os.WriteFile(headerPath, b1Header, 0o600); err != nil {
+		t.Fatalf("WriteFile(substituted canonical header): %v", err)
+	}
+
+	peer := testPeerForService(sink.service, "remote", 2)
+	beforeHeight, beforeTip, beforeOK, err := sink.blockStore.Tip()
+	if err != nil || !beforeOK {
+		t.Fatalf("sink tip before: height=%d hash=%x ok=%v err=%v", beforeHeight, beforeTip, beforeOK, err)
+	}
+	summary, err := peer.processRelayedBlock(b2Bytes)
+	if err == nil || summary != nil || !strings.Contains(err.Error(), "stored header") {
+		t.Fatalf("processRelayedBlock(corrupt ChainWork header): summary=%v err=%v", summary, err)
+	}
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) {
+		t.Fatalf("local ChainWork header corruption leaked consensus.TxError: %v", err)
 	}
 	if state := peer.snapshotState(); state.BanScore != 0 || state.LastError == "" {
 		t.Fatalf("peer state=%+v, want peer-neutral local diagnostic", state)


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1049
- GitHub Issue mirror (non-authoritative): #2706

Refs: Q-SEC-GO-CHAINWORK-HEADER-VERIFY-01

## Summary
- Verify every uncached Go chain-work header against its lookup key before its target can contribute to work or enter the in-memory cache.
- Keep corrupt local-store failures peer-neutral and publish cache entries only after the complete uncached segment succeeds.

## Invariant
Every uncached header read from the local Go blockstore is canonically parsed and proven to hash to its lookup key before its target contributes to chainwork or enters the in-memory chainwork cache; every local-data failure remains peer-neutral and cannot surface as a consensus.TxError.

## Scope
- Changed files: 3
- Surfaces: clients/go/node, clients/go/node/p2p tests
- Non-scope: Rust implementation or parity, consensus target and fork-choice rules, persistent formats or checksums, wire bytes, and peer ban-score policy.
- Consensus rules unchanged: Yes; valid-header acceptance and chain-work arithmetic are unchanged, and the repair validates only locally stored bytes.
- SECTION_HASHES.json unchanged: Yes.
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "ChainWork|StoredHeader" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "ChainWork|StoredHeader|BanScore" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race -timeout=20m -shuffle=on -count=1 -json ./...'` — PASS

## Follow-ups / Waivers
- The analogous Rust local-store integrity behavior remains explicitly deferred to separate ownership before devnet-readiness closure; this Go-only PR makes no Rust parity claim.
