### PR TITLE
RUB-1087: verify Rust stored headers against chain-work lookup keys

### DIFF
--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use num_bigint::BigUint;
 use rubin_consensus::{
-    block_hash, chain_work_from_targets, parse_block_header_bytes, BLOCK_HEADER_BYTES,
+    block_hash, chain_work_from_targets, parse_block_header_bytes, BlockHeader, BLOCK_HEADER_BYTES,
 };
 use serde::{Deserialize, Serialize};
 
@@ -661,6 +661,37 @@ impl BlockStore {
 
     // ----- Chain work -----
 
+    /// Read and verify one bounded header used by [`BlockStore::chain_work`].
+    /// The parse and hash consume those exact bytes before any target or parent.
+    fn chain_work_header(&self, lookup_hash: [u8; 32]) -> Result<BlockHeader, String> {
+        let header_bytes = self.get_header_by_hash(lookup_hash).map_err(|err| {
+            format!(
+                "stored header for {} cannot be read: {err}",
+                hex::encode(lookup_hash)
+            )
+        })?;
+        let header = parse_block_header_bytes(&header_bytes).map_err(|err| {
+            format!(
+                "stored header for {} does not parse: {err}",
+                hex::encode(lookup_hash)
+            )
+        })?;
+        let observed_hash = block_hash(&header_bytes).map_err(|err| {
+            format!(
+                "stored header for {} does not hash: {err}",
+                hex::encode(lookup_hash)
+            )
+        })?;
+        if observed_hash != lookup_hash {
+            return Err(format!(
+                "stored header for {} hashes to {}",
+                hex::encode(lookup_hash),
+                hex::encode(observed_hash)
+            ));
+        }
+        Ok(header)
+    }
+
     /// Compute cumulative proof-of-work from genesis up to (and including)
     /// the block identified by `tip_hash`, by walking parent pointers.
     pub fn chain_work(&self, tip_hash: [u8; 32]) -> Result<BigUint, String> {
@@ -672,10 +703,12 @@ impl BlockStore {
         let mut current = tip_hash;
         while current != [0u8; 32] {
             if !seen.insert(current) {
-                return Err("blockstore parent cycle".into());
+                return Err(format!(
+                    "blockstore chain-work parent cycle at {}",
+                    hex::encode(current)
+                ));
             }
-            let header_bytes = self.get_header_by_hash(current)?;
-            let header = parse_block_header_bytes(&header_bytes).map_err(|e| e.to_string())?;
+            let header = self.chain_work_header(current)?;
             targets.push(header.target);
             current = header.prev_block_hash;
         }
@@ -1160,6 +1193,8 @@ mod tests {
     };
     use std::path::{Path, PathBuf};
 
+    use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
     use super::{
         block_store_path, read_file_by_path, write_file_if_absent, write_file_if_absent_with,
         BlockStore, BLOCK_FILE_MAX_BYTES, BLOCK_STORE_DIR_NAME, HEADER_FILE_MAX_BYTES,
@@ -1506,6 +1541,64 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    fn raw_chain_work_header(
+        prev_hash: [u8; 32],
+        target: [u8; 32],
+        seed: u64,
+    ) -> [u8; BLOCK_HEADER_BYTES] {
+        let mut header = [0u8; BLOCK_HEADER_BYTES];
+        header[..4].copy_from_slice(&1u32.to_le_bytes());
+        header[4..36].copy_from_slice(&prev_hash);
+        header[36..68].fill(seed as u8);
+        header[68..76].copy_from_slice(&seed.to_le_bytes());
+        header[76..108].copy_from_slice(&target);
+        header[108..].copy_from_slice(&seed.to_le_bytes());
+        header
+    }
+
+    fn write_chain_work_header(
+        store: &BlockStore,
+        prev_hash: [u8; 32],
+        target: [u8; 32],
+        seed: u64,
+    ) -> ([u8; 32], [u8; BLOCK_HEADER_BYTES]) {
+        let header = raw_chain_work_header(prev_hash, target, seed);
+        let hash = block_hash(&header).expect("chain-work header hash");
+        std::fs::write(
+            store.headers_dir.join(format!("{}.bin", hex::encode(hash))),
+            header,
+        )
+        .expect("write chain-work header");
+        (hash, header)
+    }
+
+    fn chain_work_test_chain() -> (
+        BlockStore,
+        PathBuf,
+        [[u8; 32]; 3],
+        [[u8; BLOCK_HEADER_BYTES]; 3],
+    ) {
+        let dir = unique_temp_path("rubin-blockstore-chain-work");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("create blockstore");
+        let (root_hash, root_header) =
+            write_chain_work_header(&store, [0u8; 32], rubin_consensus::constants::POW_LIMIT, 1);
+        let (middle_hash, middle_header) =
+            write_chain_work_header(&store, root_hash, rubin_consensus::constants::POW_LIMIT, 2);
+        let (tip_hash, tip_header) = write_chain_work_header(
+            &store,
+            middle_hash,
+            rubin_consensus::constants::POW_LIMIT,
+            3,
+        );
+        (
+            store,
+            dir,
+            [root_hash, middle_hash, tip_hash],
+            [root_header, middle_header, tip_header],
+        )
+    }
+
     #[test]
     fn blockstore_chain_work_from_genesis() {
         use crate::genesis::devnet_genesis_block_bytes;
@@ -1523,12 +1616,98 @@ mod tests {
             .expect("put");
 
         let work = store.chain_work(hash).expect("chain_work");
-        assert!(work > num_bigint::BigUint::ZERO);
+        assert_eq!(work, num_bigint::BigUint::from(1u8));
 
+        std::fs::remove_dir_all(root.join("headers")).expect("remove headers");
         let zero_work = store.chain_work([0u8; 32]).expect("zero");
         assert_eq!(zero_work, num_bigint::BigUint::ZERO);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn blockstore_chain_work_rejects_local_header_rows() {
+        let (store, dir, hashes, _) = chain_work_test_chain();
+        assert_eq!(
+            store.chain_work(hashes[2]).expect("multi-header work"),
+            num_bigint::BigUint::from(3u8)
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+
+        for name in [
+            "missing",
+            "unreadable",
+            "short",
+            "long",
+            "substituted_head",
+            "substituted_middle",
+            "identity_before_target",
+            "self_referential_substitution",
+            "zero_target",
+        ] {
+            let (store, dir, hashes, headers) = chain_work_test_chain();
+            let tip_path = store
+                .headers_dir
+                .join(format!("{}.bin", hex::encode(hashes[2])));
+            let (lookup, detail) = match name {
+                "missing" => {
+                    std::fs::remove_file(&tip_path).expect("remove header");
+                    (hashes[2], "cannot be read")
+                }
+                "unreadable" => {
+                    std::fs::remove_file(&tip_path).expect("remove header");
+                    std::fs::create_dir(&tip_path).expect("plant header directory");
+                    (hashes[2], "cannot be read")
+                }
+                "short" => {
+                    std::fs::write(&tip_path, [0u8; BLOCK_HEADER_BYTES - 1]).expect("write short");
+                    (hashes[2], "does not parse")
+                }
+                "long" => {
+                    std::fs::write(&tip_path, vec![0u8; BLOCK_HEADER_BYTES + 1])
+                        .expect("write long");
+                    (hashes[2], "cannot be read")
+                }
+                "substituted_head" => {
+                    std::fs::write(&tip_path, headers[1]).expect("substitute head");
+                    (hashes[2], "hashes to")
+                }
+                "substituted_middle" => {
+                    std::fs::write(
+                        store
+                            .headers_dir
+                            .join(format!("{}.bin", hex::encode(hashes[1]))),
+                        headers[0],
+                    )
+                    .expect("substitute middle");
+                    (hashes[2], "hashes to")
+                }
+                "identity_before_target" => {
+                    std::fs::write(&tip_path, raw_chain_work_header(hashes[1], [0u8; 32], 4))
+                        .expect("write dual-invalid header");
+                    (hashes[2], "hashes to")
+                }
+                "self_referential_substitution" => {
+                    std::fs::write(
+                        &tip_path,
+                        raw_chain_work_header(hashes[2], rubin_consensus::constants::POW_LIMIT, 5),
+                    )
+                    .expect("write self-referential header");
+                    (hashes[2], "hashes to")
+                }
+                "zero_target" => {
+                    let (hash, _) = write_chain_work_header(&store, hashes[1], [0u8; 32], 6);
+                    (hash, "target is zero")
+                }
+                _ => unreachable!("named chain-work row"),
+            };
+            let err = store.chain_work(lookup).expect_err(name);
+            assert!(err.contains(detail), "{name}: {err}");
+            if name == "identity_before_target" {
+                assert!(!err.contains("target is zero"), "identity must win: {err}");
+            }
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -7481,6 +7481,102 @@ mod tests {
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    #[test]
+    fn corrupt_chain_work_header_is_peer_neutral_for_honest_competing_tip() {
+        use crate::sync::{
+            next_candidate_block_for_test, retarget_block_for_test, stock_devnet_engine_for_test,
+        };
+        use crate::sync_reorg::BRANCH_STORE_CORRUPT_ERR;
+
+        let _metrics = orphan_pool_metrics_test_guard();
+        reset_orphan_pool_metrics_for_test();
+        let (mut engine, dir) = stock_devnet_engine_for_test("rubin-corrupt-chain-work", |_| {});
+        let genesis = engine.chain_state.tip_hash;
+        let canonical = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);
+        let canonical_hash = block_hash(&canonical[..BLOCK_HEADER_BYTES]).expect("canonical hash");
+        engine
+            .apply_block_with_reorg(&canonical, None)
+            .expect("apply canonical tip");
+
+        let competing = retarget_block_for_test(
+            coinbase_only_block_with_gen(1, 0, genesis, engine.tip_timestamp + 1),
+            POW_LIMIT,
+        );
+        let competing_hash = block_hash(&competing[..BLOCK_HEADER_BYTES]).expect("competing hash");
+        assert_ne!(
+            competing_hash, canonical_hash,
+            "fixture needs distinct tips"
+        );
+
+        let root = crate::blockstore::block_store_path(&dir);
+        let header_path = root
+            .join("headers")
+            .join(format!("{}.bin", hex::encode(canonical_hash)));
+        let block_path = root
+            .join("blocks")
+            .join(format!("{}.bin", hex::encode(canonical_hash)));
+        let stored_block = fs::read(&block_path).expect("read canonical block");
+        fs::write(&header_path, &competing[..BLOCK_HEADER_BYTES]).expect("substitute header only");
+        assert_eq!(
+            fs::read(&block_path).expect("re-read canonical block"),
+            stored_block,
+            "the full block is not part of this corruption row"
+        );
+
+        let before_height = engine.chain_state.height;
+        let before_tip = engine.chain_state.tip_hash;
+        let before_canonical_len = engine
+            .block_store
+            .as_ref()
+            .expect("blockstore")
+            .canonical_len();
+        let (mut session, _client) = test_peer_session();
+        let err = session
+            .handle_block(&competing, &mut engine)
+            .expect_err("chain-work corruption must surface");
+        let rendered = err.to_string();
+        let detail = format!(
+            "stored header for {} hashes to {}",
+            hex::encode(canonical_hash),
+            hex::encode(competing_hash)
+        );
+
+        assert!(rendered.starts_with(BRANCH_STORE_CORRUPT_ERR), "{rendered}");
+        assert!(
+            rendered.contains(&detail),
+            "missing chain-work detail: {rendered}"
+        );
+        assert_eq!(
+            session.state().ban_score,
+            0,
+            "local store fault is peer-neutral"
+        );
+        assert_eq!(
+            session.orphans.len(),
+            0,
+            "no orphan retention on corruption"
+        );
+        assert_eq!(
+            engine.chain_state.height, before_height,
+            "canonical height unchanged"
+        );
+        assert_eq!(
+            engine.chain_state.tip_hash, before_tip,
+            "canonical tip unchanged"
+        );
+        assert_eq!(
+            engine
+                .block_store
+                .as_ref()
+                .expect("blockstore")
+                .canonical_len(),
+            before_canonical_len,
+            "canonical index unchanged"
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
     /// The compact-relay gate, BOTH ways. Under the stock predicate the OPTIONAL
     /// static expected-target equality is skipped, so the reconstructed block
     /// reaches the authoritative apply path and is accepted with no ban; with ANY

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -651,8 +651,12 @@ impl SyncEngine {
             .ok_or("sync engine has no blockstore")?;
 
         let current_tip_hash = self.chain_state.tip_hash;
-        let current_work = block_store.chain_work(current_tip_hash)?;
-        let ancestor_work = block_store.chain_work(common_ancestor_hash)?;
+        let current_work = block_store
+            .chain_work(current_tip_hash)
+            .map_err(branch_store_corrupt)?;
+        let ancestor_work = block_store
+            .chain_work(common_ancestor_hash)
+            .map_err(branch_store_corrupt)?;
 
         let branch_targets: Vec<[u8; 32]> = branch.iter().map(|b| b.target).collect();
         let branch_work =
@@ -1739,6 +1743,60 @@ mod tests {
             .expect("block1 canonical");
         let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
         (engine, dir, subsidy1, gen_ts)
+    }
+
+    #[test]
+    fn should_switch_renders_each_chain_work_store_failure_once() {
+        let (engine, dir, _, gen_ts) = engine_with_canonical_tip("rubin-reorg-cw-tip");
+        let (_, genesis_hash, _) = genesis_info();
+        let competing = height_one_coinbase_only_block(genesis_hash, gen_ts + 2);
+        let competing_hash = block_header_hash(&competing);
+        let (branch, ancestor, _) = engine
+            .collect_branch_to_canonical(competing_hash, &competing)
+            .expect("collect honest competing branch");
+        let current_tip = engine.chain_state.tip_hash;
+        let headers = block_store_path(&dir).join("headers");
+        let genesis_header =
+            std::fs::read(headers.join(format!("{}.bin", hex::encode(genesis_hash))))
+                .expect("read genesis header");
+        std::fs::write(
+            headers.join(format!("{}.bin", hex::encode(current_tip))),
+            genesis_header,
+        )
+        .expect("substitute current-tip header");
+
+        let err = engine
+            .should_switch_to_branch(&branch, ancestor)
+            .expect_err("current-tip chain work must fail");
+        assert_branch_store_corruption(&err);
+        assert_eq!(err.matches(BRANCH_STORE_CORRUPT_ERR).count(), 1, "{err}");
+        assert!(err.contains("hashes to"), "{err}");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+
+        let (mut engine, dir) = engine_with_store("rubin-reorg-cw-ancestor");
+        let ancestor = [0x61; 32];
+        engine
+            .block_store
+            .as_mut()
+            .expect("blockstore")
+            .set_canonical_tip(0, ancestor)
+            .expect("set fabricated canonical ancestor");
+        let branch = [ReorgBranchBlock {
+            hash: [0x62; 32],
+            header_bytes: [0u8; BLOCK_HEADER_BYTES],
+            block_bytes: Vec::new(),
+            prev_hash: ancestor,
+            target: POW_LIMIT,
+            timestamp: 0,
+            txids: Vec::new(),
+        }];
+        let err = engine
+            .should_switch_to_branch(&branch, ancestor)
+            .expect_err("common-ancestor chain work must fail");
+        assert_branch_store_corruption(&err);
+        assert_eq!(err.matches(BRANCH_STORE_CORRUPT_ERR).count(), 1, "{err}");
+        assert!(err.contains("cannot be read"), "{err}");
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     /// Drives the branch walk against a block store whose files lie. NONE of


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1087
- GitHub Issue mirror (non-authoritative): #2773

Refs: Q-SEC-RUST-CHAINWORK-HEADER-VERIFY-01

## Summary
- Verify every Rust chain-work header against its lookup key before its target or parent can affect the walk.
- Reuse the existing local-corruption boundary at both fork-choice call sites and keep honest peers neutral when local header storage is inconsistent.

## Invariant
Every header loaded from the local Rust blockstore by `BlockStore::chain_work` is canonically parsed and proven to hash to its lookup key before its target contributes to cumulative work; every failure caused by local stored data remains peer-neutral.

## Scope
- Changed files: 3
- Surfaces: clients/rust
- Non-scope: Go, consensus target and fork-choice rules, chain-work caching, persistent formats, wire bytes, production P2P behavior, specification, conformance, formal, generated, and CI artifacts.
- Consensus rules unchanged: Yes; valid-header acceptance and chain-work arithmetic are unchanged, and the repair validates only locally stored bytes.
- SECTION_HASHES.json unchanged: Yes.
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --locked -p rubin-node chain_work -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --locked -p rubin-node branch_store -- --nocapture'` — PASS

## Follow-ups / Waivers
- An identity-valid SHA3 parent cycle and the single-read code shape are reviewed structurally; no injectable seam or fabricated dynamic-cycle fixture is introduced.
