### PR TITLE
[Q-CI-EXACT-DEDUP-01] Remove confirmed duplicate CI executions without weakening coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,11 +408,6 @@ jobs:
           cd clients/go
           test -z "$(gofmt -l .)"
 
-      - name: Go↔Rust live P2P interop
-        run: |
-          cd clients/go
-          RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop' -count=1
-
       - name: Conformance Go fmt
         run: |
           cd conformance
@@ -438,12 +433,6 @@ jobs:
           cd conformance
           go vet ./...
 
-      - name: Go govulncheck
-        run: |
-          cd clients/go
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-          "$(go env GOPATH)/bin/govulncheck" ./...
-
       - name: Rust fmt
         run: |
           cd clients/rust
@@ -458,28 +447,6 @@ jobs:
         run: |
           cd clients/rust
           cargo clippy --workspace --all-targets -- -D warnings
-
-      - name: Cache cargo-audit binary
-        id: cache-cargo-audit-test
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: ~/.cargo/bin/cargo-audit
-          key: cargo-audit-${{ runner.os }}-v0.21.2
-
-      - name: Install cargo-audit
-        if: steps.cache-cargo-audit-test.outputs.cache-hit != 'true'
-        run: cargo install cargo-audit@0.21.2 --locked
-
-      - name: Cargo audit
-        run: |
-          cd clients/rust
-          cargo audit --deny warnings
-
-      - name: Conformance matrix check
-        run: python3 tools/gen_conformance_matrix.py --check
-
-      - name: Conformance fixtures policy check
-        run: python3 tools/check_conformance_fixtures_policy.py
 
       - name: Simplicity corpora drift check
         run: python3 tools/gen_simplicity_encoding_corpus.py --check

--- a/scripts/node-runtime-total-parity-gate.sh
+++ b/scripts/node-runtime-total-parity-gate.sh
@@ -28,7 +28,7 @@ run_stage "Stage 4/8: live Go↔Rust devnet RPC parity smoke" \
   "${REPO_ROOT}/scripts/devnet-rpc-parity-smoke.sh"
 
 run_stage "Stage 5/8: live Go↔Rust P2P interop coverage" \
-  "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop_(GoDialRustServerHandshake|RustClientDialGoServerHandshake|RustServerPingGoClientPong|RustClientReceivesTxFromGo|RustClientSyncsFiveBlocksFromGo)$' -count=1"
+  "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop' -count=1"
 
 run_stage "Stage 6/8: Go relay + txpool lifecycle parity checks" \
   "${DEV_ENV}" -- bash -lc "cd '${GO_MODULE_ROOT}' && go test ./node/p2p -run '^(TestAnnounceTx|TestAnnounceTxMetadataError)$' -count=1 && go test ./node -run '^TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool$' -count=1"
@@ -81,7 +81,7 @@ report = {
         },
         {
             "name": "live_go_rust_p2p_interop",
-            "command": "RUBIN_P2P_INTEROP=1 go test ./node/p2p -run ^TestRustInterop_(GoDialRustServerHandshake|RustClientDialGoServerHandshake|RustServerPingGoClientPong|RustClientReceivesTxFromGo|RustClientSyncsFiveBlocksFromGo)$ -count=1",
+            "command": "RUBIN_P2P_INTEROP=1 go test ./node/p2p -run ^TestRustInterop -count=1",
         },
         {
             "name": "go_relay_and_txpool_lifecycle",


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1091
- GitHub Issue mirror (non-authoritative): #2781

Refs: Q-CI-EXACT-DEDUP-01

## Summary
Remove five confirmed duplicate executions from the general test job while retaining their existing authoritative security, sanity, and runtime-parity owners.

## Invariant
Each confirmed duplicate CI execution runs exactly once under its existing authoritative owner, with every unique check and tested case preserved.

## Scope
- Changed files: 2
- Surfaces: tooling
- Non-scope: Relevance gating, caching, required checks, triggers, permissions, unique validators, formal, coverage, race, jscpd, OpenSSL, security scanners, nightlies, soak, product code, and test code.
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc "cd clients/go && RUBIN_P2P_INTEROP=1 go test ./node/p2p -run '^TestRustInterop' -count=1"` — PASS

## Follow-ups / Waivers
- None