### PR TITLE
[Q-SIMPLICITY-OUTPUT-GROUP-CAP-RUST-REPAIR-01] Rust mirror: CORE_SIMPLICITY output same-CMR group cap live enforcement

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -34,6 +34,7 @@ pub const MIN_HTLC_PREIMAGE_BYTES: u64 = 16; // consensus security floor (Q-A287
 pub const MAX_HTLC_PREIMAGE_BYTES: u64 = 256;
 pub const MAX_SIMPLICITY_STATE_BYTES: u64 = 512;
 pub const SIMPLICITY_MAX_GROUP_INPUTS: usize = 8;
+pub const SIMPLICITY_MAX_GROUP_OUTPUTS: usize = 8;
 pub const MAX_VAULT_KEYS: u8 = 12;
 pub const MAX_VAULT_WHITELIST_ENTRIES: u16 = 1024;
 pub const MAX_MULTISIG_KEYS: u8 = 12;

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -16,23 +16,6 @@ use crate::suite_registry::{DefaultRotationProvider, RotationProvider};
 use crate::tx::{Tx, TxOutput};
 use crate::vault::{parse_multisig_covenant_data, parse_vault_covenant_data};
 
-fn validate_simplicity_output_group_cap(
-    simplicity_output_cmrs: &[[u8; 32]],
-) -> Result<(), TxError> {
-    let mut groups = HashMap::with_capacity(simplicity_output_cmrs.len());
-    for program_cmr in simplicity_output_cmrs {
-        let count = groups.entry(*program_cmr).or_insert(0usize);
-        *count += 1;
-        if *count > SIMPLICITY_MAX_GROUP_OUTPUTS {
-            return Err(TxError::new(
-                ErrorCode::TxErrCovenantTypeInvalid,
-                "CORE_SIMPLICITY same-cmr output group exceeds limit",
-            ));
-        }
-    }
-    Ok(())
-}
-
 /// Validates covenant structure at creation time. The `rotation` parameter
 /// controls which signature suites are valid for native covenant creation
 /// at the given block height. Pass `None` for the default pre-rotation
@@ -168,11 +151,48 @@ pub fn validate_tx_covenants_genesis(
         Ok(true)
     }
 
+    fn validate_core_simplicity_genesis_output(
+        out: &TxOutput,
+        block_height: u64,
+        rp: &dyn RotationProvider,
+    ) -> Result<[u8; 32], TxError> {
+        // Deployment activation must precede covenant_data parsing.
+        validate_core_simplicity_deployment_active(block_height, rp)
+            .and_then(|_| validate_core_simplicity_covenant_data(out.value, &out.covenant_data))
+            .and_then(|_| {
+                out.covenant_data
+                    .first_chunk::<32>()
+                    .copied()
+                    .ok_or(TxError::new(
+                        ErrorCode::TxErrCovenantTypeInvalid,
+                        "CORE_SIMPLICITY program_cmr parse failure",
+                    ))
+            })
+    }
+
+    fn validate_simplicity_output_group_cap(
+        simplicity_output_cmrs: &[[u8; 32]],
+    ) -> Result<(), TxError> {
+        let mut groups = HashMap::with_capacity(simplicity_output_cmrs.len());
+        simplicity_output_cmrs.iter().try_for_each(|program_cmr| {
+            let count = groups.entry(*program_cmr).or_insert(0usize);
+            *count += 1;
+            if *count > SIMPLICITY_MAX_GROUP_OUTPUTS {
+                return Err(TxError::new(
+                    ErrorCode::TxErrCovenantTypeInvalid,
+                    "CORE_SIMPLICITY same-cmr output group exceeds limit",
+                ));
+            }
+            Ok(())
+        })
+    }
+
     // Complete per-output validation in wire order before applying the
     // transaction-level same-program_cmr cap, so a later creation error wins.
     let mut simplicity_output_cmrs = Vec::new();
-    for out in &tx.outputs {
-        match out.covenant_type {
+    tx.outputs
+        .iter()
+        .try_for_each(|out| match out.covenant_type {
             COV_TYPE_P2PK | COV_TYPE_ANCHOR => {
                 validate_p2pk_anchor(out, block_height, rp).map(|_| ())
             }
@@ -183,19 +203,9 @@ pub fn validate_tx_covenants_genesis(
                 validate_stealth_da(out, tx.tx_kind).map(|_| ())
             }
             COV_TYPE_CORE_SIMPLICITY => {
-                // Mirrors Go: gate on the deployment being active first, then
-                // validate covenant_data structure. The default provider reports
-                // inactive, so creation stays fail-closed ("deployment not
-                // active") until a deployment is wired and threaded.
-                validate_core_simplicity_deployment_active(block_height, rp)?;
-                validate_core_simplicity_covenant_data(out.value, &out.covenant_data)?;
-                // The validator above has parsed the exact envelope, including
-                // its mandatory 32-byte program_cmr prefix, so this copy adds
-                // no fallible validation path or duplicate parse.
-                let mut program_cmr = [0u8; 32];
-                program_cmr.copy_from_slice(&out.covenant_data[..32]);
-                simplicity_output_cmrs.push(program_cmr);
-                Ok(())
+                validate_core_simplicity_genesis_output(out, block_height, rp).map(|program_cmr| {
+                    simplicity_output_cmrs.push(program_cmr);
+                })
             }
             COV_TYPE_RESERVED_FUTURE => Err(TxError::new(
                 ErrorCode::TxErrCovenantTypeInvalid,
@@ -205,8 +215,7 @@ pub fn validate_tx_covenants_genesis(
                 ErrorCode::TxErrCovenantTypeInvalid,
                 "unknown covenant_type",
             )),
-        }?;
-    }
+        })?;
 
     validate_simplicity_output_group_cap(&simplicity_output_cmrs)
 }

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use crate::constants::{
     COV_TYPE_ANCHOR, COV_TYPE_CORE_SIMPLICITY, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT,
     COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT,
     MAX_ANCHOR_PAYLOAD_SIZE, MAX_COVENANT_DATA_PER_OUTPUT, MAX_P2PK_COVENANT_DATA,
+    SIMPLICITY_MAX_GROUP_OUTPUTS,
 };
 use crate::error::{ErrorCode, TxError};
 use crate::htlc::parse_htlc_covenant_data;
@@ -12,6 +15,23 @@ use crate::stealth::parse_stealth_covenant_data;
 use crate::suite_registry::{DefaultRotationProvider, RotationProvider};
 use crate::tx::{Tx, TxOutput};
 use crate::vault::{parse_multisig_covenant_data, parse_vault_covenant_data};
+
+fn validate_simplicity_output_group_cap(
+    simplicity_output_cmrs: &[[u8; 32]],
+) -> Result<(), TxError> {
+    let mut groups = HashMap::with_capacity(simplicity_output_cmrs.len());
+    for program_cmr in simplicity_output_cmrs {
+        let count = groups.entry(*program_cmr).or_insert(0usize);
+        *count += 1;
+        if *count > SIMPLICITY_MAX_GROUP_OUTPUTS {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_SIMPLICITY same-cmr output group exceeds limit",
+            ));
+        }
+    }
+    Ok(())
+}
 
 /// Validates covenant structure at creation time. The `rotation` parameter
 /// controls which signature suites are valid for native covenant creation
@@ -148,6 +168,9 @@ pub fn validate_tx_covenants_genesis(
         Ok(true)
     }
 
+    // Complete per-output validation in wire order before applying the
+    // transaction-level same-program_cmr cap, so a later creation error wins.
+    let mut simplicity_output_cmrs = Vec::new();
     for out in &tx.outputs {
         match out.covenant_type {
             COV_TYPE_P2PK | COV_TYPE_ANCHOR => {
@@ -165,7 +188,14 @@ pub fn validate_tx_covenants_genesis(
                 // inactive, so creation stays fail-closed ("deployment not
                 // active") until a deployment is wired and threaded.
                 validate_core_simplicity_deployment_active(block_height, rp)?;
-                validate_core_simplicity_covenant_data(out.value, &out.covenant_data)
+                validate_core_simplicity_covenant_data(out.value, &out.covenant_data)?;
+                // The validator above has parsed the exact envelope, including
+                // its mandatory 32-byte program_cmr prefix, so this copy adds
+                // no fallible validation path or duplicate parse.
+                let mut program_cmr = [0u8; 32];
+                program_cmr.copy_from_slice(&out.covenant_data[..32]);
+                simplicity_output_cmrs.push(program_cmr);
+                Ok(())
             }
             COV_TYPE_RESERVED_FUTURE => Err(TxError::new(
                 ErrorCode::TxErrCovenantTypeInvalid,
@@ -178,5 +208,5 @@ pub fn validate_tx_covenants_genesis(
         }?;
     }
 
-    Ok(())
+    validate_simplicity_output_group_cap(&simplicity_output_cmrs)
 }

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -260,6 +260,90 @@ fn validate_block_basic_with_fees_core_simplicity_uses_rotation() {
 }
 
 #[test]
+fn validate_block_basic_core_simplicity_output_group_cap_coinbase() {
+    use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
+
+    struct SimplicityActive;
+    impl RotationProvider for SimplicityActive {
+        fn native_create_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_create_suites(h)
+        }
+        fn native_spend_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_spend_suites(h)
+        }
+        fn simplicity_active_at_height(&self, _h: u64) -> bool {
+            true
+        }
+    }
+
+    let height = 10u64;
+    let subsidy = crate::subsidy::block_subsidy(height, 0);
+    let cmr = [0x77; 32];
+    let coinbase_with = |output_count: usize| {
+        let mut covenant_data = cmr.to_vec();
+        crate::compactsize::encode_compact_size(0, &mut covenant_data);
+        let mut outputs = Vec::with_capacity(output_count + 1);
+        let output_count_u64 = u64::try_from(output_count).expect("test output count fits u64");
+        for index in 0..output_count {
+            outputs.push(TestOutput {
+                // Keep the full subsidy constraint live while every
+                // CORE_SIMPLICITY output remains nonzero.
+                value: if index == 0 {
+                    subsidy - (output_count_u64 - 1)
+                } else {
+                    1
+                },
+                covenant_type: COV_TYPE_CORE_SIMPLICITY,
+                covenant_data: covenant_data.clone(),
+            });
+        }
+        let witness_root = witness_merkle_root_wtxids(&[[0u8; 32]]).expect("witness root");
+        outputs.push(TestOutput {
+            value: 0,
+            covenant_type: COV_TYPE_ANCHOR,
+            covenant_data: witness_commitment_hash(witness_root).to_vec(),
+        });
+        coinbase_tx_with_outputs(height as u32, &outputs)
+    };
+    let mut prev = [0u8; 32];
+    prev[0] = 0xa8;
+    let target = [0xffu8; 32];
+    let block_with = |output_count: usize, nonce: u64| {
+        let coinbase = coinbase_with(output_count);
+        let (_tx, txid, _wtxid, _nonce) = parse_tx(&coinbase).expect("coinbase bytes");
+        let root = merkle_root_txids(&[txid]).expect("coinbase merkle root");
+        build_block_bytes(prev, root, target, nonce, &[coinbase])
+    };
+    let active = SimplicityActive;
+    let validate = |block: &[u8]| {
+        crate::validate_block_basic_with_context_and_fees_at_height_and_rotation(
+            block,
+            Some(prev),
+            Some(target),
+            height,
+            None,
+            0,
+            0,
+            Some(&active),
+        )
+    };
+
+    assert_eq!(
+        validate(&block_with(SIMPLICITY_MAX_GROUP_OUTPUTS, 59))
+            .expect("coinbase exactly at group cap must validate")
+            .tx_count,
+        1
+    );
+    assert_eq!(
+        validate(&block_with(SIMPLICITY_MAX_GROUP_OUTPUTS + 1, 60)).unwrap_err(),
+        crate::error::TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY same-cmr output group exceeds limit",
+        )
+    );
+}
+
+#[test]
 fn validate_block_basic_linkage_mismatch() {
     let tx = minimal_tx_bytes();
     let (_t, txid, _w, _n) = parse_tx(&tx).expect("tx");

--- a/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
@@ -1182,6 +1182,183 @@ fn apply_non_coinbase_tx_basic_workq_covenant_genesis_error() {
 }
 
 #[test]
+fn apply_non_coinbase_tx_basic_output_group_cap_atomic() {
+    use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
+
+    struct SimplicityActive;
+    impl RotationProvider for SimplicityActive {
+        fn native_create_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_create_suites(h)
+        }
+        fn native_spend_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_spend_suites(h)
+        }
+        fn simplicity_active_at_height(&self, _h: u64) -> bool {
+            true
+        }
+    }
+
+    let mut simplicity_covenant_data = [0x91; 32].to_vec();
+    crate::compactsize::encode_compact_size(0, &mut simplicity_covenant_data);
+    let simplicity_outputs = |count: usize| {
+        (0..count)
+            .map(|_| crate::tx::TxOutput {
+                value: 1,
+                covenant_type: COV_TYPE_CORE_SIMPLICITY,
+                covenant_data: simplicity_covenant_data.clone(),
+            })
+            .collect::<Vec<_>>()
+    };
+    let tx_with_outputs = |prev_txid: [u8; 32], output_count: usize| crate::tx::Tx {
+        version: 1,
+        tx_kind: 0,
+        tx_nonce: 1,
+        inputs: vec![p2pk_input(prev_txid)],
+        outputs: simplicity_outputs(output_count),
+        locktime: 0,
+        witness: vec![],
+        da_payload: vec![],
+        da_commit_core: None,
+        da_chunk_core: None,
+    };
+    let p2pk_prev_txid = [0xb1; 32];
+    let simplicity_prev_txid = [0xb2; 32];
+    let p2pk_covenant_data = valid_p2pk_covenant_data();
+    let cases = [
+        (
+            "P2PK input",
+            tx_with_outputs(p2pk_prev_txid, SIMPLICITY_MAX_GROUP_OUTPUTS + 1),
+            tx_with_outputs(p2pk_prev_txid, SIMPLICITY_MAX_GROUP_OUTPUTS),
+            HashMap::from([(
+                Outpoint {
+                    txid: p2pk_prev_txid,
+                    vout: 0,
+                },
+                UtxoEntry {
+                    value: 100,
+                    covenant_type: COV_TYPE_P2PK,
+                    covenant_data: p2pk_covenant_data,
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            )]),
+            crate::error::TxError::new(ErrorCode::TxErrParse, "witness underflow"),
+        ),
+        (
+            "CORE_SIMPLICITY input",
+            tx_with_outputs(simplicity_prev_txid, SIMPLICITY_MAX_GROUP_OUTPUTS + 1),
+            tx_with_outputs(simplicity_prev_txid, SIMPLICITY_MAX_GROUP_OUTPUTS),
+            HashMap::from([(
+                Outpoint {
+                    txid: simplicity_prev_txid,
+                    vout: 0,
+                },
+                UtxoEntry {
+                    value: 100,
+                    covenant_type: COV_TYPE_CORE_SIMPLICITY,
+                    covenant_data: simplicity_covenant_data.clone(),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            )]),
+            crate::error::TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_SIMPLICITY spend evaluation not enabled",
+            ),
+        ),
+    ];
+    let active = SimplicityActive;
+    let group_cap_error = crate::error::TxError::new(
+        ErrorCode::TxErrCovenantTypeInvalid,
+        "CORE_SIMPLICITY same-cmr output group exceeds limit",
+    );
+
+    for (label, over_cap, at_cap, utxos, control_error) in cases {
+        let before = utxos.clone();
+        let sequential = crate::utxo_basic::apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
+            &over_cap,
+            [0xc1; 32],
+            &utxos,
+            1,
+            0,
+            0,
+            ZERO_CHAIN_ID,
+            Some(&active),
+            None,
+        );
+        match sequential {
+            Ok((work, summary)) => {
+                panic!("{label}: expected no work or summary, got {work:?} / {summary:?}")
+            }
+            Err(error) => assert_eq!(error, group_cap_error, "{label}: sequential error"),
+        }
+        assert_eq!(utxos, before, "{label}: sequential rejection mutated UTXOs");
+
+        assert_eq!(
+            crate::utxo_basic::apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
+                &at_cap,
+                [0xc2; 32],
+                &utxos,
+                1,
+                0,
+                0,
+                ZERO_CHAIN_ID,
+                Some(&active),
+                None,
+            )
+            .unwrap_err(),
+            control_error,
+            "{label}: exactly-at-cap control must reach input validation",
+        );
+
+        let mut queue = crate::sig_queue::SigCheckQueue::new(1);
+        let empty_mark = queue.mark();
+        queue
+            .push(
+                SUITE_ID_ML_DSA_87,
+                &[0x11],
+                &[0x22],
+                [0x33; 32],
+                crate::error::TxError::new(ErrorCode::TxErrSigInvalid, "dummy prefix task"),
+            )
+            .expect("seed deterministic queued prefix");
+        let prefix_mark = queue.mark();
+        let prefix_len = queue.len();
+        let prefix_debug = format!("{queue:?}");
+        assert_eq!(prefix_len, 1, "{label}: queued prefix was not seeded");
+        match crate::utxo_basic::apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_queued_sigchecks(
+            &over_cap,
+            [0xc3; 32],
+            &utxos,
+            1,
+            0,
+            0,
+            ZERO_CHAIN_ID,
+            Some(&active),
+            None,
+            &mut queue,
+        ) {
+            Ok((work, summary)) => {
+                panic!("{label}: expected no queued work or summary, got {work:?} / {summary:?}")
+            }
+            Err(error) => assert_eq!(error, group_cap_error, "{label}: queued error"),
+        }
+        assert_eq!(utxos, before, "{label}: queued rejection mutated UTXOs");
+        assert_eq!(queue.mark(), prefix_mark, "{label}: queue mark changed");
+        assert_eq!(queue.len(), prefix_len, "{label}: queue length changed");
+        assert_eq!(
+            format!("{queue:?}"),
+            prefix_debug,
+            "{label}: queue state changed"
+        );
+        assert!(!queue.is_empty(), "{label}: queued prefix was cleared");
+        queue.rollback_to(empty_mark);
+        assert_eq!(queue.mark(), empty_mark, "{label}: queue cleanup mark");
+        assert!(queue.is_empty(), "{label}: queue cleanup failed");
+    }
+}
+
+#[test]
 fn apply_non_coinbase_tx_basic_workq_sighash_prehash_error() {
     let kp = kp_or_skip!();
     let cov_data = p2pk_covenant_data_for_pubkey(&kp.pubkey);

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::compactsize::encode_compact_size;
 use crate::constants::{
-    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_SIMPLICITY_STATE_BYTES, SIMPLICITY_WITNESS_SLOTS,
-    SUITE_ID_ML_DSA_87,
+    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, COV_TYPE_VAULT, MAX_SIMPLICITY_STATE_BYTES,
+    SIMPLICITY_MAX_GROUP_OUTPUTS, SIMPLICITY_WITNESS_SLOTS, SUITE_ID_ML_DSA_87,
 };
 use crate::error::ErrorCode;
 use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
@@ -161,6 +161,89 @@ fn genesis_deployment_gate() {
     let bad = tx_with_outputs(vec![simplicity_output(1, vec![0u8; 10])]);
     let e = crate::validate_tx_covenants_genesis(&bad, 10, Some(&active)).unwrap_err();
     assert!(err_msg(&e).contains("program_cmr parse failure"));
+}
+
+#[test]
+fn genesis_core_simplicity_output_group_cap() {
+    let active = ActiveSimplicity { active_from: 10 };
+    let same_cmr_outputs = |count: usize, program_cmr: [u8; 32]| {
+        (0..count)
+            .map(|_| simplicity_output(1, encode_simplicity_covenant_data(program_cmr, &[])))
+            .collect::<Vec<_>>()
+    };
+    let cmr = [0x55; 32];
+    let mut other_cmr = [0u8; 32];
+    other_cmr[0] = 0xaa;
+    let group_cap_error = crate::error::TxError::new(
+        ErrorCode::TxErrCovenantTypeInvalid,
+        "CORE_SIMPLICITY same-cmr output group exceeds limit",
+    );
+
+    let exact_cap = tx_with_outputs(same_cmr_outputs(SIMPLICITY_MAX_GROUP_OUTPUTS, cmr));
+    assert!(crate::validate_tx_covenants_genesis(&exact_cap, 10, Some(&active)).is_ok());
+
+    let over_cap = tx_with_outputs(same_cmr_outputs(SIMPLICITY_MAX_GROUP_OUTPUTS + 1, cmr));
+    assert_eq!(
+        crate::validate_tx_covenants_genesis(&over_cap, 10, Some(&active)).unwrap_err(),
+        group_cap_error
+    );
+
+    let mut distinct_groups = same_cmr_outputs(SIMPLICITY_MAX_GROUP_OUTPUTS, cmr);
+    distinct_groups.extend(same_cmr_outputs(SIMPLICITY_MAX_GROUP_OUTPUTS, other_cmr));
+    assert!(crate::validate_tx_covenants_genesis(
+        &tx_with_outputs(distinct_groups),
+        10,
+        Some(&active)
+    )
+    .is_ok());
+
+    // The cap is creation-side and does not require a CORE_SIMPLICITY input.
+    let mut p2pk_input = over_cap.clone();
+    p2pk_input.inputs.push(crate::tx::TxInput {
+        prev_txid: [0x33; 32],
+        prev_vout: 0,
+        script_sig: vec![],
+        sequence: 0,
+    });
+    assert_eq!(
+        crate::validate_tx_covenants_genesis(&p2pk_input, 10, Some(&active)).unwrap_err(),
+        group_cap_error
+    );
+
+    let later_output_error = crate::error::TxError::new(
+        ErrorCode::TxErrVaultParamsInvalid,
+        "CORE_VAULT value must be > 0",
+    );
+    let invalid_output = TxOutput {
+        value: 0,
+        covenant_type: COV_TYPE_VAULT,
+        covenant_data: vec![],
+    };
+    let single_invalid = tx_with_outputs(vec![invalid_output.clone()]);
+    assert_eq!(
+        crate::validate_tx_covenants_genesis(&single_invalid, 10, Some(&active)).unwrap_err(),
+        later_output_error
+    );
+    let mut over_cap_then_invalid = same_cmr_outputs(SIMPLICITY_MAX_GROUP_OUTPUTS + 1, cmr);
+    over_cap_then_invalid.push(invalid_output);
+    assert_eq!(
+        crate::validate_tx_covenants_genesis(
+            &tx_with_outputs(over_cap_then_invalid),
+            10,
+            Some(&active),
+        )
+        .unwrap_err(),
+        later_output_error
+    );
+
+    // An inactive deployment remains the first rejection, before cap counting.
+    assert_eq!(
+        crate::validate_tx_covenants_genesis(&over_cap, 10, None).unwrap_err(),
+        crate::error::TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY deployment not active",
+        )
+    );
 }
 
 fn utxo_entry(covenant_type: u16) -> UtxoEntry {


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-595
- GitHub Issue mirror (non-authoritative): #2194

Refs: Q-SIMPLICITY-OUTPUT-GROUP-CAP-RUST-REPAIR-01

## Summary
- Mirror the merged Go same-CMR output-group rule in Rust creation validation: allow at most eight active CORE_SIMPLICITY outputs per program CMR.
- Complete all per-output creation checks in wire order before evaluating the group cap, preserving activation and later-output error precedence.
- Cover validator, coinbase block, sequential UTXO, and queued-signature paths with exact errors and rejection atomicity.
- Verify validator-before-insertion reachability for the three consensus TxOutput owners: utxo_basic.rs, precompute.rs, and connect_block_inmem.rs.

## Invariant
Rust collects a program CMR only after the corresponding active CORE_SIMPLICITY output passes complete creation validation. After every output has validated, a ninth output in one CMR group returns TxErrCovenantTypeInvalid with the canonical message, while later per-output errors and inactive deployment retain priority and rejection exposes no UTXO, work, summary, or queued-signature mutation.

## Scope
- Changed files: 5
- Surfaces: clients/rust
- Non-scope: Go, parsers and wire encoding, input-side group limits, Simplicity context construction or spend evaluation, activation threading, shared corpus, conformance, specification, Lean, formal manifests, and generated artifacts.
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus output_group_cap -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus simplicity -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'` — PASS

## Follow-ups / Waivers
- Existing owners remain RUB-606 for the shared live-spend corpus, RUB-694 for formal proof coverage, and RUB-731 for Rust activation threading.
- parity-exempt is intentional: RUB-595 is the Rust mirror of the already merged Go same-CMR output-group cap, and the live allowlist forbids Go edits.
- fixture-exempt is intentional: the frozen RUB-595 contract assigns shared conformance coverage to RUB-606 and forbids conformance edits in this Rust-only slice.

### Parity exemption justification
The matching Go production rule and tests are already merged. This PR brings Rust to the same threshold, activation behavior, error precedence, exact error, and atomic rejection semantics; modifying Go here would duplicate the landed slice and violate RUB-595 Rust-only scope.

### Fixture exemption justification
RUB-595 explicitly forbids conformance changes and assigns the downstream shared live-spend corpus to RUB-606. This PR supplies exact Rust public-path boundary, error-precedence, coinbase, sequential, and queued-state tests; shared cross-client fixture coverage remains with RUB-606 rather than being duplicated here.
