### PR TITLE
[Q-PRECOMPUTE-SEQUENTIAL-BOUNDARY-01] Align Go/Rust precompute state, first-error, and context isolation

### DIFF
--- a/clients/go/consensus/connect_block_parallel_precompute.go
+++ b/clients/go/consensus/connect_block_parallel_precompute.go
@@ -14,8 +14,13 @@ func addWitnessSlots(total, slots int) (int, error) {
 }
 
 // TxValidationContext holds the immutable, precomputed context for a single
-// non-coinbase transaction within a block. It is computed once against the
-// block-start UTXO snapshot and passed to read-only validation workers.
+// non-coinbase transaction within a block. The caller must provide a ParsedBlock
+// that completed canonical connect preflight, including coinbase structure and
+// locktime. The context covers the block-start UTXO snapshot plus the current
+// coinbase and earlier transactions and is intended for read-only worker
+// validation; PrecomputeTxContexts currently has no production caller.
+// The ParsedBlock and referenced Tx objects remain caller-owned and must stay
+// immutable for the lifetime of any returned context.
 //
 // Fields are intentionally value types or slices of value types to prevent
 // accidental aliasing of mutable consensus state.
@@ -24,16 +29,16 @@ type TxValidationContext struct {
 	// since index 0 is the coinbase).
 	TxIndex int
 
-	// Tx is a pointer to the parsed transaction. The Tx struct itself is
-	// treated as read-only after parsing.
+	// Tx is a pointer to a caller-owned parsed transaction. It must remain
+	// immutable for the lifetime of this context.
 	Tx *Tx
 
 	// Txid is the canonical transaction ID.
 	Txid [32]byte
 
 	// ResolvedInputs contains the UTXO entry for each input, in input order.
-	// Each entry is a snapshot taken from the block-start UTXO set. Workers
-	// MUST NOT modify these entries.
+	// Its UTXO bytes are detached from caller-owned storage, so the caller may
+	// mutate its snapshot after return. Workers MUST NOT modify these entries.
 	ResolvedInputs []UtxoEntry
 
 	// WitnessStart is the starting index into tx.Witness for this
@@ -68,14 +73,25 @@ type precomputeTxInputs struct {
 // non-coinbase transactions in a parsed block. It resolves inputs against the
 // provided block-start UTXO snapshot, computes witness slice boundaries using
 // the deterministic sequential cursor model, and precomputes sighash caches.
+// Precondition: pb completed canonical connect preflight, including coinbase
+// structure and locktime.
 //
-// The utxoSnapshot is NOT modified. Same-block output creation is tracked
-// internally to support parent-child dependencies (a later tx spending an
-// output created by an earlier tx in the same block).
+// During this call, the caller retains read-only ownership of utxoSnapshot. A
+// local overlay adds the current coinbase and earlier same-block outputs to
+// support parent-child dependencies. ParsedBlock and referenced Tx objects
+// remain caller-owned and must stay immutable for the lifetime of returned
+// contexts. Resolved UTXO bytes are detached, so the caller may mutate
+// utxoSnapshot after return. It repeats the connect path's non-coinbase
+// coinbase-like, nonce, and replay checks and validates output creation.
+// Contexts are intended for read-only workers, which validate resolved inputs;
+// this exported API currently has no production caller. Default chain and
+// rotation context match standalone.
 //
 // Returns an error if any input resolution, witness assignment, or value
-// conservation check fails. Error behavior matches the sequential path
-// exactly.
+// conservation check fails. With the default chain and rotation context, errors
+// owned by this precompute path (non-coinbase coinbase-like, nonce, and replay
+// checks; output creation; input resolution; witness boundaries; and value
+// conservation) preserve the corresponding sequential first-error order.
 func PrecomputeTxContexts(
 	pb *ParsedBlock,
 	utxoSnapshot map[Outpoint]UtxoEntry,
@@ -89,24 +105,44 @@ func PrecomputeTxContexts(
 		return nil, txerr(BLOCK_ERR_PARSE, "txids/txs length mismatch")
 	}
 
-	txCount := len(pb.Txs) - 1 // exclude coinbase
-	if txCount == 0 {
-		return nil, nil // coinbase-only block
-	}
-
 	overlay := make(map[Outpoint]UtxoEntry, len(utxoSnapshot))
 	for k, v := range utxoSnapshot {
 		overlay[k] = v
 	}
+	if err := applyInMemoryCoinbaseOutputs(pb, overlay, blockHeight, [32]byte{}, nil); err != nil {
+		return nil, err
+	}
+
+	if len(pb.Txs) == 1 {
+		return nil, nil // coinbase-only block
+	}
+	return precomputeNonCoinbaseTxContexts(pb, overlay, blockHeight)
+}
+
+func precomputeNonCoinbaseTxContexts(
+	pb *ParsedBlock,
+	overlay map[Outpoint]UtxoEntry,
+	blockHeight uint64,
+) ([]TxValidationContext, error) {
+	txCount := len(pb.Txs) - 1
 	results := make([]TxValidationContext, txCount)
+	seenNonces := make(map[uint64]struct{}, txCount)
 
 	for i := 1; i < len(pb.Txs); i++ {
+		if pb.Txs[i] == nil {
+			return nil, txerr(TX_ERR_PARSE, "nil tx")
+		}
+		if err := validateNonCoinbaseBlockTx(pb.Txs[i], seenNonces); err != nil {
+			return nil, err
+		}
 		ctx, err := precomputeTxContext(i, pb.Txs[i], pb.Txids[i], overlay, blockHeight)
 		if err != nil {
 			return nil, err
 		}
 		results[i-1] = ctx
-		updatePrecomputeOverlay(overlay, ctx, blockHeight)
+		if err := updatePrecomputeOverlay(overlay, ctx, blockHeight); err != nil {
+			return nil, err
+		}
 	}
 
 	return results, nil
@@ -118,6 +154,9 @@ func PrecomputeTxContexts(
 func precomputeTxPreChecks(tx *Tx, blockHeight uint64) error {
 	if tx == nil {
 		return txerr(TX_ERR_PARSE, "nil tx")
+	}
+	if tx.TxNonce == 0 {
+		return txerr(TX_ERR_TX_NONCE_INVALID, "tx_nonce must be >= 1 for non-coinbase")
 	}
 	if len(tx.Inputs) == 0 {
 		return txerr(TX_ERR_PARSE, "non-coinbase must have at least one input")
@@ -186,7 +225,7 @@ func collectPrecomputeTxInputs(
 		if err != nil {
 			return precomputeTxInputs{}, err
 		}
-		out.ResolvedInputs = append(out.ResolvedInputs, entry)
+		out.ResolvedInputs = append(out.ResolvedInputs, cloneUtxoEntry(entry))
 		out.InputOutpoints = append(out.InputOutpoints, op)
 		if out.SumIn, err = addU64ToU128(out.SumIn, entry.Value); err != nil {
 			return precomputeTxInputs{}, err
@@ -242,11 +281,11 @@ func rememberPrecomputeInput(op Outpoint, seenInputs map[Outpoint]struct{}) erro
 }
 
 func validatePrecomputeEntry(entry UtxoEntry, blockHeight uint64) error {
-	if entry.CreatedByCoinbase && (blockHeight < entry.CreationHeight || blockHeight-entry.CreationHeight < COINBASE_MATURITY) {
-		return txerr(TX_ERR_COINBASE_IMMATURE, "coinbase immature")
-	}
 	if entry.CovenantType == COV_TYPE_ANCHOR || entry.CovenantType == COV_TYPE_DA_COMMIT {
 		return txerr(TX_ERR_MISSING_UTXO, "attempt to spend non-spendable covenant")
+	}
+	if entry.CreatedByCoinbase && (blockHeight < entry.CreationHeight || blockHeight-entry.CreationHeight < COINBASE_MATURITY) {
+		return txerr(TX_ERR_COINBASE_IMMATURE, "coinbase immature")
 	}
 	return nil
 }
@@ -304,13 +343,16 @@ func updatePrecomputeOverlay(
 	overlay map[Outpoint]UtxoEntry,
 	ctx TxValidationContext,
 	blockHeight uint64,
-) {
+) error {
 	for _, op := range ctx.InputOutpoints {
 		delete(overlay, op)
 	}
 	for j, out := range ctx.Tx.Outputs {
 		if out.CovenantType == COV_TYPE_ANCHOR || out.CovenantType == COV_TYPE_DA_COMMIT {
 			continue
+		}
+		if uint64(j) > uint64(^uint32(0)) {
+			return txerr(TX_ERR_PARSE, "output index exceeds u32")
 		}
 		op := Outpoint{Txid: ctx.Txid, Vout: uint32(j)}
 		overlay[op] = UtxoEntry{
@@ -320,4 +362,5 @@ func updatePrecomputeOverlay(
 			CreationHeight: blockHeight,
 		}
 	}
+	return nil
 }

--- a/clients/go/consensus/connect_block_parallel_precompute_test.go
+++ b/clients/go/consensus/connect_block_parallel_precompute_test.go
@@ -472,16 +472,12 @@ func TestPrecomputeTxContexts_CoinbasePrevoutForbidden(t *testing.T) {
 
 	pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx})
 	_, err := PrecomputeTxContexts(pb, utxos, 100)
-	if err == nil {
-		t.Fatal("expected error for coinbase prevout in non-coinbase")
-	}
-	if !isTxErrCode(err, TX_ERR_PARSE) {
-		t.Fatalf("expected TX_ERR_PARSE, got: %v", err)
-	}
+	assertTxErrCodeMsg(t, err, TX_ERR_PARSE, "coinbase prevout encoding forbidden in non-coinbase")
 }
 
 func TestPrecomputeTxContexts_NonCoinbaseInputEncoding(t *testing.T) {
 	prevTxid := sha3_256([]byte("precompute-input-encoding"))
+	missingTxid := sha3_256([]byte("precompute-input-encoding-missing"))
 	utxos := map[Outpoint]UtxoEntry{
 		{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
 	}
@@ -498,14 +494,20 @@ func TestPrecomputeTxContexts_NonCoinbaseInputEncoding(t *testing.T) {
 		message string
 	}{
 		{
+			name:    "coinbase_prevout",
+			input:   TxInput{PrevVout: 0xffff_ffff},
+			code:    TX_ERR_PARSE,
+			message: "coinbase prevout encoding forbidden in non-coinbase",
+		},
+		{
 			name:    "script_sig",
-			input:   TxInput{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0, ScriptSig: []byte{0x01}},
+			input:   TxInput{PrevTxid: missingTxid, PrevVout: 0, Sequence: 0, ScriptSig: []byte{0x01}},
 			code:    TX_ERR_PARSE,
 			message: "script_sig must be empty under genesis covenant set",
 		},
 		{
 			name:    "sequence_high_bit",
-			input:   TxInput{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0x8000_0000},
+			input:   TxInput{PrevTxid: missingTxid, PrevVout: 1, Sequence: 0x8000_0000},
 			code:    TX_ERR_SEQUENCE_INVALID,
 			message: "sequence exceeds 0x7fffffff",
 		},
@@ -519,10 +521,23 @@ func TestPrecomputeTxContexts_NonCoinbaseInputEncoding(t *testing.T) {
 			}
 			pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx})
 
-			_, err := PrecomputeTxContexts(pb, utxos, 100)
+			_, err := PrecomputeTxContexts(pb, nil, 100)
 			assertTxErrCodeMsg(t, err, tc.code, tc.message)
 		})
 	}
+
+	t.Run("sequence_max", func(t *testing.T) {
+		tx := &Tx{
+			Version: 1, TxKind: 0x00, TxNonce: 1,
+			Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0x7fff_ffff}},
+			Outputs: []TxOutput{{Value: 50, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+			Witness: []WitnessItem{dummyWitness},
+		}
+		contexts, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx}), utxos, 100)
+		if err != nil || len(contexts) != 1 {
+			t.Fatalf("sequence 0x7fffffff: contexts=%d err=%v", len(contexts), err)
+		}
+	})
 }
 
 func TestPrecomputeTxContexts_NilTx(t *testing.T) {
@@ -760,5 +775,146 @@ func TestAddWitnessSlots_Overflow(t *testing.T) {
 	_, err = addWitnessSlots(maxInt-10, 20)
 	if err == nil {
 		t.Fatal("expected overflow error")
+	}
+}
+
+func precomputeP2PKSpendForTest(nonce uint64, input TxInput, outputValue uint64) *Tx {
+	return &Tx{
+		Version: 1, TxKind: 0x00, TxNonce: nonce,
+		Inputs:  []TxInput{input},
+		Outputs: []TxOutput{{Value: outputValue, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+		Witness: []WitnessItem{{
+			SuiteID:   SUITE_ID_ML_DSA_87,
+			Pubkey:    make([]byte, ML_DSA_87_PUBKEY_BYTES),
+			Signature: make([]byte, ML_DSA_87_SIG_BYTES+1),
+		}},
+	}
+}
+
+func TestPrecomputeTxContexts_CoinbaseOverlay(t *testing.T) {
+	const height = uint64(100)
+	coinbaseTxid := sha3_256([]byte{0})
+
+	t.Run("current_spendable_output_is_immature", func(t *testing.T) {
+		collision := Outpoint{Txid: coinbaseTxid, Vout: 0}
+		collisionData := validP2PKCovenantData()
+		utxos := map[Outpoint]UtxoEntry{collision: {Value: 77, CovenantType: COV_TYPE_P2PK, CovenantData: collisionData}}
+		tx := precomputeP2PKSpendForTest(1, TxInput{PrevTxid: coinbaseTxid, PrevVout: 0}, 1)
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx}), utxos, height)
+		assertTxErrCodeMsg(t, err, TX_ERR_COINBASE_IMMATURE, "coinbase immature")
+		if got := utxos[collision]; got.Value != 77 || string(got.CovenantData) != string(collisionData) {
+			t.Fatalf("caller snapshot collision mutated: %#v", got)
+		}
+	})
+
+	t.Run("anchor_is_not_inserted", func(t *testing.T) {
+		coinbase := makeSimpleCoinbase()
+		coinbase.Outputs = append(coinbase.Outputs, TxOutput{Value: 0, CovenantType: COV_TYPE_ANCHOR, CovenantData: []byte{1}})
+		tx := precomputeP2PKSpendForTest(1, TxInput{PrevTxid: coinbaseTxid, PrevVout: 1}, 1)
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(coinbase, []*Tx{tx}), nil, height)
+		assertTxErrCodeMsg(t, err, TX_ERR_MISSING_UTXO, "utxo not found")
+	})
+
+	t.Run("da_commit_is_rejected", func(t *testing.T) {
+		coinbase := makeSimpleCoinbase()
+		coinbase.Outputs = []TxOutput{{Value: 0, CovenantType: COV_TYPE_DA_COMMIT, CovenantData: make([]byte, 32)}}
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(coinbase, nil), nil, height)
+		assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT allowed only in tx_kind=0x01")
+	})
+}
+
+func TestPrecomputeTxContexts_CoinbaseApplyOutputOrder(t *testing.T) {
+	vault := TxOutput{Value: 1, CovenantType: COV_TYPE_VAULT, CovenantData: validVaultCovenantDataForP2PKOutput()}
+	invalid := TxOutput{Value: 0, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}
+	noInputs := &Tx{Version: 1, TxKind: 0, TxNonce: 1, Outputs: []TxOutput{invalid}}
+
+	for _, tc := range []struct {
+		name    string
+		outputs []TxOutput
+		txs     []*Tx
+		code    ErrorCode
+		message string
+	}{
+		{"vault_before_later_output", []TxOutput{vault, invalid}, nil, BLOCK_ERR_COINBASE_INVALID, "coinbase must not create CORE_VAULT outputs"},
+		{"output_before_vault", []TxOutput{invalid, vault}, nil, TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK value must be > 0"},
+		{"invalid_coinbase_before_invalid_tx1", []TxOutput{vault}, []*Tx{noInputs}, BLOCK_ERR_COINBASE_INVALID, "coinbase must not create CORE_VAULT outputs"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			coinbase := makeSimpleCoinbase()
+			coinbase.Outputs = tc.outputs
+			_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(coinbase, tc.txs), nil, 100)
+			assertTxErrCodeMsg(t, err, tc.code, tc.message)
+		})
+	}
+}
+
+func TestPrecomputeTxContexts_BlockEnvelopeOrder(t *testing.T) {
+	prev := sha3_256([]byte("precompute-envelope"))
+	inputOp := Outpoint{Txid: prev, Vout: 0}
+	utxos := map[Outpoint]UtxoEntry{inputOp: {Value: 2, CreationHeight: 7, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}}
+	input := TxInput{PrevTxid: prev, PrevVout: 0}
+
+	t.Run("zero_nonce_zero_inputs", func(t *testing.T) {
+		tx := &Tx{Version: 1, TxKind: 0, TxNonce: 0, Outputs: []TxOutput{{Value: 1, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}}}
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx}), utxos, 100)
+		assertTxErrCodeMsg(t, err, TX_ERR_TX_NONCE_INVALID, "tx_nonce must be >= 1 for non-coinbase")
+	})
+
+	t.Run("zero_nonce_with_input", func(t *testing.T) {
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{precomputeP2PKSpendForTest(0, input, 1)}), utxos, 100)
+		assertTxErrCodeMsg(t, err, TX_ERR_TX_NONCE_INVALID, "tx_nonce must be >= 1 for non-coinbase")
+	})
+
+	t.Run("duplicate_nonce", func(t *testing.T) {
+		txs := []*Tx{precomputeP2PKSpendForTest(1, input, 1), precomputeP2PKSpendForTest(1, input, 1)}
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), txs), utxos, 100)
+		assertTxErrCodeMsg(t, err, TX_ERR_NONCE_REPLAY, "duplicate tx_nonce in block")
+	})
+
+	t.Run("coinbase_like_at_index_one", func(t *testing.T) {
+		coinbaseLike := makeSimpleCoinbase()
+		coinbaseLike.Inputs[0].Sequence = ^uint32(0)
+		_, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{coinbaseLike}), utxos, 100)
+		assertTxErrCodeMsg(t, err, BLOCK_ERR_COINBASE_INVALID, "coinbase-like tx is only allowed at index 0")
+	})
+
+	t.Run("late_error_discards_contexts", func(t *testing.T) {
+		missing := TxInput{PrevTxid: sha3_256([]byte("precompute-late-missing")), PrevVout: 0}
+		before := cloneUtxoEntry(utxos[inputOp])
+		beforeLen := len(utxos)
+		contexts, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{
+			precomputeP2PKSpendForTest(1, input, 1), precomputeP2PKSpendForTest(2, missing, 1),
+		}), utxos, 100)
+		if contexts != nil {
+			t.Fatalf("returned %d partial contexts", len(contexts))
+		}
+		assertTxErrCodeMsg(t, err, TX_ERR_MISSING_UTXO, "utxo not found")
+		after, ok := utxos[inputOp]
+		if len(utxos) != beforeLen || !ok || after.Value != before.Value ||
+			after.CreationHeight != before.CreationHeight || after.CovenantType != before.CovenantType ||
+			after.CreatedByCoinbase != before.CreatedByCoinbase || string(after.CovenantData) != string(before.CovenantData) {
+			t.Fatalf("caller snapshot mutated after late error: before=%#v after=%#v len=%d", before, after, len(utxos))
+		}
+	})
+}
+
+func TestPrecomputeTxContexts_ContextDetachesSnapshotBytes(t *testing.T) {
+	const height = uint64(100)
+	prev := sha3_256([]byte("precompute-detached-bytes"))
+	op := Outpoint{Txid: prev, Vout: 0}
+	data := validP2PKCovenantData()
+	want := data[0]
+	utxos := map[Outpoint]UtxoEntry{op: {Value: 2, CovenantType: COV_TYPE_P2PK, CovenantData: data}}
+	contexts, err := PrecomputeTxContexts(makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{
+		precomputeP2PKSpendForTest(1, TxInput{PrevTxid: prev, PrevVout: 0}, 1),
+	}), utxos, height)
+	if err != nil {
+		t.Fatalf("precompute: %v", err)
+	}
+	entry := utxos[op]
+	entry.CovenantData[0] ^= 0xff
+	utxos[op] = entry
+	if got := contexts[0].ResolvedInputs[0].CovenantData[0]; got != want {
+		t.Fatalf("context bytes alias caller snapshot: got %x want %x", got, want)
 	}
 }

--- a/clients/rust/crates/rubin-consensus/src/precompute.rs
+++ b/clients/rust/crates/rubin-consensus/src/precompute.rs
@@ -7,12 +7,18 @@ use crate::constants::{
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
 use crate::simplicity_covenant::reject_core_simplicity_spend;
-use crate::utxo_basic::{Outpoint, UtxoEntry};
+use crate::tx::{Tx, TxInput, TxOutput};
+use crate::utxo_basic::{validate_non_coinbase_input_encoding, Outpoint, UtxoEntry};
 use crate::vault::witness_slots;
 
 /// Immutable, precomputed context for a single non-coinbase transaction within
-/// a block. Computed once against the block-start UTXO snapshot and passed to
-/// read-only validation workers.
+/// a block. The caller must provide a `ParsedBlock` that completed canonical
+/// connect preflight, including coinbase structure and locktime. The context
+/// covers the block-start UTXO snapshot plus the current coinbase and earlier
+/// transactions and is intended for read-only worker validation;
+/// [`precompute_tx_contexts`] currently has no production caller.
+/// `ParsedBlock` and its `Tx` objects remain caller-owned and must stay
+/// immutable for the lifetime of returned contexts.
 ///
 /// Fields are intentionally owned types to prevent accidental aliasing of
 /// mutable consensus state. The sighash cache is NOT stored here because
@@ -26,8 +32,9 @@ pub struct PrecomputedTxContext {
     pub tx_block_idx: usize,
     /// Canonical transaction identifier.
     pub txid: [u8; 32],
-    /// Resolved UTXO entry for each input, in input order. Snapshot values;
-    /// workers MUST NOT mutate these.
+    /// Resolved UTXO entry for each input, in input order. Its UTXO bytes are
+    /// detached from the caller snapshot, which the caller may mutate after
+    /// return. Workers MUST NOT mutate these values.
     pub resolved_inputs: Vec<UtxoEntry>,
     /// Starting index into `tx.witness` for this transaction's witness data.
     pub witness_start: usize,
@@ -47,17 +54,38 @@ pub(crate) fn add_witness_slots(total: usize, slots: usize) -> Result<usize, TxE
         .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "witness slot count overflow"))
 }
 
+struct CollectedPrecomputeInputs {
+    resolved_inputs: Vec<UtxoEntry>,
+    input_outpoints: Vec<Outpoint>,
+    total_witness_slots: usize,
+    sum_in: u128,
+    stopped_at_core_simplicity: bool,
+}
+
 /// Build an immutable [`PrecomputedTxContext`] slice for all non-coinbase
 /// transactions in a parsed block.
 ///
 /// Resolves inputs against the provided block-start UTXO snapshot, computes
 /// witness slice boundaries using the deterministic sequential cursor model,
 /// and validates value conservation.
+/// Precondition: `pb` completed canonical connect preflight, including coinbase
+/// structure and locktime.
 ///
-/// The `utxo_snapshot` is **not** modified. Same-block output creation is
-/// tracked internally to support parent-child dependencies.
+/// During this call, the caller retains read-only ownership of `utxo_snapshot`.
+/// A local overlay adds the current coinbase and earlier same-block outputs to
+/// support parent-child dependencies. `ParsedBlock` and its `Tx` objects remain
+/// caller-owned and must stay immutable for the lifetime of returned contexts.
+/// Resolved UTXO bytes are detached, so the caller may mutate `utxo_snapshot`
+/// after return. This API repeats the connect path's non-coinbase coinbase-like,
+/// nonce, and replay checks and validates output creation. Contexts are intended
+/// for read-only workers, which validate resolved inputs; this exported API
+/// currently has no production caller. Default chain and rotation context match
+/// the standalone path.
 ///
-/// Error behavior matches the sequential path exactly.
+/// With the default chain and rotation context, errors owned by this precompute
+/// path (non-coinbase coinbase-like, nonce, and replay checks; output creation;
+/// input resolution; witness boundaries; and value conservation) preserve the
+/// corresponding sequential first-error order.
 pub fn precompute_tx_contexts(
     pb: &ParsedBlock,
     utxo_snapshot: &HashMap<Outpoint, UtxoEntry>,
@@ -77,203 +105,240 @@ pub fn precompute_tx_contexts(
         ));
     }
 
-    let tx_count = pb.txs.len() - 1; // exclude coinbase
-    if tx_count == 0 {
-        return Ok(Vec::new()); // coinbase-only block
-    }
-
     // Working UTXO overlay: starts from immutable snapshot, tracks same-block
     // produced outputs. The original snapshot is never modified.
-    let mut overlay: HashMap<Outpoint, UtxoEntry> = HashMap::with_capacity(utxo_snapshot.len());
-    for (k, v) in utxo_snapshot {
-        overlay.insert(k.clone(), v.clone());
+    let mut overlay = utxo_snapshot.clone();
+    pb.apply_coinbase_outputs(&mut overlay, block_height, None)?;
+    if pb.txs.len() == 1 {
+        return Ok(Vec::new());
     }
+    precompute_non_coinbase_contexts(pb, &mut overlay, block_height)
+}
 
+fn precompute_non_coinbase_contexts(
+    pb: &ParsedBlock,
+    overlay: &mut HashMap<Outpoint, UtxoEntry>,
+    block_height: u64,
+) -> Result<Vec<PrecomputedTxContext>, TxError> {
+    let tx_count = pb.txs.len() - 1;
     let mut results = Vec::with_capacity(tx_count);
-    let zero_txid = [0u8; 32];
+    let mut seen_nonces = HashSet::with_capacity(tx_count);
 
     for i in 1..pb.txs.len() {
         let tx = &pb.txs[i];
         let txid = pb.txids[i];
 
-        if tx.inputs.is_empty() {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "non-coinbase must have at least one input",
-            ));
-        }
-
-        // Output covenant genesis must be validated here so the precompute/worker
-        // path matches the sequential path exactly. Workers (`validate_tx_local`)
-        // only validate inputs, so without this an output whose covenant is
-        // invalid at creation time (e.g. an unassigned 0x0102 CORE_EXT output)
-        // would be precomputed and reported valid even though sequential apply
-        // rejects it. Default rotation (`None`) mirrors the worker env.
-        validate_tx_covenants_genesis(tx, block_height, None)?;
-
-        // Resolve inputs and compute witness boundaries.
-        let mut resolved_inputs = Vec::with_capacity(tx.inputs.len());
-        let mut input_outpoints = Vec::with_capacity(tx.inputs.len());
-        let mut seen_inputs: HashSet<Outpoint> = HashSet::with_capacity(tx.inputs.len());
-        let mut total_witness_slots: usize = 0;
-        let mut sum_in: u128 = 0;
-        // Mirror Go's StoppedAtCoreSimplicity: a 0x0106 input contributes 0
-        // witness slots, relaxes the witness-count mismatch check, and triggers
-        // the dedicated spend reject after bound validation.
-        let mut stopped_at_core_simplicity = false;
-
-        for input in &tx.inputs {
-            // Coinbase prevout encoding forbidden in non-coinbase.
-            if input.prev_vout == 0xffff_ffff && input.prev_txid == zero_txid {
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "coinbase prevout encoding forbidden in non-coinbase",
-                ));
-            }
-
-            let op = Outpoint {
-                txid: input.prev_txid,
-                vout: input.prev_vout,
-            };
-
-            if !seen_inputs.insert(op.clone()) {
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "duplicate input outpoint",
-                ));
-            }
-
-            let entry = overlay
-                .get(&op)
-                .cloned()
-                .ok_or_else(|| TxError::new(ErrorCode::TxErrMissingUtxo, "utxo not found"))?;
-
-            // Early-reject immature coinbase outputs (defense-in-depth;
-            // also checked downstream in the sequential validation path).
-            if entry.created_by_coinbase
-                && (block_height < entry.creation_height
-                    || block_height - entry.creation_height < COINBASE_MATURITY)
-            {
-                return Err(TxError::new(
-                    ErrorCode::TxErrCoinbaseImmature,
-                    "coinbase immature",
-                ));
-            }
-
-            if entry.covenant_type == COV_TYPE_ANCHOR || entry.covenant_type == COV_TYPE_DA_COMMIT {
-                return Err(TxError::new(
-                    ErrorCode::TxErrMissingUtxo,
-                    "attempt to spend non-spendable covenant",
-                ));
-            }
-
-            if entry.covenant_type == COV_TYPE_CORE_SIMPLICITY {
-                // Mirror Go's early return (collectPrecomputeTxInputs): STOP
-                // resolving inputs at the first 0x0106 so no trailing input can
-                // surface a competing error ahead of the dedicated reject. The
-                // 0x0106 input contributes 0 witness slots; the reject is
-                // deferred until after the (mismatch-relaxed) bound check.
-                // `sum_in` is left unaccumulated — the reject precedes the fee /
-                // value-conservation checks, so its value is never read.
-                stopped_at_core_simplicity = true;
-                resolved_inputs.push(entry);
-                input_outpoints.push(op);
-                break;
-            }
-
-            let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
-            if slots == 0 {
-                return Err(TxError::new(ErrorCode::TxErrParse, "invalid witness slots"));
-            }
-            total_witness_slots = add_witness_slots(total_witness_slots, slots)?;
-
-            sum_in = sum_in.checked_add(u128::from(entry.value)).ok_or_else(|| {
-                TxError::new(ErrorCode::TxErrValueConservation, "input sum overflow")
-            })?;
-
-            resolved_inputs.push(entry);
-            input_outpoints.push(op);
-        }
-
-        // Witness boundary check. Cursor is per-tx (reset to 0 for each tx),
-        // matching the sequential path.
-        let witness_start: usize = 0;
-        let witness_end = total_witness_slots;
-        if witness_end > tx.witness.len() {
-            return Err(TxError::new(ErrorCode::TxErrParse, "witness underflow"));
-        }
-        if !stopped_at_core_simplicity && witness_end != tx.witness.len() {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "witness_count mismatch",
-            ));
-        }
-        // Fail-closed: surface the dedicated 0x0106 spend reject ahead of the
-        // fee/value-conservation checks, with Go-identical code+message.
-        if stopped_at_core_simplicity {
-            return Err(reject_core_simplicity_spend());
-        }
-
-        // Fee = sum_in − sum_out, matching sequential value conservation.
-        let mut sum_out: u128 = 0;
-        for output in &tx.outputs {
-            sum_out = sum_out
-                .checked_add(u128::from(output.value))
-                .ok_or_else(|| {
-                    TxError::new(ErrorCode::TxErrValueConservation, "output sum overflow")
-                })?;
-        }
-        if sum_in < sum_out {
-            return Err(TxError::new(
-                ErrorCode::TxErrValueConservation,
-                "outputs exceed inputs",
-            ));
-        }
-        let fee_big = sum_in - sum_out;
-        if fee_big > u128::from(u64::MAX) {
-            return Err(TxError::new(
-                ErrorCode::TxErrValueConservation,
-                "fee overflow u64",
-            ));
-        }
-        let fee = fee_big as u64;
-
-        results.push(PrecomputedTxContext {
-            tx_index: i,
-            tx_block_idx: i,
-            txid,
-            resolved_inputs,
-            witness_start,
-            witness_end,
-            input_outpoints: input_outpoints.clone(),
-            fee,
-        });
-
-        // Track same-block outputs: remove spent UTXOs, add created outputs.
-        for op in &input_outpoints {
-            overlay.remove(op);
-        }
-        for (j, output) in tx.outputs.iter().enumerate() {
-            if output.covenant_type == COV_TYPE_ANCHOR || output.covenant_type == COV_TYPE_DA_COMMIT
-            {
-                continue;
-            }
-            let op = Outpoint {
-                txid,
-                vout: j as u32,
-            };
-            overlay.insert(
-                op,
-                UtxoEntry {
-                    value: output.value,
-                    covenant_type: output.covenant_type,
-                    covenant_data: output.covenant_data.clone(),
-                    creation_height: block_height,
-                    created_by_coinbase: false,
-                },
-            );
-        }
+        ParsedBlock::validate_non_coinbase_block_tx(tx, &mut seen_nonces)?;
+        let (context, input_outpoints) = precompute_tx_context(i, tx, txid, overlay, block_height)?;
+        results.push(context);
+        update_precompute_overlay(overlay, tx, txid, &input_outpoints, block_height)?;
     }
-
     Ok(results)
+}
+
+fn precompute_tx_context(
+    tx_index: usize,
+    tx: &Tx,
+    txid: [u8; 32],
+    overlay: &HashMap<Outpoint, UtxoEntry>,
+    block_height: u64,
+) -> Result<(PrecomputedTxContext, Vec<Outpoint>), TxError> {
+    if tx.tx_nonce == 0 {
+        return Err(TxError::new(
+            ErrorCode::TxErrTxNonceInvalid,
+            "tx_nonce must be >= 1 for non-coinbase",
+        ));
+    }
+    if tx.inputs.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-coinbase must have at least one input",
+        ));
+    }
+    validate_tx_covenants_genesis(tx, block_height, None)?;
+    let inputs = collect_precompute_inputs(tx, overlay, block_height)?;
+    let (witness_start, witness_end) = precompute_witness_bounds(
+        tx,
+        inputs.total_witness_slots,
+        inputs.stopped_at_core_simplicity,
+    )?;
+    if inputs.stopped_at_core_simplicity {
+        return Err(reject_core_simplicity_spend());
+    }
+    let fee = compute_precompute_fee(inputs.sum_in, &tx.outputs)?;
+    let input_outpoints = inputs.input_outpoints;
+    let context = PrecomputedTxContext {
+        tx_index,
+        tx_block_idx: tx_index,
+        txid,
+        resolved_inputs: inputs.resolved_inputs,
+        witness_start,
+        witness_end,
+        input_outpoints: input_outpoints.clone(),
+        fee,
+    };
+    Ok((context, input_outpoints))
+}
+
+fn collect_precompute_inputs(
+    tx: &Tx,
+    overlay: &HashMap<Outpoint, UtxoEntry>,
+    block_height: u64,
+) -> Result<CollectedPrecomputeInputs, TxError> {
+    let mut out = CollectedPrecomputeInputs {
+        resolved_inputs: Vec::with_capacity(tx.inputs.len()),
+        input_outpoints: Vec::with_capacity(tx.inputs.len()),
+        total_witness_slots: 0,
+        sum_in: 0,
+        stopped_at_core_simplicity: false,
+    };
+    let mut seen_inputs = HashSet::with_capacity(tx.inputs.len());
+    for input in &tx.inputs {
+        let (entry, op) = resolve_precompute_input(input, &mut seen_inputs, overlay, block_height)?;
+        if entry.covenant_type == COV_TYPE_CORE_SIMPLICITY {
+            // Standalone precompute is reject-only for 0x0106 under the default
+            // context. Stop before trailing inputs and defer the dedicated
+            // reject until after relaxed witness bounds. Active CORE_SIMPLICITY
+            // parity is outside this boundary.
+            out.stopped_at_core_simplicity = true;
+            out.resolved_inputs.push(entry);
+            out.input_outpoints.push(op);
+            break;
+        }
+        let slots = precompute_witness_slots(&entry)?;
+        out.total_witness_slots = add_witness_slots(out.total_witness_slots, slots)?;
+        out.sum_in = out
+            .sum_in
+            .checked_add(u128::from(entry.value))
+            .ok_or_else(|| TxError::new(ErrorCode::TxErrValueConservation, "input sum overflow"))?;
+        out.resolved_inputs.push(entry);
+        out.input_outpoints.push(op);
+    }
+    Ok(out)
+}
+
+fn resolve_precompute_input(
+    input: &TxInput,
+    seen_inputs: &mut HashSet<Outpoint>,
+    overlay: &HashMap<Outpoint, UtxoEntry>,
+    block_height: u64,
+) -> Result<(UtxoEntry, Outpoint), TxError> {
+    validate_non_coinbase_input_encoding(input)?;
+    let op = Outpoint {
+        txid: input.prev_txid,
+        vout: input.prev_vout,
+    };
+    if !seen_inputs.insert(op.clone()) {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "duplicate input outpoint",
+        ));
+    }
+    let entry = overlay
+        .get(&op)
+        .cloned()
+        .ok_or_else(|| TxError::new(ErrorCode::TxErrMissingUtxo, "utxo not found"))?;
+    validate_precompute_entry(&entry, block_height)?;
+    Ok((entry, op))
+}
+
+fn validate_precompute_entry(entry: &UtxoEntry, block_height: u64) -> Result<(), TxError> {
+    if matches!(entry.covenant_type, COV_TYPE_ANCHOR | COV_TYPE_DA_COMMIT) {
+        return Err(TxError::new(
+            ErrorCode::TxErrMissingUtxo,
+            "attempt to spend non-spendable covenant",
+        ));
+    }
+    if entry.created_by_coinbase
+        && (block_height < entry.creation_height
+            || block_height - entry.creation_height < COINBASE_MATURITY)
+    {
+        return Err(TxError::new(
+            ErrorCode::TxErrCoinbaseImmature,
+            "coinbase immature",
+        ));
+    }
+    Ok(())
+}
+
+fn precompute_witness_slots(entry: &UtxoEntry) -> Result<usize, TxError> {
+    let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
+    if slots == 0 {
+        return Err(TxError::new(ErrorCode::TxErrParse, "invalid witness slots"));
+    }
+    Ok(slots)
+}
+
+fn precompute_witness_bounds(
+    tx: &Tx,
+    total_witness_slots: usize,
+    stopped_at_core_simplicity: bool,
+) -> Result<(usize, usize), TxError> {
+    let witness_start = 0;
+    let witness_end = total_witness_slots;
+    if witness_end > tx.witness.len() {
+        return Err(TxError::new(ErrorCode::TxErrParse, "witness underflow"));
+    }
+    if !stopped_at_core_simplicity && witness_end != tx.witness.len() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "witness_count mismatch",
+        ));
+    }
+    Ok((witness_start, witness_end))
+}
+
+fn compute_precompute_fee(sum_in: u128, outputs: &[TxOutput]) -> Result<u64, TxError> {
+    let mut sum_out = 0u128;
+    for output in outputs {
+        sum_out = sum_out
+            .checked_add(u128::from(output.value))
+            .ok_or_else(|| {
+                TxError::new(ErrorCode::TxErrValueConservation, "output sum overflow")
+            })?;
+    }
+    if sum_in < sum_out {
+        return Err(TxError::new(
+            ErrorCode::TxErrValueConservation,
+            "outputs exceed inputs",
+        ));
+    }
+    let fee = sum_in - sum_out;
+    if fee > u128::from(u64::MAX) {
+        return Err(TxError::new(
+            ErrorCode::TxErrValueConservation,
+            "fee overflow u64",
+        ));
+    }
+    Ok(fee as u64)
+}
+
+fn update_precompute_overlay(
+    overlay: &mut HashMap<Outpoint, UtxoEntry>,
+    tx: &Tx,
+    txid: [u8; 32],
+    input_outpoints: &[Outpoint],
+    block_height: u64,
+) -> Result<(), TxError> {
+    for op in input_outpoints {
+        overlay.remove(op);
+    }
+    for (index, output) in tx.outputs.iter().enumerate() {
+        if matches!(output.covenant_type, COV_TYPE_ANCHOR | COV_TYPE_DA_COMMIT) {
+            continue;
+        }
+        let vout = u32::try_from(index)
+            .map_err(|_| TxError::new(ErrorCode::TxErrParse, "output index exceeds u32"))?;
+        overlay.insert(
+            Outpoint { txid, vout },
+            UtxoEntry {
+                value: output.value,
+                covenant_type: output.covenant_type,
+                covenant_data: output.covenant_data.clone(),
+                creation_height: block_height,
+                created_by_coinbase: false,
+            },
+        );
+    }
+    Ok(())
 }

--- a/clients/rust/crates/rubin-consensus/src/precompute.rs
+++ b/clients/rust/crates/rubin-consensus/src/precompute.rs
@@ -310,7 +310,8 @@ fn compute_precompute_fee(sum_in: u128, outputs: &[TxOutput]) -> Result<u64, TxE
             "fee overflow u64",
         ));
     }
-    Ok(fee as u64)
+    u64::try_from(fee)
+        .map_err(|_| TxError::new(ErrorCode::TxErrValueConservation, "fee overflow u64"))
 }
 
 fn update_precompute_overlay(

--- a/clients/rust/crates/rubin-consensus/src/tests/precompute.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/precompute.rs
@@ -1,4 +1,7 @@
-use super::{encode_htlc_covenant_data, p2pk_covenant_data_for_pubkey, test_mldsa87_keypair};
+use super::{
+    encode_htlc_covenant_data, p2pk_covenant_data_for_pubkey, test_mldsa87_keypair,
+    valid_vault_covenant_data_for_p2pk_output,
+};
 use std::collections::HashMap;
 
 use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
@@ -8,7 +11,7 @@ use crate::hash::sha3_256;
 use crate::precompute::precompute_tx_contexts;
 use crate::tx::{Tx, TxInput, TxOutput, WitnessItem};
 use crate::utxo_basic::{Outpoint, UtxoEntry};
-use crate::ErrorCode;
+use crate::{ErrorCode, TxError};
 
 fn valid_p2pk_covenant_data() -> Vec<u8> {
     // Genesis-valid CORE_P2PK covenant_data: suite_id byte + key-id placeholder.
@@ -24,6 +27,68 @@ fn dummy_witness() -> WitnessItem {
         suite_id: SUITE_ID_ML_DSA_87,
         pubkey: vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize],
         signature: vec![0u8; (ML_DSA_87_SIG_BYTES + 1) as usize],
+    }
+}
+
+fn precompute_p2pk_spend_for_test(nonce: u64, input: TxInput, output_value: u64) -> Tx {
+    Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: nonce,
+        inputs: vec![input],
+        outputs: vec![TxOutput {
+            value: output_value,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: vec![dummy_witness()],
+        da_payload: Vec::new(),
+    }
+}
+
+fn precompute_input_for_test(prev_txid: [u8; 32], prev_vout: u32) -> TxInput {
+    TxInput {
+        prev_txid,
+        prev_vout,
+        script_sig: Vec::new(),
+        sequence: 0,
+    }
+}
+
+fn precompute_error(pb: ParsedBlock, utxos: &HashMap<Outpoint, UtxoEntry>, height: u64) -> TxError {
+    precompute_tx_contexts(&pb, utxos, height).expect_err("precompute rejection")
+}
+
+fn assert_precompute_error(
+    coinbase: Tx,
+    txs: Vec<Tx>,
+    utxos: &HashMap<Outpoint, UtxoEntry>,
+    code: ErrorCode,
+    message: &str,
+) {
+    let err = precompute_error(make_parsed_block(coinbase, txs), utxos, 100);
+    assert_eq!(err.code, code);
+    assert_eq!(err.msg, message);
+}
+
+fn precompute_p2pk_utxo(value: u64) -> UtxoEntry {
+    UtxoEntry {
+        value,
+        covenant_type: COV_TYPE_P2PK,
+        covenant_data: valid_p2pk_covenant_data(),
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+fn precompute_p2pk_output(value: u64) -> TxOutput {
+    TxOutput {
+        value,
+        covenant_type: COV_TYPE_P2PK,
+        covenant_data: valid_p2pk_covenant_data(),
     }
 }
 
@@ -666,6 +731,10 @@ fn precompute_coinbase_prevout_forbidden() {
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
     let err = precompute_tx_contexts(&pb, &HashMap::new(), 100).unwrap_err();
     assert_eq!(err.code.as_str(), "TX_ERR_PARSE");
+    assert_eq!(
+        err.msg,
+        "coinbase prevout encoding forbidden in non-coinbase"
+    );
 }
 
 #[test]
@@ -709,7 +778,8 @@ fn precompute_nil_like_non_coinbase_tx_rejected() {
     };
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
     let err = precompute_tx_contexts(&pb, &HashMap::new(), 0).unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.code, ErrorCode::TxErrTxNonceInvalid);
+    assert_eq!(err.msg, "tx_nonce must be >= 1 for non-coinbase");
 }
 
 #[test]
@@ -1018,10 +1088,9 @@ fn add_witness_slots_overflow() {
     );
 }
 
-// RUB-591: a 0x0106 spend input is rejected by precompute with the dedicated
-// "spend evaluation not enabled" message and TX_ERR_COVENANT_TYPE_INVALID — even
-// with a mismatched witness count that would otherwise surface TX_ERR_PARSE
-// ("witness_count mismatch"). Mirrors Go StoppedAtCoreSimplicity priority.
+// Rust standalone precompute rejects 0x0106 under the default context with its
+// dedicated error before a competing witness-count error. Active
+// CORE_SIMPLICITY parity is outside this reject-only boundary.
 #[test]
 fn precompute_core_simplicity_0x0106_spend_rejects_ahead_of_witness_errors() {
     let prev_txid = sha3_256(b"simplicity-spend");
@@ -1072,10 +1141,9 @@ fn precompute_core_simplicity_0x0106_spend_rejects_ahead_of_witness_errors() {
     );
 }
 
-// RUB-591: precompute must STOP at the first 0x0106 input (mirror Go's early
-// return), so a trailing input that is independently invalid (here: a missing
-// UTXO) cannot surface its own error ahead of the dedicated 0x0106 reject. With
-// a `continue` (instead of `break`) this would return TX_ERR_MISSING_UTXO.
+// Rust standalone precompute stops at the first 0x0106 input under the default
+// context, so a trailing missing UTXO cannot precede the dedicated reject.
+// Active CORE_SIMPLICITY parity is outside this reject-only boundary.
 #[test]
 fn precompute_core_simplicity_0x0106_spend_wins_over_trailing_input_error() {
     let simp_prev = sha3_256(b"simplicity-first-input");
@@ -1132,4 +1200,236 @@ fn precompute_core_simplicity_0x0106_spend_wins_over_trailing_input_error() {
         "trailing missing-utxo must not mask the 0x0106 reject; got: {}",
         err.msg
     );
+}
+
+#[test]
+fn precompute_coinbase_overlay() {
+    let coinbase_txid = sha3_256(&[0]);
+    let collision = Outpoint {
+        txid: coinbase_txid,
+        vout: 0,
+    };
+    let utxos = HashMap::from([(collision.clone(), precompute_p2pk_utxo(77))]);
+    let tx = precompute_p2pk_spend_for_test(1, precompute_input_for_test(coinbase_txid, 0), 1);
+    assert_precompute_error(
+        simple_coinbase(),
+        vec![tx],
+        &utxos,
+        ErrorCode::TxErrCoinbaseImmature,
+        "coinbase immature",
+    );
+    assert_eq!(utxos.get(&collision), Some(&precompute_p2pk_utxo(77)));
+
+    let mut coinbase = simple_coinbase();
+    coinbase.outputs.push(TxOutput {
+        value: 0,
+        covenant_type: COV_TYPE_ANCHOR,
+        covenant_data: vec![1],
+    });
+    let tx = precompute_p2pk_spend_for_test(1, precompute_input_for_test(coinbase_txid, 1), 1);
+    assert_precompute_error(
+        coinbase,
+        vec![tx],
+        &HashMap::new(),
+        ErrorCode::TxErrMissingUtxo,
+        "utxo not found",
+    );
+
+    let mut coinbase = simple_coinbase();
+    coinbase.outputs = vec![TxOutput {
+        value: 0,
+        covenant_type: COV_TYPE_DA_COMMIT,
+        covenant_data: vec![0; 32],
+    }];
+    assert_precompute_error(
+        coinbase,
+        vec![],
+        &HashMap::new(),
+        ErrorCode::TxErrCovenantTypeInvalid,
+        "CORE_DA_COMMIT allowed only in tx_kind=0x01",
+    );
+}
+
+#[test]
+fn precompute_coinbase_apply_output_order() {
+    let vault = TxOutput {
+        value: 1,
+        covenant_type: COV_TYPE_VAULT,
+        covenant_data: valid_vault_covenant_data_for_p2pk_output(),
+    };
+    let invalid = precompute_p2pk_output(0);
+    let mut no_inputs = precompute_p2pk_spend_for_test(1, precompute_input_for_test([1; 32], 0), 1);
+    no_inputs.inputs.clear();
+    no_inputs.witness.clear();
+
+    for (outputs, txs, code, message) in [
+        (
+            vec![vault.clone(), invalid.clone()],
+            vec![],
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "coinbase must not create CORE_VAULT outputs",
+        ),
+        (
+            vec![invalid.clone(), vault.clone()],
+            vec![],
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_P2PK value must be > 0",
+        ),
+        (
+            vec![vault],
+            vec![no_inputs],
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "coinbase must not create CORE_VAULT outputs",
+        ),
+    ] {
+        let mut coinbase = simple_coinbase();
+        coinbase.outputs = outputs;
+        assert_precompute_error(coinbase, txs, &HashMap::new(), code, message);
+    }
+}
+
+#[test]
+fn precompute_block_envelope_order() {
+    let prev = sha3_256(b"precompute-envelope");
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: prev,
+            vout: 0,
+        },
+        precompute_p2pk_utxo(2),
+    )]);
+    let input = precompute_input_for_test(prev, 0);
+
+    assert_precompute_error(
+        simple_coinbase(),
+        vec![precompute_p2pk_spend_for_test(0, input.clone(), 1)],
+        &utxos,
+        ErrorCode::TxErrTxNonceInvalid,
+        "tx_nonce must be >= 1 for non-coinbase",
+    );
+    assert_precompute_error(
+        simple_coinbase(),
+        vec![
+            precompute_p2pk_spend_for_test(1, input.clone(), 1),
+            precompute_p2pk_spend_for_test(1, input.clone(), 1),
+        ],
+        &utxos,
+        ErrorCode::TxErrNonceReplay,
+        "duplicate tx_nonce in block",
+    );
+
+    let mut coinbase_like = simple_coinbase();
+    coinbase_like.inputs[0].sequence = u32::MAX;
+    assert_precompute_error(
+        simple_coinbase(),
+        vec![coinbase_like],
+        &utxos,
+        ErrorCode::BlockErrCoinbaseInvalid,
+        "coinbase-like tx found at index > 0",
+    );
+
+    let missing = precompute_input_for_test(sha3_256(b"precompute-late-missing"), 0);
+    match precompute_tx_contexts(
+        &make_parsed_block(
+            simple_coinbase(),
+            vec![
+                precompute_p2pk_spend_for_test(1, input, 1),
+                precompute_p2pk_spend_for_test(2, missing, 1),
+            ],
+        ),
+        &utxos,
+        100,
+    ) {
+        Err(err) => {
+            assert_eq!(err.code, ErrorCode::TxErrMissingUtxo);
+            assert_eq!(err.msg, "utxo not found");
+        }
+        Ok(contexts) => panic!("returned {} partial contexts", contexts.len()),
+    }
+}
+
+#[test]
+fn precompute_context_detaches_snapshot_bytes() {
+    let prev = sha3_256(b"precompute-detached-bytes");
+    let op = Outpoint {
+        txid: prev,
+        vout: 0,
+    };
+    let mut utxos = HashMap::from([(op.clone(), precompute_p2pk_utxo(2))]);
+    let contexts = precompute_tx_contexts(
+        &make_parsed_block(
+            simple_coinbase(),
+            vec![precompute_p2pk_spend_for_test(
+                1,
+                precompute_input_for_test(prev, 0),
+                1,
+            )],
+        ),
+        &utxos,
+        100,
+    )
+    .expect("precompute");
+    let want = contexts[0].resolved_inputs[0].covenant_data[0];
+    utxos.get_mut(&op).unwrap().covenant_data[0] ^= 0xff;
+    assert_eq!(contexts[0].resolved_inputs[0].covenant_data[0], want);
+}
+
+#[test]
+fn precompute_input_encoding_precedes_lookup() {
+    for (name, input, code, message) in [
+        (
+            "script_sig_before_missing",
+            TxInput {
+                prev_txid: [0x11; 32],
+                prev_vout: 0,
+                script_sig: vec![1],
+                sequence: 0,
+            },
+            ErrorCode::TxErrParse,
+            "script_sig must be empty under genesis covenant set",
+        ),
+        (
+            "sequence_before_missing",
+            TxInput {
+                prev_txid: [0x12; 32],
+                prev_vout: 0,
+                script_sig: Vec::new(),
+                sequence: 0x8000_0000,
+            },
+            ErrorCode::TxErrSequenceInvalid,
+            "sequence exceeds 0x7fffffff",
+        ),
+    ] {
+        let err = precompute_error(
+            make_parsed_block(
+                simple_coinbase(),
+                vec![precompute_p2pk_spend_for_test(1, input, 1)],
+            ),
+            &HashMap::new(),
+            100,
+        );
+        assert_eq!(err.code, code, "{name}");
+        assert_eq!(err.msg, message, "{name}");
+    }
+
+    let prev = sha3_256(b"precompute-input-encoding-boundary");
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: prev,
+            vout: 0,
+        },
+        precompute_p2pk_utxo(2),
+    )]);
+    let mut input = precompute_input_for_test(prev, 0);
+    input.sequence = 0x7fff_ffff;
+    let contexts = precompute_tx_contexts(
+        &make_parsed_block(
+            simple_coinbase(),
+            vec![precompute_p2pk_spend_for_test(1, input, 1)],
+        ),
+        &utxos,
+        100,
+    )
+    .expect("empty script_sig with sequence 0x7fffffff");
+    assert_eq!(contexts.len(), 1);
 }

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -15,7 +15,7 @@ use crate::simplicity_covenant::reject_core_simplicity_spend;
 use crate::spend_verify::{validate_p2pk_spend_q, validate_threshold_sig_spend_q};
 use crate::stealth::{parse_stealth_covenant_data, validate_stealth_spend_q};
 use crate::suite_registry::{RotationProvider, SuiteRegistry};
-use crate::tx::Tx;
+use crate::tx::{Tx, TxInput};
 use crate::vault::{
     hash_in_sorted_32, output_descriptor_bytes, parse_multisig_covenant_data,
     parse_vault_covenant_data, parse_vault_covenant_data_for_spend, witness_slots,
@@ -195,6 +195,30 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
     Ok((work, summary))
 }
 
+/// Validates the wire-level encoding that every non-coinbase input must share.
+/// This preserves the sequential check order for standalone precompute.
+pub(crate) fn validate_non_coinbase_input_encoding(input: &TxInput) -> Result<(), TxError> {
+    if input.prev_vout == u32::MAX && input.prev_txid == [0u8; 32] {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "coinbase prevout encoding forbidden in non-coinbase",
+        ));
+    }
+    if !input.script_sig.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "script_sig must be empty under genesis covenant set",
+        ));
+    }
+    if input.sequence > 0x7fff_ffff {
+        return Err(TxError::new(
+            ErrorCode::TxErrSequenceInvalid,
+            "sequence exceeds 0x7fffffff",
+        ));
+    }
+    Ok(())
+}
+
 fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_impl(
     ctx: UtxoApplyImplContext<'_>,
     sig_queue: Option<&mut SigCheckQueue>,
@@ -247,27 +271,9 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
     let mut resolved_inputs: Vec<UtxoEntry> = Vec::with_capacity(tx.inputs.len());
     let mut resolved_witness_ranges: Vec<Range<usize>> = Vec::with_capacity(tx.inputs.len());
     let mut resolved_outpoints: Vec<Outpoint> = Vec::with_capacity(tx.inputs.len());
-    let zero_txid: [u8; 32] = [0u8; 32];
 
     for input in &tx.inputs {
-        if input.prev_vout == 0xffff_ffff && input.prev_txid == zero_txid {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "coinbase prevout encoding forbidden in non-coinbase",
-            ));
-        }
-        if !input.script_sig.is_empty() {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "script_sig must be empty under genesis covenant set",
-            ));
-        }
-        if input.sequence > 0x7fffffff {
-            return Err(TxError::new(
-                ErrorCode::TxErrSequenceInvalid,
-                "sequence exceeds 0x7fffffff",
-            ));
-        }
+        validate_non_coinbase_input_encoding(input)?;
         let op = Outpoint {
             txid: input.prev_txid,
             vout: input.prev_vout,


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1102
- GitHub Issue mirror (non-authoritative): #2806

Refs: Q-PRECOMPUTE-SEQUENTIAL-BOUNDARY-01

## Summary
- Align the exported Go and Rust default-context precompute helpers with canonical block-order setup by applying the current coinbase before transaction index 1.
- Enforce the connect path's nonce, replay, and input-encoding first-error order while preserving same-block parent-child resolution and fail-atomic results.
- Detach returned resolved UTXO bytes from caller-owned storage and reuse one Rust input-encoding owner across sequential apply and precompute.

## Invariant
After canonical parse/connect preflight, both default-context precompute helpers use one isolated block-order UTXO overlay, apply the current coinbase before later transactions, preserve the named canonical first-error order, and neither mutate caller-owned state nor expose aliased resolved bytes.

## Scope
- Changed files: 5
- Surfaces: clients/go, clients/rust
- Non-scope: production wiring, worker behavior, active CORE_SIMPLICITY, non-default chain or rotation contexts, formal/conformance/spec artifacts, public API changes, and unrelated cleanup.
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "^TestPrecomputeTxContexts_" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus precompute -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus utxo_basic -- --nocapture'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus/...'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus'` — PASS

## Follow-ups / Waivers
- RUB-721 retains production parallel worker-time versus later synchronous first-error composition, and RUB-1103 retains Rust worker failure-index propagation; this PR changes neither worker nor production wiring.
- No parity or fixture waiver: both standalone helpers are repaired atomically, and the contract confirms that no formal or shared conformance owner consumes these APIs.
