### PR TITLE
RUB-1113: publish standard mempool reservations through one pending-outpoint owner

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -31,10 +31,15 @@ const (
 )
 
 type mempoolEntry struct {
-	raw          []byte
-	txid         [32]byte
-	wtxid        [32]byte
-	inputs       []consensus.Outpoint
+	raw    []byte
+	txid   [32]byte
+	wtxid  [32]byte
+	inputs []consensus.Outpoint
+	// token is the exact pending-outpoint reservation this entry holds. It is
+	// the zero token exactly when the entry spends no outpoint and therefore
+	// claims nothing (the pre-owner validateEntryInputsLocked was likewise a
+	// no-op for an empty input set).
+	token        PendingOutpointToken
 	fee          uint64
 	weight       uint64
 	size         int
@@ -56,7 +61,10 @@ type Mempool struct {
 	currentMinFeeRate uint64
 	txs               map[[32]byte]*mempoolEntry
 	wtxids            map[[32]byte][32]byte
-	spenders          map[consensus.Outpoint][32]byte
+	// pendingOutpoints is the sole conflict-admission authority. It replaces
+	// the former spenders index: outpoint ownership now lives with the claim
+	// and its token, so no second spender map can drift from the records.
+	pendingOutpoints *PendingOutpointOwner
 	// Admission counters are bumped exactly once for each AddTx call on a
 	// non-nil Mempool that reaches the final outcome accounting path.
 	// Nil-receiver calls return before that defer is registered and are
@@ -77,18 +85,29 @@ type Mempool struct {
 	// evictedResidentTotal counts cumulative resident-entry capacity
 	// evictions since process start. It is bumped exactly once per
 	// already-admitted entry that is removed by capacity pressure
-	// (the deleteEntryLocked loop in addEntryLocked after
+	// (the per-victim counter loop in addEntryLockedWithFloor, after
 	// validateCapacityAdmissionLocked classifies the candidate as
-	// admitted-and-evicting). Candidate-worst rejection — where the
-	// incoming candidate is rejected at capacity and no resident is
-	// evicted — does not increment this counter; that path returns
-	// txAdmitUnavailable before the deleteEntryLocked loop. Fee-floor
+	// admitted-and-evicting and commitStandardDeltaLocked removes the
+	// victims with their exact tokens). Candidate-worst rejection —
+	// where the incoming candidate is rejected at capacity and no
+	// resident is evicted — does not increment this counter; that path
+	// returns txAdmitUnavailable with an empty victim list. Fee-floor
 	// rejection of an incoming transaction never reaches this counter
 	// either, because the fee-floor check happens before
 	// validateCapacityAdmissionLocked. Confirmed-block removals via
 	// EvictConfirmed/applyConnectedBlock are conflict resolution, not
 	// policy capacity eviction, and also do not increment this counter.
 	evictedResidentTotal atomic.Uint64
+}
+
+// PendingOutpointOwner returns the single pending-outpoint owner bound to this
+// mempool at construction. The pointer is stable for the mempool's lifetime;
+// a nil receiver returns nil so callers can wire unconditionally.
+func (m *Mempool) PendingOutpointOwner() *PendingOutpointOwner {
+	if m == nil {
+		return nil
+	}
+	return m.pendingOutpoints
 }
 
 // AllTxIDs returns the txids of every transaction currently in the mempool.
@@ -176,6 +195,10 @@ func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
 // addTxWithSource validates and admits a transaction while recording the
 // caller-declared origin in the mempool entry. Source provenance does not
 // grant admission priority or bypass; invalid source values reject.
+//
+// Its ChainState.admissionMu.RLock below BLOCKS INDEFINITELY, by design, once a
+// canonical transition has entered the fail-closed terminal state described on
+// canonicalTransition.end: waiting for the required restart is the contract.
 func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -110,6 +110,17 @@ func (m *Mempool) PendingOutpointOwner() *PendingOutpointOwner {
 	return m.pendingOutpoints
 }
 
+// checkEmptyForBindingLocked proves the pool holds no resident record in any
+// index. SyncEngine.SetMempool is initialization-only, so a candidate that
+// already admitted anything cannot be adopted: its records were validated
+// against a canonical tip that engine never guarded. The caller holds m.mu.
+func (m *Mempool) checkEmptyForBindingLocked() error {
+	if len(m.txs) != 0 || len(m.wtxids) != 0 || m.usedBytes != 0 {
+		return fmt.Errorf("mempool candidate is not empty: entries=%d wtxids=%d used_bytes=%d", len(m.txs), len(m.wtxids), m.usedBytes)
+	}
+	return nil
+}
+
 // AllTxIDs returns the txids of every transaction currently in the mempool.
 // The slice ordering is not guaranteed to be stable between calls.
 func (m *Mempool) AllTxIDs() [][32]byte {

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -53,23 +53,43 @@ func (m *Mempool) EvictConfirmed(blockBytes []byte) error {
 }
 
 func (m *Mempool) EvictConfirmedParsed(block *consensus.ParsedBlock) error {
-	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) {
-		for _, txid := range block.Txids {
-			m.removeTxLocked(txid)
-		}
+	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) error {
+		return m.commitStandardDeltaLocked(standardMempoolDelta{
+			removals: m.blockTerminalEntriesLocked(nil, make(map[[32]byte]struct{}), block, false),
+		})
 	})
 }
 
 func (m *Mempool) applyConnectedBlockParsed(block *consensus.ParsedBlock) error {
-	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) {
-		for _, txid := range block.Txids {
-			m.removeTxLocked(txid)
+	return m.applyConnectedBlocksParsed([]*consensus.ParsedBlock{block})
+}
+
+// applyConnectedBlocksParsed removes every standard entry the given canonical
+// blocks include or conflict with, in ONE standard-domain commit, and releases
+// each removed entry's exact token with it. A preferred-branch reorg pre-cleans
+// the whole winning branch through this single call instead of running a
+// per-block cleanup inside the transition.
+func (m *Mempool) applyConnectedBlocksParsed(blocks []*consensus.ParsedBlock) error {
+	if m == nil {
+		return errors.New("nil mempool")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var removals []*mempoolEntry
+	seen := make(map[[32]byte]struct{})
+	for _, block := range blocks {
+		if block == nil {
+			return errors.New("nil parsed block")
 		}
-		for txid := range m.collectConflictsLocked(block) {
-			m.removeTxLocked(txid)
-		}
+		removals = m.blockTerminalEntriesLocked(removals, seen, block, true)
+	}
+	if err := m.commitStandardDeltaLocked(standardMempoolDelta{removals: removals}); err != nil {
+		return err
+	}
+	for range blocks {
 		m.decayMinFeeRateAfterConnectedBlockLocked()
-	})
+	}
+	return nil
 }
 
 func (m *Mempool) RemoveConflicting(blockBytes []byte) error {
@@ -88,24 +108,39 @@ func (m *Mempool) withParsedBlock(blockBytes []byte, fn func(*consensus.ParsedBl
 }
 
 func (m *Mempool) RemoveConflictingParsed(block *consensus.ParsedBlock) error {
-	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) {
-		for txid := range m.collectConflictsLocked(block) {
-			m.removeTxLocked(txid)
-		}
+	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) error {
+		return m.commitStandardDeltaLocked(standardMempoolDelta{
+			removals: m.blockConflictEntriesLocked(nil, make(map[[32]byte]struct{}), block),
+		})
 	})
 }
 
-func (m *Mempool) withLockedParsedBlock(block *consensus.ParsedBlock, fn func(*consensus.ParsedBlock)) error {
+func (m *Mempool) withLockedParsedBlock(block *consensus.ParsedBlock, fn func(*consensus.ParsedBlock) error) error {
 	if m == nil {
 		return errors.New("nil mempool")
 	}
 	if block == nil {
 		return errors.New("nil parsed block")
 	}
+	// A PUBLIC terminal removal takes the same ChainState admission read guard
+	// standard admission takes, then Mempool.mu, then owner.mu. Without it a
+	// terminal removal could delete a record and its claim inside a canonical
+	// transition's snapshot/restore window, and an abort would then resurrect
+	// an entry the caller was told had been removed.
+	//
+	// The unexported connected-block cleanup (applyConnectedBlocksParsed)
+	// deliberately does NOT route through here: it runs under the transition's
+	// own admissionMu.Lock, and sync.RWMutex is not reentrant.
+	//
+	// Like standard admission, that RLock BLOCKS INDEFINITELY by design in the
+	// fail-closed terminal state described on canonicalTransition.end.
+	if m.chainState != nil {
+		m.chainState.admissionMu.RLock()
+		defer m.chainState.admissionMu.RUnlock()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	fn(block)
-	return nil
+	return fn(block)
 }
 
 // policySnapshot returns the current mempool policy under the mempool read lock.
@@ -153,12 +188,19 @@ func policyInputSnapshot(tx *consensus.Tx, utxos map[consensus.Outpoint]consensu
 	return out, nil
 }
 
-func (m *Mempool) removeTxLocked(txid [32]byte) {
+// removeTxLocked terminates one resident entry by txid through the same typed
+// standard delta the admission and capacity paths use, so its record and its
+// claim cannot become observably separated.
+//
+// It has no production caller: every live terminal path already builds a bounded
+// multi-entry delta directly. It survives as the single-entry form the package's
+// own tests drive, and routes through the delta so they exercise the real rule.
+func (m *Mempool) removeTxLocked(txid [32]byte) error {
 	entry, ok := m.txs[txid]
 	if !ok {
-		return
+		return nil
 	}
-	m.deleteEntryLocked(txid, entry)
+	return m.commitStandardDeltaLocked(standardMempoolDelta{removals: []*mempoolEntry{entry}})
 }
 
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {
@@ -171,10 +213,13 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	if err := validateMempoolEntrySource(entry.source); err != nil {
 		return err
 	}
-	if err := m.validateEntryInputsLocked(entry); err != nil {
+	if err := m.reserveEntryInputsLocked(entry); err != nil {
 		return err
 	}
-	return m.validateAdmissionSeqLocked(entry)
+	if err := m.validateAdmissionSeqLocked(entry); err != nil {
+		return m.releaseCandidateLocked(entry, err)
+	}
+	return nil
 }
 
 func validateBasicMempoolEntry(entry *mempoolEntry) error {
@@ -218,13 +263,47 @@ func validateMempoolEntrySource(source mempoolTxSource) error {
 	return nil
 }
 
-func (m *Mempool) validateEntryInputsLocked(entry *mempoolEntry) error {
-	for _, op := range entry.inputs {
-		if existing, ok := m.spenders[op]; ok {
-			return txAdmitConflict(fmt.Sprintf("mempool double-spend conflict with %x", existing))
-		}
+// reserveEntryInputsLocked occupies the conflict slot that validateEntryInputsLocked
+// used to hold. It claims every input of the candidate from the single owner,
+// bound to the ChainState tip the caller's admission read guard is pinning, and
+// records the issued token on the entry. An owner conflict maps to the existing
+// TxAdmitConflict double-spend family; an active transition, an expected-tip
+// mismatch, an exhausted sequence space and any owner-internal failure all map
+// to TxAdmitUnavailable, so no new public TxAdmit kind appears here.
+//
+// A candidate with no inputs claims nothing and takes no token, exactly as the
+// replaced loop was a no-op over an empty input slice.
+func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry) error {
+	if len(entry.inputs) == 0 {
+		return nil
 	}
+	token, err := m.pendingOutpointOwnerLocked().Reserve(
+		pendingOutpointTipOf(m.chainState),
+		PendingOutpointStandardMempool,
+		entry.txid,
+		entry.inputs,
+	)
+	if err != nil {
+		return txAdmitFromPendingOutpointError(err)
+	}
+	entry.token = token
 	return nil
+}
+
+// releaseCandidateLocked releases a reservation the conflict slot issued for a
+// candidate that a LATER admission check rejected, and returns cause unchanged
+// so the public error order is preserved. The issued sequence stays consumed;
+// high-waters never decrease. Release cannot fail for a claim this call just
+// installed, and reporting a release fault in place of cause would rewrite the
+// contractual admission error, so the release result is deliberately dropped.
+func (m *Mempool) releaseCandidateLocked(entry *mempoolEntry, cause error) error {
+	var zero PendingOutpointToken
+	if entry == nil || entry.token == zero {
+		return cause
+	}
+	_ = m.pendingOutpoints.Release(entry.token)
+	entry.token = zero
+	return cause
 }
 
 func (m *Mempool) validateAdmissionSeqLocked(entry *mempoolEntry) error {
@@ -294,22 +373,24 @@ func (m *Mempool) addEntryLockedWithFloor(entry *mempoolEntry, snappedFloor uint
 	}
 	evictedEntries, err := m.validateCapacityAdmissionLocked(entry, snappedFloor)
 	if err != nil {
-		return err
+		return m.releaseCandidateLocked(entry, err)
 	}
 	m.ensureMinFeeRateLocked()
-	m.ensureIndexesLocked()
-	for _, evicted := range evictedEntries {
-		m.deleteEntryLocked(evicted.txid, evicted)
+	// One typed delta: every exact victim token is released and the candidate
+	// record plus its token finalization are installed together. A failure here
+	// publishes no entry and exactly releases the candidate reservation.
+	if err := m.commitStandardDeltaLocked(standardMempoolDelta{candidate: entry, removals: evictedEntries}); err != nil {
+		return m.releaseCandidateLocked(entry, err)
+	}
+	for range evictedEntries {
 		// Bump the resident-eviction counter exactly once per
-		// already-admitted entry that capacity pressure removes here.
-		// Candidate-worst rejection returned txAdmitUnavailable above
-		// without populating evictedEntries, so that path skips this
-		// loop entirely. Fee-floor rejection returned earlier from
-		// validateFeeFloorLocked and likewise never reaches here.
+		// already-admitted entry that capacity pressure removed in the
+		// commit above. Candidate-worst rejection returned
+		// txAdmitUnavailable earlier without populating evictedEntries,
+		// and fee-floor rejection returned from validateFeeFloorLocked
+		// before that, so neither path reaches this loop.
 		m.evictedResidentTotal.Add(1)
 	}
-	m.assignAdmissionSeqLocked(entry)
-	m.insertEntryIndexesLocked(entry)
 	m.raiseMinFeeRateAfterEvictionLocked(evictedEntries)
 	return nil
 }
@@ -321,9 +402,19 @@ func (m *Mempool) ensureIndexesLocked() {
 	if m.wtxids == nil {
 		m.wtxids = make(map[[32]byte][32]byte)
 	}
-	if m.spenders == nil {
-		m.spenders = make(map[consensus.Outpoint][32]byte)
+}
+
+// pendingOutpointOwnerLocked returns the single owner, creating it on first use
+// for a bare Mempool value exactly as ensureIndexesLocked creates the txid and
+// wtxid indexes — and as it used to create the spenders index this owner
+// replaces. NewMempoolWithConfig always installs the owner eagerly from the
+// bound ChainState stable tip, so no production path takes the lazy branch and
+// no second owner can exist for one mempool.
+func (m *Mempool) pendingOutpointOwnerLocked() *PendingOutpointOwner {
+	if m.pendingOutpoints == nil {
+		m.pendingOutpoints = newPendingOutpointOwner(pendingOutpointTipOf(m.chainState))
 	}
+	return m.pendingOutpoints
 }
 
 func (m *Mempool) assignAdmissionSeqLocked(entry *mempoolEntry) {
@@ -339,24 +430,48 @@ func (m *Mempool) insertEntryIndexesLocked(entry *mempoolEntry) {
 	m.txs[entry.txid] = entry
 	m.wtxids[entry.wtxid] = entry.txid
 	m.usedBytes += entry.size
-	for _, op := range entry.inputs {
-		m.spenders[op] = entry.txid
-	}
 }
 
-func (m *Mempool) collectConflictsLocked(block *consensus.ParsedBlock) map[[32]byte]struct{} {
-	conflicts := make(map[[32]byte]struct{})
+// blockTerminalEntriesLocked appends the resident entries a canonical block
+// terminates: first the entries it includes by txid, then — when conflicts is
+// true — the entries whose claimed outpoints the block's non-coinbase inputs
+// spend. Order follows block order and then input order, and seen deduplicates
+// across blocks, so the resulting delta is deterministic and never lists the
+// same record twice.
+func (m *Mempool) blockTerminalEntriesLocked(out []*mempoolEntry, seen map[[32]byte]struct{}, block *consensus.ParsedBlock, conflicts bool) []*mempoolEntry {
+	for _, txid := range block.Txids {
+		out = m.appendResidentEntryLocked(out, seen, txid)
+	}
+	if !conflicts {
+		return out
+	}
+	return m.blockConflictEntriesLocked(out, seen, block)
+}
+
+func (m *Mempool) blockConflictEntriesLocked(out []*mempoolEntry, seen map[[32]byte]struct{}, block *consensus.ParsedBlock) []*mempoolEntry {
 	for i, tx := range block.Txs {
 		if i == 0 || tx == nil {
 			continue
 		}
 		for _, in := range tx.Inputs {
-			if txid, ok := m.spenders[outpointFromInput(in)]; ok {
-				conflicts[txid] = struct{}{}
+			if txid, ok := m.pendingOutpoints.txidForOutpoint(outpointFromInput(in)); ok {
+				out = m.appendResidentEntryLocked(out, seen, txid)
 			}
 		}
 	}
-	return conflicts
+	return out
+}
+
+func (m *Mempool) appendResidentEntryLocked(out []*mempoolEntry, seen map[[32]byte]struct{}, txid [32]byte) []*mempoolEntry {
+	if _, done := seen[txid]; done {
+		return out
+	}
+	entry, ok := m.txs[txid]
+	if !ok {
+		return out
+	}
+	seen[txid] = struct{}{}
+	return append(out, entry)
 }
 
 func outpointFromInput(in consensus.TxInput) consensus.Outpoint {
@@ -374,9 +489,6 @@ func (m *Mempool) deleteEntryLocked(txid [32]byte, entry *mempoolEntry) {
 		} else {
 			m.usedBytes = 0
 		}
-	}
-	for _, op := range entry.inputs {
-		delete(m.spenders, op)
 	}
 	if existing, ok := m.wtxids[entry.wtxid]; ok && existing == txid {
 		delete(m.wtxids, entry.wtxid)

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -264,25 +264,32 @@ func validateMempoolEntrySource(source mempoolTxSource) error {
 }
 
 // reserveEntryInputsLocked occupies the conflict slot that validateEntryInputsLocked
-// used to hold. It claims every input of the candidate from the single owner,
-// bound to the ChainState tip the caller's admission read guard is pinning, and
-// records the issued token on the entry. An owner conflict maps to the existing
-// TxAdmitConflict double-spend family; an active transition, an expected-tip
-// mismatch, an exhausted sequence space and any owner-internal failure all map
-// to TxAdmitUnavailable, so no new public TxAdmit kind appears here.
+// used to hold. It reads ONE exact owner admission context, requires that
+// context's stable tip to equal the ChainState tip the caller's admission read
+// guard is pinning, and claims every input of the candidate against that exact
+// tip/generation pair, recording the issued token on the entry. Passing the
+// whole observed context — not just a tip — is what makes a stale reader lose:
+// Reserve refuses a generation the owner has already left behind.
 //
-// A candidate with no inputs claims nothing and takes no token, exactly as the
-// replaced loop was a no-op over an empty input slice.
+// An owner conflict maps to the existing TxAdmitConflict double-spend family; an
+// active transition, an expected-tip or expected-generation mismatch, an
+// exhausted sequence space and any owner-internal failure all map to
+// TxAdmitUnavailable, so no new public TxAdmit kind appears here. A candidate
+// with no inputs claims nothing and takes no token, exactly as the replaced loop
+// was a no-op over an empty input slice.
 func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry) error {
 	if len(entry.inputs) == 0 {
 		return nil
 	}
-	token, err := m.pendingOutpointOwnerLocked().Reserve(
-		pendingOutpointTipOf(m.chainState),
-		PendingOutpointStandardMempool,
-		entry.txid,
-		entry.inputs,
-	)
+	owner := m.pendingOutpointOwnerLocked()
+	admission, ok := owner.AdmissionContext()
+	if !ok {
+		return txAdmitUnavailable("pending-outpoint owner admission context unavailable")
+	}
+	if admission.StableTip != pendingOutpointTipOf(m.chainState) {
+		return txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip")
+	}
+	token, err := owner.Reserve(admission, PendingOutpointStandardMempool, entry.txid, entry.inputs)
 	if err != nil {
 		return txAdmitFromPendingOutpointError(err)
 	}

--- a/clients/go/node/mempool_stats.go
+++ b/clients/go/node/mempool_stats.go
@@ -131,7 +131,9 @@ func NewMempoolWithConfig(chainState *ChainState, blockStore *BlockStore, chainI
 		currentMinFeeRate: DefaultMempoolMinFeeRate,
 		txs:               make(map[[32]byte]*mempoolEntry),
 		wtxids:            make(map[[32]byte][32]byte),
-		spenders:          make(map[consensus.Outpoint][32]byte),
+		// Exactly one owner per mempool, initialized from the bound
+		// ChainState stable tip. Nothing else constructs one.
+		pendingOutpoints: newPendingOutpointOwner(pendingOutpointTipOf(chainState)),
 	}, nil
 }
 
@@ -200,8 +202,8 @@ func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
 // adjustments performed by raiseMinFeeRateAfterEvictionLocked and
 // decayMinFeeRateAfterConnectedBlockLocked. EvictedResidentTotal is
 // loaded INSIDE the read-lock window. Writers bump that counter
-// under m.mu.Lock inside addEntryLocked's deleteEntryLocked loop,
-// so the reader's m.mu.RLock pairs with the writer's m.mu.Lock and
+// under m.mu.Lock in addEntryLockedWithFloor's per-victim counter
+// loop, so the reader's m.mu.RLock pairs with the writer's m.mu.Lock and
 // the atomic.Load observes the same critical section as the gauge
 // fields read on the surrounding lines. Covered by
 // TestMempoolStatsScrapePurity and the

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
+// assertPostSlotRejectionSnapshot pins the shape of an admission failure that
+// happened AFTER the conflict slot issued a reservation: no entry is published,
+// every record and live claim is byte-identical, and the issued token sequence
+// stays consumed — the owner high-water never decreases, so no sequence can be
+// handed out twice.
+func assertPostSlotRejectionSnapshot(t *testing.T, before, after mempoolSnapshot) {
+	t.Helper()
+	if after.pending.tokenHighWater != before.pending.tokenHighWater+1 {
+		t.Fatalf("token high-water=%d, want exactly one consumed sequence above %d", after.pending.tokenHighWater, before.pending.tokenHighWater)
+	}
+	after.pending.tokenHighWater = before.pending.tokenHighWater
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("rejected candidate mutated mempool: before=%+v after=%+v", before, after)
+	}
+}
+
 func TestMempoolAdd(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -94,8 +110,8 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 	if got, ok := mp.wtxids[wtxid]; !ok || got != txid {
 		t.Fatalf("wtxid index got %x ok=%v, want txid %x", got, ok, txid)
 	}
-	if got, ok := mp.spenders[outpoints[0]]; !ok || got != txid {
-		t.Fatalf("spender index got %x ok=%v, want txid %x", got, ok, txid)
+	if got, ok := mp.pendingOutpoints.txidForOutpoint(outpoints[0]); !ok || got != txid {
+		t.Fatalf("pending-outpoint claim got %x ok=%v, want txid %x", got, ok, txid)
 	}
 }
 
@@ -208,8 +224,8 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 		t.Fatalf("addEntryLocked: %v", err)
 	}
 
-	if mp.txs == nil || mp.wtxids == nil || mp.spenders == nil {
-		t.Fatalf("indexes were not initialized: txs=%v wtxids=%v spenders=%v", mp.txs != nil, mp.wtxids != nil, mp.spenders != nil)
+	if mp.txs == nil || mp.wtxids == nil {
+		t.Fatalf("indexes were not initialized: txs=%v wtxids=%v", mp.txs != nil, mp.wtxids != nil)
 	}
 	if got := mp.txs[entry.txid]; got != entry {
 		t.Fatalf("tx index got %p, want entry %p", got, entry)
@@ -217,8 +233,8 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 	if got := mp.wtxids[entry.wtxid]; got != entry.txid {
 		t.Fatalf("wtxid index got %x, want txid %x", got, entry.txid)
 	}
-	if got := mp.spenders[op]; got != entry.txid {
-		t.Fatalf("spender index got %x, want txid %x", got, entry.txid)
+	if got, ok := mp.pendingOutpoints.txidForOutpoint(op); !ok || got != entry.txid {
+		t.Fatalf("pending-outpoint claim got %x ok=%v, want txid %x", got, ok, entry.txid)
 	}
 	if mp.lastAdmissionSeq != entry.admissionSeq {
 		t.Fatalf("lastAdmissionSeq=%d, want %d", mp.lastAdmissionSeq, entry.admissionSeq)
@@ -266,8 +282,8 @@ func TestMempoolAddEntryLockedRejectsZeroTxidWithoutMutation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
 		t.Fatalf("expected invalid txid rejection, got %v", err)
 	}
-	if mp.txs != nil || mp.wtxids != nil || mp.spenders != nil {
-		t.Fatalf("indexes initialized after zero txid reject: txs=%v wtxids=%v spenders=%v", mp.txs != nil, mp.wtxids != nil, mp.spenders != nil)
+	if mp.txs != nil || mp.wtxids != nil {
+		t.Fatalf("indexes initialized after zero txid reject: txs=%v wtxids=%v", mp.txs != nil, mp.wtxids != nil)
 	}
 	if mp.usedBytes != 0 {
 		t.Fatalf("usedBytes=%d, want 0 after zero txid reject", mp.usedBytes)
@@ -685,8 +701,8 @@ func TestMempoolAddEntryLockedCapacityPlanRejectsWithoutMutation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry weight") {
 		t.Fatalf("expected capacity plan metadata rejection, got %v", err)
 	}
-	if len(mp.txs) != 1 || mp.txs[badResidentID] == nil || mp.wtxids != nil || mp.spenders != nil || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 0 || mp.usedBytes != 1 {
-		t.Fatalf("capacity-plan error mutated mempool: len=%d wtxids=%v spenders=%v seq=%d floor=%d used=%d", len(mp.txs), mp.wtxids != nil, mp.spenders != nil, mp.lastAdmissionSeq, mp.currentMinFeeRate, mp.usedBytes)
+	if len(mp.txs) != 1 || mp.txs[badResidentID] == nil || mp.wtxids != nil || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 0 || mp.usedBytes != 1 {
+		t.Fatalf("capacity-plan error mutated mempool: len=%d wtxids=%v seq=%d floor=%d used=%d", len(mp.txs), mp.wtxids != nil, mp.lastAdmissionSeq, mp.currentMinFeeRate, mp.usedBytes)
 	}
 }
 
@@ -756,15 +772,17 @@ func TestMempoolEntryIndexesRemovedWithEntry(t *testing.T) {
 	}
 
 	mp.mu.Lock()
-	mp.removeTxLocked(txid)
+	if err := mp.removeTxLocked(txid); err != nil {
+		t.Fatalf("removeTxLocked: %v", err)
+	}
 	if _, ok := mp.txs[txid]; ok {
 		t.Fatalf("removed txid %x still present", txid)
 	}
 	if _, ok := mp.wtxids[wtxid]; ok {
 		t.Fatalf("removed wtxid %x still indexed", wtxid)
 	}
-	if _, ok := mp.spenders[outpoints[0]]; ok {
-		t.Fatalf("removed spender %x:%d still indexed", outpoints[0].Txid, outpoints[0].Vout)
+	if _, ok := mp.pendingOutpoints.txidForOutpoint(outpoints[0]); ok {
+		t.Fatalf("removed claim %x:%d still indexed", outpoints[0].Txid, outpoints[0].Vout)
 	}
 	mp.mu.Unlock()
 }
@@ -2874,8 +2892,8 @@ func TestMempoolDoubleSpend(t *testing.T) {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
 	tx1ID := txID(t, tx1)
-	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
-		t.Fatalf("spender index got %x ok=%v, want tx1 %x", got, ok, tx1ID)
+	if got, ok := mp.pendingOutpoints.txidForOutpoint(outpoints[0]); !ok || got != tx1ID {
+		t.Fatalf("pending-outpoint claim got %x ok=%v, want tx1 %x", got, ok, tx1ID)
 	}
 	seqAfterTx1 := mp.lastAdmissionSeq
 	if err := mp.AddTx(tx2); err == nil {
@@ -2887,8 +2905,8 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	if mp.Contains(txID(t, tx2)) {
 		t.Fatalf("conflicting tx entered mempool")
 	}
-	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
-		t.Fatalf("spender index after conflict got %x ok=%v, want tx1 %x", got, ok, tx1ID)
+	if got, ok := mp.pendingOutpoints.txidForOutpoint(outpoints[0]); !ok || got != tx1ID {
+		t.Fatalf("pending-outpoint claim after conflict got %x ok=%v, want tx1 %x", got, ok, tx1ID)
 	}
 	if mp.lastAdmissionSeq != seqAfterTx1 {
 		t.Fatalf("lastAdmissionSeq after conflict=%d, want %d", mp.lastAdmissionSeq, seqAfterTx1)
@@ -2983,9 +3001,7 @@ func TestMempoolCandidateWorstRejectsWithoutMutation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot after candidate-worst: %v", err)
 	}
-	if !reflect.DeepEqual(after, before) {
-		t.Fatalf("mempool snapshot mutated after candidate-worst reject: before=%+v after=%+v", before, after)
-	}
+	assertPostSlotRejectionSnapshot(t, before, after)
 	if got := mp.Len(); got != 1 {
 		t.Fatalf("mempool len=%d, want 1", got)
 	}
@@ -3475,9 +3491,7 @@ func TestMempoolAddReorgTxUsesNormalCapacityAdmission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot after lower reorg: %v", err)
 	}
-	if !reflect.DeepEqual(afterReject, before) {
-		t.Fatalf("lower reorg candidate mutated mempool: before=%+v after=%+v", before, afterReject)
-	}
+	assertPostSlotRejectionSnapshot(t, before, afterReject)
 	if mp.Contains(txID(t, lowerReorg)) {
 		t.Fatalf("lower reorg candidate entered mempool")
 	}
@@ -3697,7 +3711,9 @@ func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) 
 	mp.currentMinFeeRate = 7
 	tx2ID := txID(t, tx2)
 	mp.mu.Lock()
-	mp.removeTxLocked(tx2ID)
+	if err := mp.removeTxLocked(tx2ID); err != nil {
+		t.Fatalf("removeTxLocked: %v", err)
+	}
 	if mp.lastAdmissionSeq != 2 {
 		t.Fatalf("lastAdmissionSeq after removing tx2=%d, want 2", mp.lastAdmissionSeq)
 	}
@@ -3796,7 +3812,10 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 		for i := range base.entries {
 			entries = append(entries, cloneMempoolEntry(&base.entries[i]))
 		}
-		return mempoolSnapshot{entries: entries, lastAdmissionSeq: base.lastAdmissionSeq, currentMinFeeRate: base.currentMinFeeRate}
+		// The owner image travels with the entries: each case below corrupts
+		// exactly one thing, so the record/claim binding must stay valid
+		// everywhere else.
+		return mempoolSnapshot{entries: entries, pending: base.pending, lastAdmissionSeq: base.lastAdmissionSeq, currentMinFeeRate: base.currentMinFeeRate}
 	}
 	withEditedFirst := func(edit func(*mempoolEntry)) func(mempoolSnapshot) mempoolSnapshot {
 		return func(base mempoolSnapshot) mempoolSnapshot {
@@ -3922,13 +3941,18 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 			want: "mempool snapshot admission high-watermark below restored max",
 		},
 		{
-			name: "duplicate_spender",
+			// The former standalone spenders map is gone, so a snapshot
+			// double-spend is now caught by the record/claim bijection: the
+			// second record over an already-claimed outpoint has no finalized
+			// standard claim of its own, and the owner is the sole authority.
+			name: "double_spending_record_without_claim",
 			mutate: func(base mempoolSnapshot) mempoolSnapshot {
 				bad := cloneSnapshotForTest(base)
 				bad.entries = append(bad.entries, snapshotEntry(txDoubleSpend, doubleSpendID, []consensus.Outpoint{outpoints[0]}))
+				bad.lastAdmissionSeq = bad.entries[len(bad.entries)-1].admissionSeq
 				return bad
 			},
-			want: "duplicate mempool snapshot spender",
+			want: "zero or foreign pending-outpoint token",
 		},
 		{
 			name: "aggregate_count_over_cap",
@@ -4005,21 +4029,30 @@ func TestRestoreMempoolSnapshotAllowsExactCapacityBoundary(t *testing.T) {
 		t.Fatalf("snapshotMempool: %v", err)
 	}
 
-	target, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
-		MaxTransactions: 2,
-		MaxBytes:        len(tx1) + len(tx2),
-	})
-	if err != nil {
-		t.Fatalf("new target mempool: %v", err)
+	// Restore is SAME-owner restore: the snapshot's tokens belong to this
+	// mempool's owner, so it is restored into the mempool it came from after
+	// its records were cleared. A second Mempool has a second owner and every
+	// token in this snapshot would be foreign to it.
+	source.mu.Lock()
+	for _, txBytes := range [][]byte{tx1, tx2} {
+		if err := source.removeTxLocked(txID(t, txBytes)); err != nil {
+			source.mu.Unlock()
+			t.Fatalf("removeTxLocked: %v", err)
+		}
 	}
-	if err := restoreMempoolSnapshot(target, snapshot); err != nil {
+	source.mu.Unlock()
+	if got := source.Len(); got != 0 {
+		t.Fatalf("mempool len=%d after clearing, want 0", got)
+	}
+
+	if err := restoreMempoolSnapshot(source, snapshot); err != nil {
 		t.Fatalf("restoreMempoolSnapshot exact boundary: %v", err)
 	}
-	if got := target.Len(); got != 2 {
+	if got := source.Len(); got != 2 {
 		t.Fatalf("mempool len=%d, want 2", got)
 	}
-	if target.usedBytes != len(tx1)+len(tx2) {
-		t.Fatalf("usedBytes=%d, want %d", target.usedBytes, len(tx1)+len(tx2))
+	if source.usedBytes != len(tx1)+len(tx2) {
+		t.Fatalf("usedBytes=%d, want %d", source.usedBytes, len(tx1)+len(tx2))
 	}
 }
 
@@ -4039,6 +4072,396 @@ func TestMempoolAddTxHeightOverflow(t *testing.T) {
 	}
 	if txErr.Kind != TxAdmitUnavailable {
 		t.Fatalf("expected TxAdmitUnavailable, got %v", txErr.Kind)
+	}
+}
+
+// residentClaim returns the resident entry for txid together with the live
+// owner claim behind its exact token, so a test asserts the record/claim
+// binding rather than the record alone.
+func residentClaim(t *testing.T, mp *Mempool, txid [32]byte) (*mempoolEntry, *pendingOutpointClaim) {
+	t.Helper()
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+	entry, ok := mp.txs[txid]
+	if !ok {
+		t.Fatalf("no resident entry for %x", txid)
+	}
+	owner := mp.pendingOutpoints
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	return entry, owner.byToken[entry.token]
+}
+
+func ownerCounts(mp *Mempool) (outpoints int, claims int, highWater uint64) {
+	owner := mp.pendingOutpoints
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	return len(owner.byOutpoint), len(owner.byToken), owner.tokenHighWater
+}
+
+// TestMempoolPendingOutpointAdmissionFinalizesExactlyOneToken proves the
+// accepted admission row on the PUBLIC path: every input-bearing candidate
+// reserves and finalizes exactly one standard token from the single owner
+// bound at construction, the claim carries the entry's exact ordered inputs,
+// and independent outpoints admit without interfering. It also pins the
+// restart row: a fresh Mempool has a fresh owner for which every prior token
+// is foreign.
+func TestMempoolPendingOutpointAdmissionFinalizesExactlyOneToken(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	owner := mp.PendingOutpointOwner()
+	if owner == nil || owner != mp.pendingOutpoints {
+		t.Fatalf("PendingOutpointOwner()=%p, want the single bound owner %p", owner, mp.pendingOutpoints)
+	}
+
+	txs := [][]byte{
+		mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress),
+		mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress),
+	}
+	for i, txBytes := range txs {
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx(%d): %v", i, err)
+		}
+		entry, claim := residentClaim(t, mp, txID(t, txBytes))
+		if entry.token.owner != owner || entry.token.seq != uint64(i+1) {
+			t.Fatalf("entry %d token=(owner=%p,seq=%d), want seq %d from the bound owner", i, entry.token.owner, entry.token.seq, i+1)
+		}
+		if claim == nil || !claim.finalized || claim.domain != PendingOutpointStandardMempool || claim.txid != entry.txid {
+			t.Fatalf("entry %d claim=%+v, want a finalized standard claim for %x", i, claim, entry.txid)
+		}
+		if !reflect.DeepEqual(claim.inputs, entry.inputs) {
+			t.Fatalf("entry %d claim inputs=%v, want the entry inputs %v", i, claim.inputs, entry.inputs)
+		}
+		if got, ok := owner.txidForOutpoint(outpoints[i]); !ok || got != entry.txid {
+			t.Fatalf("entry %d index row=(%x,%v), want %x", i, got, ok, entry.txid)
+		}
+	}
+	gotOutpoints, gotClaims, gotHighWater := ownerCounts(mp)
+	if gotOutpoints != 2 || gotClaims != 2 || gotHighWater != 2 {
+		t.Fatalf("owner state=(outpoints=%d claims=%d high_water=%d), want 2/2/2", gotOutpoints, gotClaims, gotHighWater)
+	}
+
+	// Restart is not same-owner restore: a fresh Mempool gets a fresh owner and
+	// every token the previous owner issued is foreign to it.
+	restarted, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("restart mempool: %v", err)
+	}
+	if restarted.pendingOutpoints == owner {
+		t.Fatal("restart reused the previous owner")
+	}
+	entry, _ := residentClaim(t, mp, txID(t, txs[0]))
+	if got := testOwnerKind(t, restarted.pendingOutpoints.Release(entry.token)); got != PendingOutpointInternal {
+		t.Fatalf("prior-owner token on the restarted owner kind=%d, want internal", got)
+	}
+	if gotOutpoints, gotClaims, gotHighWater := ownerCounts(restarted); gotOutpoints != 0 || gotClaims != 0 || gotHighWater != 0 {
+		t.Fatalf("restarted owner state=(%d,%d,%d), want an empty fresh owner", gotOutpoints, gotClaims, gotHighWater)
+	}
+}
+
+// TestMempoolPendingOutpointInputlessEntryHoldsZeroTokenAndNoClaim pins the
+// input-less row: such a candidate performs the same no-op at the conflict slot
+// the pre-owner loop did, consumes no sequence, carries the zero token and
+// creates no claim — while an input-bearing sibling in the same mempool still
+// holds its exact finalized claim. Terminal removal accepts both shapes.
+func TestMempoolPendingOutpointInputlessEntryHoldsZeroTokenAndNoClaim(t *testing.T) {
+	op := consensus.Outpoint{Txid: [32]byte{0x01}, Vout: 2}
+	inputless := &mempoolEntry{txid: [32]byte{0x0a}, wtxid: [32]byte{0x0b}, fee: 1, weight: 1, size: 1}
+	spending := &mempoolEntry{txid: [32]byte{0x0c}, wtxid: [32]byte{0x0d}, inputs: []consensus.Outpoint{op}, fee: 1, weight: 1, size: 1}
+
+	mp := &Mempool{maxTxs: 10, maxBytes: 100}
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+	for _, entry := range []*mempoolEntry{inputless, spending} {
+		if err := mp.addEntryLocked(entry); err != nil {
+			t.Fatalf("addEntryLocked(%x): %v", entry.txid, err)
+		}
+	}
+
+	var zero PendingOutpointToken
+	if inputless.token != zero {
+		t.Fatalf("input-less entry token=%+v, want the zero token", inputless.token)
+	}
+	owner := mp.pendingOutpoints
+	if spending.token == zero || spending.token.seq != 1 || owner.tokenHighWater != 1 {
+		t.Fatalf("input-less admission consumed a sequence: spending seq=%d high_water=%d", spending.token.seq, owner.tokenHighWater)
+	}
+	if len(owner.byToken) != 1 || len(owner.byOutpoint) != 1 {
+		t.Fatalf("owner holds claims=%d outpoints=%d, want exactly the spending entry's", len(owner.byToken), len(owner.byOutpoint))
+	}
+	if claim := owner.byToken[spending.token]; claim == nil || !claim.finalized {
+		t.Fatalf("spending claim=%+v, want finalized", claim)
+	}
+
+	// The typed delta accepts the input-less shape on the terminal path too.
+	if err := mp.removeTxLocked(inputless.txid); err != nil {
+		t.Fatalf("removeTxLocked(input-less): %v", err)
+	}
+	if err := mp.removeTxLocked(spending.txid); err != nil {
+		t.Fatalf("removeTxLocked(spending): %v", err)
+	}
+	if len(mp.txs) != 0 || len(owner.byToken) != 0 || len(owner.byOutpoint) != 0 {
+		t.Fatalf("after removal records=%d claims=%d outpoints=%d, want all empty", len(mp.txs), len(owner.byToken), len(owner.byOutpoint))
+	}
+	if owner.tokenHighWater != 1 {
+		t.Fatalf("token high-water=%d after removal, want the consumed sequence retained", owner.tokenHighWater)
+	}
+}
+
+// TestMempoolPendingOutpointCapacityReplacementReleasesVictimTokens proves the
+// capacity row: the evicting admission releases every exact victim token and
+// installs plus finalizes the candidate in ONE typed delta, so no victim's
+// outpoint survives its record and no sequence is reused.
+func TestMempoolPendingOutpointCapacityReplacementReleasesVictimTokens(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 2, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+	txBest := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 300_000, 3, fromKey, fromAddress, toAddress)
+	for _, txBytes := range [][]byte{txLow, txHigh} {
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx(setup %x): %v", txID(t, txBytes), err)
+		}
+	}
+	victimEntry, _ := residentClaim(t, mp, txID(t, txLow))
+	victimToken := victimEntry.token
+
+	if err := mp.AddTx(txBest); err != nil {
+		t.Fatalf("AddTx(best): %v", err)
+	}
+	if mp.Contains(txID(t, txLow)) {
+		t.Fatal("victim survived capacity replacement")
+	}
+	owner := mp.PendingOutpointOwner()
+	if _, ok := owner.txidForOutpoint(outpoints[0]); ok {
+		t.Fatal("victim outpoint is still claimed after its record was evicted")
+	}
+	owner.mu.Lock()
+	victimClaim := owner.byToken[victimToken]
+	owner.mu.Unlock()
+	if victimClaim != nil {
+		t.Fatalf("victim claim %+v survived its record", victimClaim)
+	}
+	// An exact retry of the victim release is harmless and leaves no tombstone.
+	if err := owner.Release(victimToken); err != nil {
+		t.Fatalf("exact victim Release retry: %v", err)
+	}
+	for _, txBytes := range [][]byte{txHigh, txBest} {
+		entry, claim := residentClaim(t, mp, txID(t, txBytes))
+		if claim == nil || !claim.finalized || claim.txid != entry.txid {
+			t.Fatalf("survivor %x claim=%+v, want its own finalized claim", entry.txid, claim)
+		}
+	}
+	gotOutpoints, gotClaims, gotHighWater := ownerCounts(mp)
+	if gotOutpoints != 2 || gotClaims != 2 || gotHighWater != 3 {
+		t.Fatalf("owner state=(outpoints=%d claims=%d high_water=%d), want 2/2/3", gotOutpoints, gotClaims, gotHighWater)
+	}
+}
+
+// TestMempoolPendingOutpointBlockCleanupReleasesExactTokens pins the terminal
+// block rows: a connected block releases the exact tokens of both the entries
+// it includes and the entries it conflicts with, and the public eviction entry
+// point does the same for inclusion alone.
+func TestMempoolPendingOutpointBlockCleanupReleasesExactTokens(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	included := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	resident := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
+	// conflicting spends the same outpoint as resident but never enters the pool.
+	conflicting := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90_000, 100_000, 3, fromKey, fromAddress, toAddress)
+	for _, txBytes := range [][]byte{included, resident} {
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx(%x): %v", txID(t, txBytes), err)
+		}
+	}
+
+	parsed, err := consensus.ParseBlockBytes(buildMultiTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, included, conflicting))
+	if err != nil {
+		t.Fatalf("ParseBlockBytes: %v", err)
+	}
+	if err := mp.applyConnectedBlockParsed(parsed); err != nil {
+		t.Fatalf("applyConnectedBlockParsed: %v", err)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("mempool len=%d, want 0 after inclusion plus conflict cleanup", got)
+	}
+	gotOutpoints, gotClaims, gotHighWater := ownerCounts(mp)
+	if gotOutpoints != 0 || gotClaims != 0 {
+		t.Fatalf("owner still holds outpoints=%d claims=%d after cleanup", gotOutpoints, gotClaims)
+	}
+	if gotHighWater != 2 {
+		t.Fatalf("token high-water=%d after cleanup, want the two consumed sequences retained", gotHighWater)
+	}
+
+	// Public EvictConfirmedParsed releases the exact token of an included entry.
+	if err := mp.AddTx(resident); err != nil {
+		t.Fatalf("AddTx(re-admit): %v", err)
+	}
+	entry, _ := residentClaim(t, mp, txID(t, resident))
+	if entry.token.seq != 3 {
+		t.Fatalf("re-admitted seq=%d, want 3 (no sequence reuse)", entry.token.seq)
+	}
+	evictBlock, err := consensus.ParseBlockBytes(buildSingleTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, resident))
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(evict): %v", err)
+	}
+	if err := mp.EvictConfirmedParsed(evictBlock); err != nil {
+		t.Fatalf("EvictConfirmedParsed: %v", err)
+	}
+	if gotOutpoints, gotClaims, _ := ownerCounts(mp); gotOutpoints != 0 || gotClaims != 0 {
+		t.Fatalf("owner still holds outpoints=%d claims=%d after eviction", gotOutpoints, gotClaims)
+	}
+}
+
+// TestMempoolSnapshotPendingOutpointRoundTripRestoresExactTokens proves the
+// same-owner rollback row: a restore rebuilds every record with its exact token
+// and finalized claim, discards state admitted after the snapshot, and leaves
+// both high-waters at their advanced values so no sequence is ever reused.
+func TestMempoolSnapshotPendingOutpointRoundTripRestoresExactTokens(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	kept := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(kept); err != nil {
+		t.Fatalf("AddTx(kept): %v", err)
+	}
+	keptEntry, _ := residentClaim(t, mp, txID(t, kept))
+	keptToken := keptEntry.token
+
+	snapshot, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+	discarded := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(discarded); err != nil {
+		t.Fatalf("AddTx(discarded): %v", err)
+	}
+	if err := restoreMempoolSnapshot(mp, snapshot); err != nil {
+		t.Fatalf("restoreMempoolSnapshot: %v", err)
+	}
+
+	if mp.Contains(txID(t, discarded)) {
+		t.Fatal("restore kept a record admitted after the snapshot")
+	}
+	restored, claim := residentClaim(t, mp, txID(t, kept))
+	if restored.token != keptToken {
+		t.Fatalf("restored token seq=%d, want the exact pre-snapshot seq %d", restored.token.seq, keptToken.seq)
+	}
+	if claim == nil || !claim.finalized || claim.txid != restored.txid {
+		t.Fatalf("restored claim=%+v, want the exact finalized claim", claim)
+	}
+	if _, ok := mp.PendingOutpointOwner().txidForOutpoint(outpoints[1]); ok {
+		t.Fatal("restore left the discarded candidate's outpoint claimed")
+	}
+	gotOutpoints, gotClaims, gotHighWater := ownerCounts(mp)
+	if gotOutpoints != 1 || gotClaims != 1 {
+		t.Fatalf("restored owner state=(outpoints=%d claims=%d), want 1/1", gotOutpoints, gotClaims)
+	}
+	if gotHighWater != 2 {
+		t.Fatalf("token high-water=%d after restore, want the advanced value 2 retained", gotHighWater)
+	}
+	// The retained high-water is what stops a reused sequence after the abort.
+	next := mustReserve(t, mp.PendingOutpointOwner(), [32]byte{0xfe}, testOutpoint(77))
+	if next.seq != 3 {
+		t.Fatalf("post-restore reservation seq=%d, want 3", next.seq)
+	}
+}
+
+// TestMempoolSnapshotPendingOutpointRejectsBrokenClaimBinding pins all four
+// snapshot rejection rows: a record whose token has no finalized standard claim,
+// a standard claim with no record, an input-less record carrying a token, and a
+// claim whose inputs disagree with its record. A refused restore publishes
+// NEITHER half — records and owner claims both stay exactly pre-restore.
+func TestMempoolSnapshotPendingOutpointRejectsBrokenClaimBinding(t *testing.T) {
+	base := func(t *testing.T) (*Mempool, mempoolSnapshot, [32]byte) {
+		t.Helper()
+		fromKey := mustNodeMLDSA87Keypair(t)
+		toKey := mustNodeMLDSA87Keypair(t)
+		fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+		toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+		mp, err := NewMempool(st, nil, devnetGenesisChainID)
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx: %v", err)
+		}
+		snapshot, err := snapshotMempool(mp)
+		if err != nil {
+			t.Fatalf("snapshotMempool: %v", err)
+		}
+		return mp, snapshot, txID(t, txBytes)
+	}
+	cases := map[string]func(*mempoolSnapshot){
+		"record without claim": func(s *mempoolSnapshot) { s.pending.claims = nil },
+		"claim without record": func(s *mempoolSnapshot) { s.entries = nil },
+		"token on input-less record": func(s *mempoolSnapshot) {
+			s.entries[0].inputs = nil
+			s.pending.claims = nil
+		},
+		"claim input mismatch": func(s *mempoolSnapshot) {
+			s.pending.claims[0].inputs = []consensus.Outpoint{testOutpoint(123)}
+		},
+	}
+	for name, corrupt := range cases {
+		t.Run(name, func(t *testing.T) {
+			mp, snapshot, txid := base(t)
+			beforeLen := mp.Len()
+			mp.mu.RLock()
+			claimedOutpoint := mp.txs[txid].inputs[0]
+			mp.mu.RUnlock()
+			beforeOutpoints, beforeClaims, beforeHighWater := ownerCounts(mp)
+			corrupt(&snapshot)
+			if err := restoreMempoolSnapshot(mp, snapshot); err == nil {
+				t.Fatalf("restore accepted a %s snapshot", name)
+			}
+			if mp.Len() != beforeLen || !mp.Contains(txid) {
+				t.Fatalf("refused restore published records: len=%d contains=%v", mp.Len(), mp.Contains(txid))
+			}
+			// The OWNER half too: publishing the snapshot image while the records
+			// stay pre-restore is exactly the torn state this ordering forbids.
+			gotOutpoints, gotClaims, gotHighWater := ownerCounts(mp)
+			if gotOutpoints != beforeOutpoints || gotClaims != beforeClaims || gotHighWater != beforeHighWater {
+				t.Fatalf("refused restore published owner state=(%d,%d,%d), want (%d,%d,%d)",
+					gotOutpoints, gotClaims, gotHighWater, beforeOutpoints, beforeClaims, beforeHighWater)
+			}
+			if got, ok := mp.PendingOutpointOwner().txidForOutpoint(claimedOutpoint); !ok || got != txid {
+				t.Fatalf("refused restore rewrote the owner index: got=(%x,%v), want %x", got, ok, txid)
+			}
+		})
 	}
 }
 

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -28,6 +28,20 @@ func NewCanonicalMempoolTxPool(mempool *node.Mempool) *CanonicalMempoolTxPool {
 	return &CanonicalMempoolTxPool{mempool: mempool}
 }
 
+// PendingOutpointOwner returns the pointer-identical pending-outpoint owner of
+// the adapted canonical mempool, so a relay-side consumer binds to the same
+// single authority instead of starting a second one. Nil-safe on a nil adapter
+// or a nil adapted mempool.
+//
+// Deliberately NOT part of the generic TxPool interface: the interface stays
+// the narrow relay contract, and only this concrete adapter exposes the owner.
+func (p *CanonicalMempoolTxPool) PendingOutpointOwner() *node.PendingOutpointOwner {
+	if p == nil {
+		return nil
+	}
+	return p.mempool.PendingOutpointOwner()
+}
+
 func (p *CanonicalMempoolTxPool) Get(txid [32]byte) ([]byte, bool) {
 	if p == nil || p.mempool == nil {
 		return nil, false

--- a/clients/go/node/p2p/mempool_test.go
+++ b/clients/go/node/p2p/mempool_test.go
@@ -3,7 +3,44 @@ package p2p
 import (
 	"sync"
 	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
+
+// TestCanonicalMempoolTxPoolPendingOutpointOwner proves the relay adapter hands
+// back the POINTER-IDENTICAL owner of the mempool it adapts, so a relay-side
+// consumer binds to the one authority instead of starting a second, and that
+// the accessor stays off the generic TxPool interface.
+func TestCanonicalMempoolTxPoolPendingOutpointOwner(t *testing.T) {
+	mempool, err := node.NewMempool(node.NewChainState(), nil, [32]byte{})
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	owner := mempool.PendingOutpointOwner()
+	if owner == nil {
+		t.Fatal("mempool has no owner")
+	}
+	if got := NewCanonicalMempoolTxPool(mempool).PendingOutpointOwner(); got != owner {
+		t.Fatalf("adapter owner=%p, want the pointer-identical mempool owner %p", got, owner)
+	}
+
+	var nilAdapter *CanonicalMempoolTxPool
+	if got := nilAdapter.PendingOutpointOwner(); got != nil {
+		t.Fatalf("nil adapter owner=%p, want nil", got)
+	}
+	if got := NewCanonicalMempoolTxPool(nil).PendingOutpointOwner(); got != nil {
+		t.Fatalf("nil-backed adapter owner=%p, want nil", got)
+	}
+
+	// Widening the generic TxPool interface with the accessor would force every
+	// implementation to carry it. MemoryTxPool must not.
+	var generic TxPool = NewMemoryTxPool()
+	if _, widened := generic.(interface {
+		PendingOutpointOwner() *node.PendingOutpointOwner
+	}); widened {
+		t.Fatal("the generic TxPool surface was widened with the owner accessor")
+	}
+}
 
 func TestMemoryTxPool_PutAndGet(t *testing.T) {
 	pool := NewMemoryTxPool()

--- a/clients/go/node/pending_outpoint_owner.go
+++ b/clients/go/node/pending_outpoint_owner.go
@@ -176,14 +176,25 @@ func validatePendingOutpointRequest(
 }
 
 // checkReserveAvailableLocked reports whether the owner can issue a reservation
-// bound to expectedTip at all. It only reads owner state under the caller's
-// o.mu and mutates nothing; every failure here is unavailable, never a conflict.
-func (o *PendingOutpointOwner) checkReserveAvailableLocked(expectedTip PendingOutpointTip) error {
+// bound to the COMPLETE context the caller observed. The checks run in exactly
+// this order — active transition, exact stable tip, exact generation, sequence
+// space — each failure is unavailable rather than a conflict, and it only reads
+// owner state under the caller's o.mu.
+//
+// The generation term is what a tip comparison alone cannot express: after an
+// A->B->A reorg, or an aborted transition, the stable tip compares equal to a
+// context cached BEFORE that transition while everything derived under it is
+// stale. Generation never decreases or repeats, so an older expected generation
+// loses here, before the conflict scan and before any sequence is consumed.
+func (o *PendingOutpointOwner) checkReserveAvailableLocked(expected PendingOutpointAdmissionContext) error {
 	if o.inTransition {
 		return pendingOutpointUnavailable("pending-outpoint owner transition in progress")
 	}
-	if expectedTip != o.stableTip {
+	if expected.StableTip != o.stableTip {
 		return pendingOutpointUnavailable("pending-outpoint expected tip mismatch")
+	}
+	if expected.Generation != o.generation {
+		return pendingOutpointUnavailable("pending-outpoint expected generation mismatch")
 	}
 	if o.tokenHighWater == ^uint64(0) {
 		return pendingOutpointUnavailable("pending-outpoint token sequence exhausted")
@@ -211,15 +222,19 @@ func (o *PendingOutpointOwner) checkNoConflictLocked(orderedInputs []consensus.O
 }
 
 // Reserve claims every outpoint in orderedInputs for txid in domain, bound to
-// expectedTip. It validates the request (owner, domain, txid, input set) before
-// it looks at availability or conflicts, so a malformed request is an internal
-// error that mutates nothing and consumes no sequence. Availability failures —
-// active transition, expected-tip mismatch, sequence exhaustion — and the first
-// conflict in canonical input order likewise mutate nothing. Every check is a
-// pure read that completes before the first write below. On success exactly one
-// sequence is consumed and the complete reserved claim is installed.
+// the COMPLETE admission context the caller observed — stable tip AND
+// generation, deliberately not a tip alone, so a caller that decided anything
+// under an older generation loses instead of reserving against state it never
+// saw. It validates the request (owner, domain, txid, input set) before it looks
+// at availability or conflicts, so a malformed request is an internal error that
+// mutates nothing and consumes no sequence. Availability failures — active
+// transition, expected-tip mismatch, expected-generation mismatch, sequence
+// exhaustion — and the first conflict in canonical input order likewise mutate
+// nothing: every check is a pure read that completes before the first write
+// below. On success exactly one sequence is consumed and the complete reserved
+// claim is installed.
 func (o *PendingOutpointOwner) Reserve(
-	expectedTip PendingOutpointTip,
+	expectedContext PendingOutpointAdmissionContext,
 	domain PendingOutpointDomain,
 	txid [32]byte,
 	orderedInputs []consensus.Outpoint,
@@ -234,7 +249,7 @@ func (o *PendingOutpointOwner) Reserve(
 
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if err := o.checkReserveAvailableLocked(expectedTip); err != nil {
+	if err := o.checkReserveAvailableLocked(expectedContext); err != nil {
 		return zero, err
 	}
 	if err := o.checkNoConflictLocked(orderedInputs); err != nil {
@@ -276,10 +291,26 @@ func (o *PendingOutpointOwner) AdmissionContext() (PendingOutpointAdmissionConte
 	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	return o.admissionContextLocked()
+}
+
+// admissionContextLocked is AdmissionContext's body for a caller that already
+// holds o.mu: the binding recheck compares the context and installs the pointer
+// without releasing the owner mutex in between.
+func (o *PendingOutpointOwner) admissionContextLocked() (PendingOutpointAdmissionContext, bool) {
 	if o.inTransition || o.generation == ^uint64(0) {
 		return PendingOutpointAdmissionContext{}, false
 	}
 	return PendingOutpointAdmissionContext{StableTip: o.stableTip, Generation: o.generation}, true
+}
+
+// checkNoClaimsLocked proves the owner holds no live claim in either index. The
+// caller holds o.mu.
+func (o *PendingOutpointOwner) checkNoClaimsLocked() error {
+	if len(o.byOutpoint) != 0 || len(o.byToken) != 0 {
+		return pendingOutpointInternal(fmt.Sprintf("pending-outpoint owner holds %d outpoint and %d token claims", len(o.byOutpoint), len(o.byToken)))
+	}
+	return nil
 }
 
 // Finalize publishes a reserved claim of the current generation. An exact retry

--- a/clients/go/node/pending_outpoint_owner.go
+++ b/clients/go/node/pending_outpoint_owner.go
@@ -1,0 +1,737 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// PendingOutpointDomain names the pool that owns a pending-outpoint claim.
+// StandardMempool is the only domain this issue creates claims for; the DA
+// value exists so a later DA consumer binds to the same owner instead of
+// starting a second spend authority.
+type PendingOutpointDomain uint8
+
+const (
+	// PendingOutpointStandardMempool is the standard Mempool admission domain.
+	PendingOutpointStandardMempool PendingOutpointDomain = 1
+	// PendingOutpointDA is the data-availability domain. No record, route,
+	// lock, eviction or lifecycle behavior is attached to it here.
+	PendingOutpointDA PendingOutpointDomain = 2
+)
+
+func (d PendingOutpointDomain) valid() bool {
+	return d == PendingOutpointStandardMempool || d == PendingOutpointDA
+}
+
+// PendingOutpointTip is the stable canonical tip a reservation is bound to.
+// A reservation whose expected tip differs from the owner's committed stable
+// tip is unavailable, never a conflict.
+type PendingOutpointTip struct {
+	HasTip bool
+	Height uint64
+	Hash   [32]byte
+}
+
+func pendingOutpointTipOf(s *ChainState) PendingOutpointTip {
+	view := s.view()
+	return PendingOutpointTip{HasTip: view.hasTip, Height: view.height, Hash: view.tipHash}
+}
+
+// PendingOutpointAdmissionContext is one linearizable read of the owner's
+// admission-visible state: the exact stable canonical tip reservations are
+// currently bound to, and the monotonic transition generation that tip belongs
+// to.
+//
+// Generation is the cache-validity term. The initial stable context and every
+// begun canonical transition have DISTINCT generations, and neither a commit
+// nor an abort ever decreases or reuses the generation high-water, so an
+// A->B->A reorg and a failed transition both produce a generation no earlier
+// context ever carried. A downstream policy cache may therefore treat an
+// unchanged generation, and only that, as "nothing observable moved".
+type PendingOutpointAdmissionContext struct {
+	StableTip  PendingOutpointTip
+	Generation uint64
+}
+
+// PendingOutpointToken identifies exactly one reservation. It is comparable and
+// opaque outside package node: it carries the issuing owner's identity and a
+// nonzero monotonic sequence, has no exported constructor, and is never
+// serialized. A token from a previous process, or from any other owner, is
+// foreign to this owner by construction.
+type PendingOutpointToken struct {
+	owner *PendingOutpointOwner
+	seq   uint64
+}
+
+// PendingOutpointErrorKind classifies pending-outpoint failures.
+type PendingOutpointErrorKind uint8
+
+const (
+	// PendingOutpointConflict reports an outpoint already claimed by another
+	// live reservation. Evidence names the first conflicting outpoint in the
+	// supplied input order, its index, and the claiming txid.
+	PendingOutpointConflict PendingOutpointErrorKind = iota + 1
+	// PendingOutpointUnavailable reports a temporarily closed owner: an active
+	// canonical transition, an expected-tip mismatch, a stale generation, or an
+	// exhausted sequence space.
+	PendingOutpointUnavailable
+	// PendingOutpointInternal reports a malformed request or an owner-state
+	// inconsistency. It never publishes domain state.
+	PendingOutpointInternal
+)
+
+// PendingOutpointError is the typed owner error. Conflict evidence fields are
+// meaningful only for PendingOutpointConflict.
+type PendingOutpointError struct {
+	Kind         PendingOutpointErrorKind
+	Msg          string
+	Outpoint     consensus.Outpoint
+	InputIndex   int
+	ExistingTxid [32]byte
+}
+
+func (e *PendingOutpointError) Error() string { return e.Msg }
+
+func pendingOutpointInternal(msg string) *PendingOutpointError {
+	return &PendingOutpointError{Kind: PendingOutpointInternal, Msg: msg}
+}
+
+func pendingOutpointUnavailable(msg string) *PendingOutpointError {
+	return &PendingOutpointError{Kind: PendingOutpointUnavailable, Msg: msg}
+}
+
+// pendingOutpointClaim is one live reservation. inputs keeps the exact caller
+// order so a release compare-deletes precisely the rows it installed.
+type pendingOutpointClaim struct {
+	token      PendingOutpointToken
+	domain     PendingOutpointDomain
+	txid       [32]byte
+	inputs     []consensus.Outpoint
+	generation uint64
+	finalized  bool
+}
+
+// pendingOutpointRow is the by-outpoint index row. It carries the exact owner
+// identity and token sequence, so a stale release can never delete a newer
+// claim that happens to cover the same outpoint.
+type pendingOutpointRow struct {
+	token PendingOutpointToken
+	txid  [32]byte
+}
+
+// PendingOutpointOwner is the single authority over outpoints claimed by
+// in-flight and resident pool candidates.
+//
+// Lock contract: callers acquire ChainState.admissionMu, then Mempool.mu, then
+// this owner's mutex. The mutex is never held across parsing, consensus
+// validation, signature work, I/O, relay or waiting.
+type PendingOutpointOwner struct {
+	mu             sync.Mutex
+	byOutpoint     map[consensus.Outpoint]pendingOutpointRow
+	byToken        map[PendingOutpointToken]*pendingOutpointClaim
+	tokenHighWater uint64
+	generation     uint64
+	inTransition   bool
+	stableTip      PendingOutpointTip
+}
+
+func newPendingOutpointOwner(tip PendingOutpointTip) *PendingOutpointOwner {
+	return &PendingOutpointOwner{
+		byOutpoint: make(map[consensus.Outpoint]pendingOutpointRow),
+		byToken:    make(map[PendingOutpointToken]*pendingOutpointClaim),
+		stableTip:  tip,
+	}
+}
+
+// validatePendingOutpointRequest checks a reservation request in isolation:
+// domain, txid, and the input set. It reads no owner state, acquires no lock,
+// and mutates nothing, so a malformed request is rejected as internal before the
+// owner mutex is taken and can consume no sequence.
+func validatePendingOutpointRequest(
+	domain PendingOutpointDomain,
+	txid [32]byte,
+	orderedInputs []consensus.Outpoint,
+) error {
+	if !domain.valid() {
+		return pendingOutpointInternal(fmt.Sprintf("invalid pending-outpoint domain %d", uint8(domain)))
+	}
+	if txid == ([32]byte{}) {
+		return pendingOutpointInternal("zero pending-outpoint txid")
+	}
+	if len(orderedInputs) == 0 {
+		return pendingOutpointInternal("empty pending-outpoint input set")
+	}
+	seen := make(map[consensus.Outpoint]struct{}, len(orderedInputs))
+	for _, op := range orderedInputs {
+		if _, dup := seen[op]; dup {
+			return pendingOutpointInternal(fmt.Sprintf("duplicate pending-outpoint input txid=%x vout=%d", op.Txid, op.Vout))
+		}
+		seen[op] = struct{}{}
+	}
+	return nil
+}
+
+// checkReserveAvailableLocked reports whether the owner can issue a reservation
+// bound to expectedTip at all. It only reads owner state under the caller's
+// o.mu and mutates nothing; every failure here is unavailable, never a conflict.
+func (o *PendingOutpointOwner) checkReserveAvailableLocked(expectedTip PendingOutpointTip) error {
+	if o.inTransition {
+		return pendingOutpointUnavailable("pending-outpoint owner transition in progress")
+	}
+	if expectedTip != o.stableTip {
+		return pendingOutpointUnavailable("pending-outpoint expected tip mismatch")
+	}
+	if o.tokenHighWater == ^uint64(0) {
+		return pendingOutpointUnavailable("pending-outpoint token sequence exhausted")
+	}
+	return nil
+}
+
+// checkNoConflictLocked reports the FIRST outpoint of orderedInputs already held
+// by a live claim, in the supplied canonical input order. It only reads the
+// by-outpoint index under the caller's o.mu and mutates nothing, so a conflict
+// leaves no partial claim behind.
+func (o *PendingOutpointOwner) checkNoConflictLocked(orderedInputs []consensus.Outpoint) error {
+	for index, op := range orderedInputs {
+		if row, taken := o.byOutpoint[op]; taken {
+			return &PendingOutpointError{
+				Kind:         PendingOutpointConflict,
+				Msg:          fmt.Sprintf("mempool double-spend conflict with %x", row.txid),
+				Outpoint:     op,
+				InputIndex:   index,
+				ExistingTxid: row.txid,
+			}
+		}
+	}
+	return nil
+}
+
+// Reserve claims every outpoint in orderedInputs for txid in domain, bound to
+// expectedTip. It validates the request (owner, domain, txid, input set) before
+// it looks at availability or conflicts, so a malformed request is an internal
+// error that mutates nothing and consumes no sequence. Availability failures —
+// active transition, expected-tip mismatch, sequence exhaustion — and the first
+// conflict in canonical input order likewise mutate nothing. Every check is a
+// pure read that completes before the first write below. On success exactly one
+// sequence is consumed and the complete reserved claim is installed.
+func (o *PendingOutpointOwner) Reserve(
+	expectedTip PendingOutpointTip,
+	domain PendingOutpointDomain,
+	txid [32]byte,
+	orderedInputs []consensus.Outpoint,
+) (PendingOutpointToken, error) {
+	var zero PendingOutpointToken
+	if o == nil {
+		return zero, pendingOutpointInternal("nil pending-outpoint owner")
+	}
+	if err := validatePendingOutpointRequest(domain, txid, orderedInputs); err != nil {
+		return zero, err
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.checkReserveAvailableLocked(expectedTip); err != nil {
+		return zero, err
+	}
+	if err := o.checkNoConflictLocked(orderedInputs); err != nil {
+		return zero, err
+	}
+	o.tokenHighWater++
+	token := PendingOutpointToken{owner: o, seq: o.tokenHighWater}
+	o.byToken[token] = &pendingOutpointClaim{
+		token:      token,
+		domain:     domain,
+		txid:       txid,
+		inputs:     append([]consensus.Outpoint(nil), orderedInputs...),
+		generation: o.generation,
+	}
+	for _, op := range orderedInputs {
+		o.byOutpoint[op] = pendingOutpointRow{token: token, txid: txid}
+	}
+	return token, nil
+}
+
+// AdmissionContext reports the current stable tip and generation, read under
+// ONE owner-lock acquisition so the pair is always internally consistent. It
+// mutates nothing.
+//
+// It returns false — never a stale or partial context — when the owner is nil,
+// when a canonical transition is active (including the terminal fail-closed
+// state a latched post-commit persistence fault leaves behind), or when the
+// generation space is exhausted so no further transition could ever be
+// distinguished. A reader racing a transition begin therefore observes either
+// the prior stable context or unavailability, never a stable context paired
+// with an active transition.
+//
+// This is the ONLY downstream policy-generation seam on the owner: it adds no
+// generic TxPool method, no cache, no callback, no notification hook and no DA
+// behavior.
+func (o *PendingOutpointOwner) AdmissionContext() (PendingOutpointAdmissionContext, bool) {
+	if o == nil {
+		return PendingOutpointAdmissionContext{}, false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.inTransition || o.generation == ^uint64(0) {
+		return PendingOutpointAdmissionContext{}, false
+	}
+	return PendingOutpointAdmissionContext{StableTip: o.stableTip, Generation: o.generation}, true
+}
+
+// Finalize publishes a reserved claim of the current generation. An exact retry
+// of an already-finalized current-generation token succeeds without a second
+// mutation. Finalization during a transition, after a release, or from an older
+// generation is unavailable and publishes nothing; an invalid or foreign token
+// identity is internal.
+func (o *PendingOutpointOwner) Finalize(token PendingOutpointToken) error {
+	if o == nil {
+		return pendingOutpointInternal("nil pending-outpoint owner")
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	claim, err := o.claimForTokenLocked(token)
+	if err != nil {
+		return err
+	}
+	if o.inTransition {
+		return pendingOutpointUnavailable("pending-outpoint owner transition in progress")
+	}
+	if claim == nil {
+		return pendingOutpointUnavailable("pending-outpoint token is no longer live")
+	}
+	if claim.generation != o.generation {
+		return pendingOutpointUnavailable("pending-outpoint token belongs to an older generation")
+	}
+	if claim.finalized {
+		return nil
+	}
+	claim.finalized = true
+	return nil
+}
+
+// Release drops a claim and every by-outpoint row it installed, or drops none.
+// It is generation-independent and remains valid during a transition. An exact
+// retry after the claim is already gone succeeds and leaves no tombstone. A
+// zero token, a foreign owner, a sequence above the high-water mark, or a
+// partially matching live index is internal and changes nothing.
+func (o *PendingOutpointOwner) Release(token PendingOutpointToken) error {
+	if o == nil {
+		return pendingOutpointInternal("nil pending-outpoint owner")
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	claim, err := o.claimForTokenLocked(token)
+	if err != nil || claim == nil {
+		return err
+	}
+	for _, op := range claim.inputs {
+		if row, ok := o.byOutpoint[op]; !ok || row.token != token {
+			return pendingOutpointInternal(fmt.Sprintf("pending-outpoint index mismatch for txid=%x vout=%d", op.Txid, op.Vout))
+		}
+	}
+	o.dropClaimLocked(token)
+	return nil
+}
+
+// pendingOutpointIndex is one by-outpoint / by-token index pair plus the token
+// high-water it was built under. The owner's LIVE pair and a not-yet-published
+// restore candidate are both read through it, so one binding rule serves both
+// and a restore is proven consistent BEFORE anything becomes visible.
+type pendingOutpointIndex struct {
+	owner          *PendingOutpointOwner
+	byOutpoint     map[consensus.Outpoint]pendingOutpointRow
+	byToken        map[PendingOutpointToken]*pendingOutpointClaim
+	tokenHighWater uint64
+}
+
+// indexLocked views the owner's live indexes. The caller holds o.mu.
+func (o *PendingOutpointOwner) indexLocked() pendingOutpointIndex {
+	return pendingOutpointIndex{
+		owner:          o,
+		byOutpoint:     o.byOutpoint,
+		byToken:        o.byToken,
+		tokenHighWater: o.tokenHighWater,
+	}
+}
+
+// claimForToken resolves an owner-issued token. It reports an internal error for
+// an identity this owner never issued, and (nil, nil) for a valid past sequence
+// that no longer has a live claim.
+func (ix pendingOutpointIndex) claimForToken(token PendingOutpointToken) (*pendingOutpointClaim, error) {
+	if token.owner != ix.owner || token.seq == 0 {
+		return nil, pendingOutpointInternal("zero or foreign pending-outpoint token")
+	}
+	if token.seq > ix.tokenHighWater {
+		return nil, pendingOutpointInternal("pending-outpoint token sequence above high-water")
+	}
+	return ix.byToken[token], nil
+}
+
+func (o *PendingOutpointOwner) claimForTokenLocked(token PendingOutpointToken) (*pendingOutpointClaim, error) {
+	return o.indexLocked().claimForToken(token)
+}
+
+// dropClaimLocked deletes an already-validated claim. It cannot fail, so a
+// commit that validated its whole delta first has no error-capable step left.
+func (o *PendingOutpointOwner) dropClaimLocked(token PendingOutpointToken) {
+	claim := o.byToken[token]
+	if claim == nil {
+		return
+	}
+	for _, op := range claim.inputs {
+		if row, ok := o.byOutpoint[op]; ok && row.token == token {
+			delete(o.byOutpoint, op)
+		}
+	}
+	delete(o.byToken, token)
+}
+
+// checkInputLessEntryToken proves that an input-less record carries the zero
+// token, the only shape an entry with no claim may have. It reads no index and
+// mutates nothing.
+func checkInputLessEntryToken(txid [32]byte, token PendingOutpointToken) error {
+	if token != (PendingOutpointToken{}) {
+		return pendingOutpointInternal(fmt.Sprintf("pending-outpoint token on input-less entry %x", txid))
+	}
+	return nil
+}
+
+// checkClaimInputs proves that claim covers exactly inputs, in the same order,
+// and that every one of those outpoints is indexed back to the same token. It
+// only reads the index and mutates nothing.
+func (ix pendingOutpointIndex) checkClaimInputs(
+	txid [32]byte,
+	inputs []consensus.Outpoint,
+	claim *pendingOutpointClaim,
+	token PendingOutpointToken,
+) error {
+	if len(claim.inputs) != len(inputs) {
+		return pendingOutpointInternal(fmt.Sprintf("pending-outpoint claim input count mismatch for entry %x", txid))
+	}
+	for i, op := range inputs {
+		row, ok := ix.byOutpoint[op]
+		if claim.inputs[i] != op || !ok || row.token != token {
+			return pendingOutpointInternal(fmt.Sprintf("pending-outpoint claim input mismatch for entry %x at index %d", txid, i))
+		}
+	}
+	return nil
+}
+
+// validateEntryClaim proves that a pool record and its claim agree exactly: same
+// owner, sequence, domain, txid, ordered inputs, index rows and phase. An
+// input-less record carries no claim and MUST carry no token. It only reads the
+// index and mutates nothing.
+func (ix pendingOutpointIndex) validateEntryClaim(
+	txid [32]byte,
+	inputs []consensus.Outpoint,
+	token PendingOutpointToken,
+	wantFinalized bool,
+) error {
+	if len(inputs) == 0 {
+		return checkInputLessEntryToken(txid, token)
+	}
+	claim, err := ix.claimForToken(token)
+	if err != nil {
+		return err
+	}
+	if claim == nil {
+		return pendingOutpointInternal(fmt.Sprintf("no live pending-outpoint claim for entry %x", txid))
+	}
+	if claim.domain != PendingOutpointStandardMempool || claim.txid != txid || claim.finalized != wantFinalized {
+		return pendingOutpointInternal(fmt.Sprintf("pending-outpoint claim mismatch for entry %x", txid))
+	}
+	return ix.checkClaimInputs(txid, inputs, claim, token)
+}
+
+func (o *PendingOutpointOwner) validateEntryClaimLocked(
+	txid [32]byte,
+	inputs []consensus.Outpoint,
+	token PendingOutpointToken,
+	wantFinalized bool,
+) error {
+	return o.indexLocked().validateEntryClaim(txid, inputs, token, wantFinalized)
+}
+
+// txidForOutpoint reports the txid currently claiming op, if any.
+func (o *PendingOutpointOwner) txidForOutpoint(op consensus.Outpoint) ([32]byte, bool) {
+	if o == nil {
+		return [32]byte{}, false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	row, ok := o.byOutpoint[op]
+	return row.txid, ok
+}
+
+// beginTransition opens exactly one canonical transition and advances the
+// generation high-water. Reserve and Finalize are unavailable until the
+// transition commits its stable tip or aborts. A nil owner means no pool is
+// bound to the engine and is a no-op, not an error.
+func (o *PendingOutpointOwner) beginTransition() (uint64, error) {
+	if o == nil {
+		return 0, nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.inTransition {
+		return 0, pendingOutpointUnavailable("pending-outpoint owner transition already active")
+	}
+	if o.generation == ^uint64(0) {
+		return 0, pendingOutpointUnavailable("pending-outpoint generation exhausted")
+	}
+	o.generation++
+	o.inTransition = true
+	return o.generation, nil
+}
+
+// commitStableTip publishes the transition's stable tip and reopens admission.
+// It is the last step of a successful transition.
+func (o *PendingOutpointOwner) commitStableTip(tip PendingOutpointTip) error {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.inTransition {
+		return pendingOutpointInternal("pending-outpoint stable tip commit without an active transition")
+	}
+	o.stableTip = tip
+	o.inTransition = false
+	return nil
+}
+
+// endTransitionAborted reopens admission after an exact restore. The stable tip
+// keeps its pre-transition value; token and generation high-waters stay
+// advanced so no sequence is ever reused.
+func (o *PendingOutpointOwner) endTransitionAborted() {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.inTransition = false
+}
+
+// pendingOutpointSnapshot is the exact same-owner rollback image.
+type pendingOutpointSnapshot struct {
+	claims              []pendingOutpointClaim
+	stableTip           PendingOutpointTip
+	tokenHighWater      uint64
+	generationHighWater uint64
+}
+
+func (o *PendingOutpointOwner) snapshot() pendingOutpointSnapshot {
+	if o == nil {
+		return pendingOutpointSnapshot{}
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	claims := make([]pendingOutpointClaim, 0, len(o.byToken))
+	for _, claim := range o.byToken {
+		copied := *claim
+		copied.inputs = append([]consensus.Outpoint(nil), claim.inputs...)
+		claims = append(claims, copied)
+	}
+	// Sequence order, never map order: the snapshot is compared and restored
+	// verbatim, so its contents must not depend on map iteration.
+	sort.Slice(claims, func(i, j int) bool { return claims[i].token.seq < claims[j].token.seq })
+	return pendingOutpointSnapshot{
+		claims:              claims,
+		stableTip:           o.stableTip,
+		tokenHighWater:      o.tokenHighWater,
+		generationHighWater: o.generation,
+	}
+}
+
+// checkSnapshotClaim proves one snapshot claim is this owner's and well formed:
+// an owned nonzero sequence at or below the snapshot high-water, a valid domain,
+// a nonzero txid, and a nonempty input set. It reads no index and mutates
+// nothing.
+func (o *PendingOutpointOwner) checkSnapshotClaim(claim pendingOutpointClaim, tokenHighWater uint64) error {
+	if claim.token.owner != o || claim.token.seq == 0 || claim.token.seq > tokenHighWater {
+		return pendingOutpointInternal("foreign pending-outpoint token in snapshot")
+	}
+	if !claim.domain.valid() || claim.txid == ([32]byte{}) || len(claim.inputs) == 0 {
+		return pendingOutpointInternal(fmt.Sprintf("malformed pending-outpoint claim in snapshot for %x", claim.txid))
+	}
+	return nil
+}
+
+// buildRestoreLocked builds both candidate indexes from snap and publishes
+// NEITHER. The caller cross-checks them against the records it is about to
+// install and only then calls publishRestoreLocked, so owner image and records
+// become visible together or not at all. The caller holds o.mu.
+func (o *PendingOutpointOwner) buildRestoreLocked(snap pendingOutpointSnapshot) (pendingOutpointIndex, error) {
+	byOutpoint := make(map[consensus.Outpoint]pendingOutpointRow, len(snap.claims))
+	byToken := make(map[PendingOutpointToken]*pendingOutpointClaim, len(snap.claims))
+	for i := range snap.claims {
+		claim := snap.claims[i]
+		if err := o.checkSnapshotClaim(claim, snap.tokenHighWater); err != nil {
+			return pendingOutpointIndex{}, err
+		}
+		if _, dup := byToken[claim.token]; dup {
+			return pendingOutpointIndex{}, pendingOutpointInternal("duplicate pending-outpoint token in snapshot")
+		}
+		for _, op := range claim.inputs {
+			if _, dup := byOutpoint[op]; dup {
+				return pendingOutpointIndex{}, pendingOutpointInternal(fmt.Sprintf("duplicate pending-outpoint in snapshot txid=%x vout=%d", op.Txid, op.Vout))
+			}
+			byOutpoint[op] = pendingOutpointRow{token: claim.token, txid: claim.txid}
+		}
+		restored := claim
+		restored.inputs = append([]consensus.Outpoint(nil), claim.inputs...)
+		byToken[claim.token] = &restored
+	}
+	return pendingOutpointIndex{
+		owner:          o,
+		byOutpoint:     byOutpoint,
+		byToken:        byToken,
+		tokenHighWater: snap.tokenHighWater,
+	}, nil
+}
+
+// publishRestoreLocked installs an already-built, already-cross-checked candidate
+// index. It cannot fail, so no error-capable step remains once the owner image is
+// visible. High-waters never regress — the larger of current and snapshot wins —
+// so an aborted transition cannot hand out a sequence twice. Caller holds o.mu.
+func (o *PendingOutpointOwner) publishRestoreLocked(snap pendingOutpointSnapshot, candidate pendingOutpointIndex) {
+	o.byOutpoint = candidate.byOutpoint
+	o.byToken = candidate.byToken
+	if snap.tokenHighWater > o.tokenHighWater {
+		o.tokenHighWater = snap.tokenHighWater
+	}
+	if snap.generationHighWater > o.generation {
+		o.generation = snap.generationHighWater
+	}
+	o.stableTip = snap.stableTip
+}
+
+// standardMempoolDelta is the fully precomputed standard-domain change one
+// commit applies: at most one candidate entry plus a bounded exact list of
+// victim or terminal entries. Every entry carries its own exact token.
+type standardMempoolDelta struct {
+	candidate *mempoolEntry
+	removals  []*mempoolEntry
+}
+
+// commitStandardDeltaLocked applies delta to the standard Mempool records and
+// to the owner's claims together. The caller holds Mempool.mu.
+//
+// Everything fallible runs first: map allocation, record residency, and each
+// entry's exact claim. Once mutation begins under the owner mutex there is no
+// parse, validation, cryptography, I/O, wait, re-entry, callback, new lock, or
+// error-capable step left, so a record and its claim cannot become observably
+// separated. An exact idempotent retry performs no second domain mutation
+// because a removal that is no longer resident fails validation before any
+// write.
+func (m *Mempool) commitStandardDeltaLocked(delta standardMempoolDelta) error {
+	if m == nil {
+		return txAdmitUnavailable("nil mempool")
+	}
+	m.ensureIndexesLocked()
+	owner := m.pendingOutpointOwnerLocked()
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if err := m.validateStandardDeltaLocked(delta, owner); err != nil {
+		return err
+	}
+	for _, entry := range delta.removals {
+		m.deleteEntryLocked(entry.txid, entry)
+		owner.dropClaimLocked(entry.token)
+	}
+	if delta.candidate != nil {
+		m.assignAdmissionSeqLocked(delta.candidate)
+		m.insertEntryIndexesLocked(delta.candidate)
+		if claim := owner.byToken[delta.candidate.token]; claim != nil {
+			claim.finalized = true
+		}
+	}
+	return nil
+}
+
+// validateStandardRemovalsLocked proves every removal is a distinct resident
+// record whose exact finalized claim still matches it, recording each removed
+// txid in removed so the candidate cannot collide with one. It mutates neither
+// the Mempool nor the owner — removed is the caller's own accumulator, passed in
+// rather than returned so this function's complexity stays measurable by the
+// Codacy-parity gate, whose Go parser truncates a `struct{}` return type. The
+// caller holds Mempool.mu then owner.mu.
+func (m *Mempool) validateStandardRemovalsLocked(
+	removals []*mempoolEntry,
+	removed map[[32]byte]struct{},
+	owner *PendingOutpointOwner,
+) error {
+	for _, entry := range removals {
+		if entry == nil {
+			return txAdmitUnavailable("nil standard mempool terminal entry")
+		}
+		if _, dup := removed[entry.txid]; dup {
+			return txAdmitUnavailable(fmt.Sprintf("duplicate standard mempool terminal entry %x", entry.txid))
+		}
+		removed[entry.txid] = struct{}{}
+		if resident, ok := m.txs[entry.txid]; !ok || resident != entry {
+			return txAdmitUnavailable(fmt.Sprintf("standard mempool terminal entry %x is not resident", entry.txid))
+		}
+		if err := owner.validateEntryClaimLocked(entry.txid, entry.inputs, entry.token, true); err != nil {
+			return txAdmitFromPendingOutpointError(err)
+		}
+	}
+	return nil
+}
+
+// validateStandardCandidateLocked proves the candidate is not also being
+// removed, that the owner is not mid-transition, and that its exact reserved
+// claim belongs to the current generation. It only reads the owner indexes and
+// mutates nothing; the caller holds Mempool.mu then owner.mu.
+func validateStandardCandidateLocked(
+	candidate *mempoolEntry,
+	removed map[[32]byte]struct{},
+	owner *PendingOutpointOwner,
+) error {
+	if _, dup := removed[candidate.txid]; dup {
+		return txAdmitUnavailable(fmt.Sprintf("candidate %x is also a terminal entry", candidate.txid))
+	}
+	if owner.inTransition {
+		return txAdmitUnavailable("pending-outpoint owner transition in progress")
+	}
+	if err := owner.validateEntryClaimLocked(candidate.txid, candidate.inputs, candidate.token, false); err != nil {
+		return txAdmitFromPendingOutpointError(err)
+	}
+	if claim := owner.byToken[candidate.token]; claim != nil && claim.generation != owner.generation {
+		return txAdmitUnavailable("pending-outpoint token belongs to an older generation")
+	}
+	return nil
+}
+
+// validateStandardDeltaLocked runs the delta's complete removals-then-candidate
+// checking chain. It mutates neither the Mempool nor the owner, so it runs to
+// completion before commitStandardDeltaLocked writes anything.
+func (m *Mempool) validateStandardDeltaLocked(delta standardMempoolDelta, owner *PendingOutpointOwner) error {
+	removed := make(map[[32]byte]struct{}, len(delta.removals))
+	if err := m.validateStandardRemovalsLocked(delta.removals, removed, owner); err != nil {
+		return err
+	}
+	if delta.candidate == nil {
+		return nil
+	}
+	return validateStandardCandidateLocked(delta.candidate, removed, owner)
+}
+
+// txAdmitFromPendingOutpointError maps owner failures onto the existing public
+// admission kinds. A conflict keeps the existing mempool double-spend message
+// family; unavailable and internal both surface as TxAdmitUnavailable, so no
+// new public TxAdmit kind is introduced.
+func txAdmitFromPendingOutpointError(err error) error {
+	var ownerErr *PendingOutpointError
+	if !errors.As(err, &ownerErr) {
+		return txAdmitUnavailable(err.Error())
+	}
+	if ownerErr.Kind == PendingOutpointConflict {
+		return txAdmitConflict(ownerErr.Msg)
+	}
+	return txAdmitUnavailable(ownerErr.Msg)
+}

--- a/clients/go/node/pending_outpoint_owner_test.go
+++ b/clients/go/node/pending_outpoint_owner_test.go
@@ -23,7 +23,11 @@ func testOwnerKind(t *testing.T, err error) PendingOutpointErrorKind {
 
 func mustReserve(t *testing.T, o *PendingOutpointOwner, txid [32]byte, inputs ...consensus.Outpoint) PendingOutpointToken {
 	t.Helper()
-	token, err := o.Reserve(o.stableTip, PendingOutpointStandardMempool, txid, inputs)
+	admission, ok := o.AdmissionContext()
+	if !ok {
+		t.Fatalf("AdmissionContext unavailable before Reserve(%x)", txid)
+	}
+	token, err := o.Reserve(admission, PendingOutpointStandardMempool, txid, inputs)
 	if err != nil {
 		t.Fatalf("Reserve(%x): %v", txid, err)
 	}
@@ -63,19 +67,20 @@ func TestPendingOutpointOwnerReserveInstallsCompleteClaim(t *testing.T) {
 func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
 	otherTip := PendingOutpointTip{HasTip: true, Height: 7, Hash: [32]byte{0x77}}
 	cases := []struct {
-		name   string
-		setup  func(o *PendingOutpointOwner)
-		tip    PendingOutpointTip
-		domain PendingOutpointDomain
-		txid   [32]byte
-		inputs []consensus.Outpoint
-		want   PendingOutpointErrorKind
+		name      string
+		setup     func(o *PendingOutpointOwner)
+		admission PendingOutpointAdmissionContext
+		domain    PendingOutpointDomain
+		txid      [32]byte
+		inputs    []consensus.Outpoint
+		want      PendingOutpointErrorKind
 	}{
-		{"invalid domain", nil, PendingOutpointTip{}, PendingOutpointDomain(0), [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
-		{"zero txid", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
-		{"empty input set", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, nil, PendingOutpointInternal},
-		{"duplicate input", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1), testOutpoint(1)}, PendingOutpointInternal},
-		{"expected tip mismatch", nil, otherTip, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointUnavailable},
+		{"invalid domain", nil, PendingOutpointAdmissionContext{}, PendingOutpointDomain(0), [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
+		{"zero txid", nil, PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
+		{"empty input set", nil, PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x01}, nil, PendingOutpointInternal},
+		{"duplicate input", nil, PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1), testOutpoint(1)}, PendingOutpointInternal},
+		{"expected tip mismatch", nil, PendingOutpointAdmissionContext{StableTip: otherTip}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointUnavailable},
+		{"expected generation mismatch", nil, PendingOutpointAdmissionContext{Generation: 1}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointUnavailable},
 		{
 			"active transition",
 			func(o *PendingOutpointOwner) {
@@ -83,7 +88,7 @@ func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
 					t.Fatalf("beginTransition: %v", err)
 				}
 			},
-			PendingOutpointTip{},
+			PendingOutpointAdmissionContext{},
 			PendingOutpointStandardMempool,
 			[32]byte{0x01},
 			[]consensus.Outpoint{testOutpoint(1)},
@@ -92,7 +97,7 @@ func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
 		{
 			"token sequence exhausted",
 			func(o *PendingOutpointOwner) { o.tokenHighWater = ^uint64(0) },
-			PendingOutpointTip{},
+			PendingOutpointAdmissionContext{},
 			PendingOutpointStandardMempool,
 			[32]byte{0x01},
 			[]consensus.Outpoint{testOutpoint(1)},
@@ -106,7 +111,7 @@ func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
 				tc.setup(owner)
 			}
 			highWater, generation := owner.tokenHighWater, owner.generation
-			token, err := owner.Reserve(tc.tip, tc.domain, tc.txid, tc.inputs)
+			token, err := owner.Reserve(tc.admission, tc.domain, tc.txid, tc.inputs)
 			if err == nil {
 				t.Fatalf("Reserve accepted %s", tc.name)
 			}
@@ -123,7 +128,7 @@ func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
 	}
 	t.Run("nil owner", func(t *testing.T) {
 		var owner *PendingOutpointOwner
-		_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)})
+		_, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)})
 		if testOwnerKind(t, err) != PendingOutpointInternal {
 			t.Fatalf("nil owner Reserve = %v, want internal", err)
 		}
@@ -139,7 +144,7 @@ func TestPendingOutpointOwnerConflictReportsFirstInputAndInstallsNothing(t *test
 	first := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(5))
 	highWater := owner.tokenHighWater
 
-	_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x02},
+	_, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x02},
 		[]consensus.Outpoint{testOutpoint(1), testOutpoint(2), testOutpoint(5)})
 	var ownerErr *PendingOutpointError
 	if !errors.As(err, &ownerErr) || ownerErr.Kind != PendingOutpointConflict {
@@ -157,7 +162,7 @@ func TestPendingOutpointOwnerConflictReportsFirstInputAndInstallsNothing(t *test
 	if err := owner.Release(first); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x02},
+	if _, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x02},
 		[]consensus.Outpoint{testOutpoint(1), testOutpoint(2), testOutpoint(5)}); err != nil {
 		t.Fatalf("Reserve after release: %v", err)
 	}
@@ -430,11 +435,11 @@ func TestPendingOutpointOwnerRestoreRejectsInconsistentSnapshots(t *testing.T) {
 // standard claim does, so the two can never both hold one outpoint.
 func TestPendingOutpointOwnerDomainsShareOneAuthority(t *testing.T) {
 	owner := newPendingOutpointOwner(PendingOutpointTip{})
-	daToken, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointDA, [32]byte{0xda}, []consensus.Outpoint{testOutpoint(1)})
+	daToken, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointDA, [32]byte{0xda}, []consensus.Outpoint{testOutpoint(1)})
 	if err != nil {
 		t.Fatalf("DA Reserve: %v", err)
 	}
-	if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}); testOwnerKind(t, err) != PendingOutpointConflict {
+	if _, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}); testOwnerKind(t, err) != PendingOutpointConflict {
 		t.Fatalf("standard Reserve over a DA claim = %v, want conflict", err)
 	}
 	// A DA claim is not a standard record: the standard binding check refuses
@@ -464,7 +469,7 @@ func TestPendingOutpointOwnerConcurrentContendersProduceOneWinner(t *testing.T) 
 			go func(i int) {
 				defer wg.Done()
 				txid := [32]byte{byte(0x10 + i)}
-				_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, txid,
+				_, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, txid,
 					[]consensus.Outpoint{shared, testOutpoint(uint32(100 + i))})
 				var ownerErr *PendingOutpointError
 				mu.Lock()
@@ -498,7 +503,7 @@ func TestPendingOutpointOwnerConcurrentContendersProduceOneWinner(t *testing.T) 
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool,
+				if _, err := owner.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool,
 					[32]byte{byte(0x20 + i)}, []consensus.Outpoint{testOutpoint(uint32(200 + i))}); err != nil {
 					t.Errorf("independent contender %d: %v", i, err)
 				}
@@ -510,6 +515,75 @@ func TestPendingOutpointOwnerConcurrentContendersProduceOneWinner(t *testing.T) 
 				len(owner.byOutpoint), len(owner.byToken), owner.tokenHighWater, contenders)
 		}
 	})
+}
+
+// TestPendingOutpointOwnerReserveRejectsStaleAdmissionGenerationWithoutMutation
+// pins the hostile row a tip comparison cannot see. After A->B->A, and again
+// after an abort, the owner's stable tip compares EQUAL to a context cached
+// before those transitions while everything derived under it is stale. That
+// cached context must lose as unavailable BEFORE the conflict scan — an
+// otherwise-present conflict on the same outpoint proves the order — consuming
+// no sequence, while the current context still reaches that conflict.
+func TestPendingOutpointOwnerReserveRejectsStaleAdmissionGenerationWithoutMutation(t *testing.T) {
+	tipA := PendingOutpointTip{HasTip: true, Height: 9, Hash: [32]byte{0x0a}}
+	tipB := PendingOutpointTip{HasTip: true, Height: 10, Hash: [32]byte{0x0b}}
+	owner := newPendingOutpointOwner(tipA)
+	shared := testOutpoint(1)
+	if err := owner.Finalize(mustReserve(t, owner, [32]byte{0x01}, shared)); err != nil {
+		t.Fatalf("Finalize(held): %v", err)
+	}
+	stale, ok := owner.AdmissionContext()
+	if !ok {
+		t.Fatal("AdmissionContext unavailable on the stable owner")
+	}
+
+	assertStaleReserveLoses := func(what string, expected PendingOutpointAdmissionContext) {
+		t.Helper()
+		highWater, claims := owner.tokenHighWater, len(owner.byToken)
+		token, err := owner.Reserve(expected, PendingOutpointStandardMempool, [32]byte{0x02}, []consensus.Outpoint{shared})
+		if got := testOwnerKind(t, err); got != PendingOutpointUnavailable {
+			t.Fatalf("%s: kind=%d, want unavailable before the conflict scan", what, got)
+		}
+		if (token != PendingOutpointToken{}) || owner.tokenHighWater != highWater || len(owner.byToken) != claims {
+			t.Fatalf("%s: high_water=%d claims=%d, want %d/%d unchanged", what, owner.tokenHighWater, len(owner.byToken), highWater, claims)
+		}
+		if got, live := owner.txidForOutpoint(shared); !live || got != [32]byte{0x01} {
+			t.Fatalf("%s: outpoint row=(%x,%v), want the untouched original claim", what, got, live)
+		}
+	}
+
+	// A->B->A: the stable tip returns to exactly what the cached context holds.
+	for _, tip := range []PendingOutpointTip{tipB, tipA} {
+		if _, err := owner.beginTransition(); err != nil {
+			t.Fatalf("beginTransition(%v): %v", tip, err)
+		}
+		if err := owner.commitStableTip(tip); err != nil {
+			t.Fatalf("commitStableTip(%v): %v", tip, err)
+		}
+	}
+	current, ok := owner.AdmissionContext()
+	if !ok || current.StableTip != stale.StableTip || current.Generation == stale.Generation {
+		t.Fatalf("context after A->B->A=%+v (ok=%v), want the same tip on a later generation than %+v", current, ok, stale)
+	}
+	assertStaleReserveLoses("stale context after A->B->A", stale)
+
+	// The conflict really is present: the CURRENT context reaches it.
+	_, err := owner.Reserve(current, PendingOutpointStandardMempool, [32]byte{0x02}, []consensus.Outpoint{shared})
+	if got := testOwnerKind(t, err); got != PendingOutpointConflict {
+		t.Fatalf("current-context Reserve kind=%d, want the conflict the stale context never reached", got)
+	}
+
+	// An abort leaves the stable tip untouched and still advances the
+	// generation, so a context cached before it is stale in the same way.
+	if _, err := owner.beginTransition(); err != nil {
+		t.Fatalf("beginTransition(aborted): %v", err)
+	}
+	owner.endTransitionAborted()
+	afterAbort, ok := owner.AdmissionContext()
+	if !ok || afterAbort.StableTip != current.StableTip || afterAbort.Generation != current.Generation+1 {
+		t.Fatalf("context after abort=%+v (ok=%v), want the same tip one generation past %+v", afterAbort, ok, current)
+	}
+	assertStaleReserveLoses("stale context after an abort", current)
 }
 
 // TestPendingOutpointOwnerStaleReleaseCannotDeleteNewerClaim pins the hostile

--- a/clients/go/node/pending_outpoint_owner_test.go
+++ b/clients/go/node/pending_outpoint_owner_test.go
@@ -1,0 +1,671 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func testOutpoint(vout uint32) consensus.Outpoint {
+	return consensus.Outpoint{Txid: [32]byte{0xaa}, Vout: vout}
+}
+
+func testOwnerKind(t *testing.T, err error) PendingOutpointErrorKind {
+	t.Helper()
+	var ownerErr *PendingOutpointError
+	if !errors.As(err, &ownerErr) {
+		t.Fatalf("error %v is not a *PendingOutpointError", err)
+	}
+	return ownerErr.Kind
+}
+
+func mustReserve(t *testing.T, o *PendingOutpointOwner, txid [32]byte, inputs ...consensus.Outpoint) PendingOutpointToken {
+	t.Helper()
+	token, err := o.Reserve(o.stableTip, PendingOutpointStandardMempool, txid, inputs)
+	if err != nil {
+		t.Fatalf("Reserve(%x): %v", txid, err)
+	}
+	return token
+}
+
+// TestPendingOutpointOwnerReserveInstallsCompleteClaim pins the accepted rows:
+// one-input and many-input reservations install a complete claim preserving
+// canonical input order and consume exactly one sequence each.
+func TestPendingOutpointOwnerReserveInstallsCompleteClaim(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	inputs := []consensus.Outpoint{testOutpoint(3), testOutpoint(1), testOutpoint(2)}
+	token := mustReserve(t, owner, [32]byte{0x01}, inputs...)
+	if token.owner != owner || token.seq != 1 || owner.tokenHighWater != 1 {
+		t.Fatalf("token seq=%d high_water=%d, want seq 1 from this owner", token.seq, owner.tokenHighWater)
+	}
+	claim := owner.byToken[token]
+	if claim == nil || claim.finalized || claim.domain != PendingOutpointStandardMempool {
+		t.Fatalf("claim=%+v, want a reserved standard claim", claim)
+	}
+	for i, op := range inputs {
+		if claim.inputs[i] != op {
+			t.Fatalf("claim input %d = %v, want caller order %v", i, claim.inputs[i], op)
+		}
+		if got, ok := owner.txidForOutpoint(op); !ok || got != claim.txid {
+			t.Fatalf("index row for %v = (%x,%v), want txid %x", op, got, ok, claim.txid)
+		}
+	}
+	if single := mustReserve(t, owner, [32]byte{0x02}, testOutpoint(9)); single.seq != 2 {
+		t.Fatalf("second reservation seq=%d, want 2", single.seq)
+	}
+}
+
+// TestPendingOutpointOwnerReserveRejectionsMutateNothing pins every rejected
+// Reserve row, its error kind, and the no-mutation / no-sequence-consumed rule.
+// Malformed requests are internal; a closed owner is unavailable.
+func TestPendingOutpointOwnerReserveRejectionsMutateNothing(t *testing.T) {
+	otherTip := PendingOutpointTip{HasTip: true, Height: 7, Hash: [32]byte{0x77}}
+	cases := []struct {
+		name   string
+		setup  func(o *PendingOutpointOwner)
+		tip    PendingOutpointTip
+		domain PendingOutpointDomain
+		txid   [32]byte
+		inputs []consensus.Outpoint
+		want   PendingOutpointErrorKind
+	}{
+		{"invalid domain", nil, PendingOutpointTip{}, PendingOutpointDomain(0), [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
+		{"zero txid", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointInternal},
+		{"empty input set", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, nil, PendingOutpointInternal},
+		{"duplicate input", nil, PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1), testOutpoint(1)}, PendingOutpointInternal},
+		{"expected tip mismatch", nil, otherTip, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}, PendingOutpointUnavailable},
+		{
+			"active transition",
+			func(o *PendingOutpointOwner) {
+				if _, err := o.beginTransition(); err != nil {
+					t.Fatalf("beginTransition: %v", err)
+				}
+			},
+			PendingOutpointTip{},
+			PendingOutpointStandardMempool,
+			[32]byte{0x01},
+			[]consensus.Outpoint{testOutpoint(1)},
+			PendingOutpointUnavailable,
+		},
+		{
+			"token sequence exhausted",
+			func(o *PendingOutpointOwner) { o.tokenHighWater = ^uint64(0) },
+			PendingOutpointTip{},
+			PendingOutpointStandardMempool,
+			[32]byte{0x01},
+			[]consensus.Outpoint{testOutpoint(1)},
+			PendingOutpointUnavailable,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			owner := newPendingOutpointOwner(PendingOutpointTip{})
+			if tc.setup != nil {
+				tc.setup(owner)
+			}
+			highWater, generation := owner.tokenHighWater, owner.generation
+			token, err := owner.Reserve(tc.tip, tc.domain, tc.txid, tc.inputs)
+			if err == nil {
+				t.Fatalf("Reserve accepted %s", tc.name)
+			}
+			if got := testOwnerKind(t, err); got != tc.want {
+				t.Fatalf("kind=%d, want %d", got, tc.want)
+			}
+			if (token != PendingOutpointToken{}) || len(owner.byOutpoint) != 0 || len(owner.byToken) != 0 {
+				t.Fatalf("rejected Reserve mutated owner state: outpoints=%d claims=%d", len(owner.byOutpoint), len(owner.byToken))
+			}
+			if owner.tokenHighWater != highWater || owner.generation != generation {
+				t.Fatalf("high_water=%d gen=%d, want %d/%d", owner.tokenHighWater, owner.generation, highWater, generation)
+			}
+		})
+	}
+	t.Run("nil owner", func(t *testing.T) {
+		var owner *PendingOutpointOwner
+		_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)})
+		if testOwnerKind(t, err) != PendingOutpointInternal {
+			t.Fatalf("nil owner Reserve = %v, want internal", err)
+		}
+	})
+}
+
+// TestPendingOutpointOwnerConflictReportsFirstInputAndInstallsNothing pins the
+// first-conflict rule: the scan follows the supplied slice order, reports that
+// exact input index and the claiming txid, and leaves no partial claim behind
+// even when the conflicting input is the last one.
+func TestPendingOutpointOwnerConflictReportsFirstInputAndInstallsNothing(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	first := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(5))
+	highWater := owner.tokenHighWater
+
+	_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x02},
+		[]consensus.Outpoint{testOutpoint(1), testOutpoint(2), testOutpoint(5)})
+	var ownerErr *PendingOutpointError
+	if !errors.As(err, &ownerErr) || ownerErr.Kind != PendingOutpointConflict {
+		t.Fatalf("late-input conflict = %v, want conflict", err)
+	}
+	if ownerErr.InputIndex != 2 || ownerErr.Outpoint != testOutpoint(5) || ownerErr.ExistingTxid != [32]byte{0x01} {
+		t.Fatalf("conflict evidence=%+v, want index 2 on outpoint 5 held by 0x01", ownerErr)
+	}
+	if len(owner.byOutpoint) != 1 || owner.tokenHighWater != highWater {
+		t.Fatalf("conflict installed a partial claim: outpoints=%d high_water=%d", len(owner.byOutpoint), owner.tokenHighWater)
+	}
+	if _, taken := owner.txidForOutpoint(testOutpoint(1)); taken {
+		t.Fatal("conflicting request claimed its earlier inputs")
+	}
+	if err := owner.Release(first); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x02},
+		[]consensus.Outpoint{testOutpoint(1), testOutpoint(2), testOutpoint(5)}); err != nil {
+		t.Fatalf("Reserve after release: %v", err)
+	}
+}
+
+// TestPendingOutpointOwnerFinalizeAndReleaseSemantics pins the retry rows and
+// every rejected token row for both terminal operations.
+func TestPendingOutpointOwnerFinalizeAndReleaseSemantics(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	token := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(1), testOutpoint(2))
+
+	if err := owner.Finalize(token); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if err := owner.Finalize(token); err != nil {
+		t.Fatalf("exact Finalize retry: %v", err)
+	}
+	if !owner.byToken[token].finalized || len(owner.byOutpoint) != 2 {
+		t.Fatalf("Finalize retry mutated state: outpoints=%d", len(owner.byOutpoint))
+	}
+
+	foreign := newPendingOutpointOwner(PendingOutpointTip{})
+	foreignToken := mustReserve(t, foreign, [32]byte{0x09}, testOutpoint(1))
+	badTokens := map[string]PendingOutpointToken{
+		"zero token":       {},
+		"foreign owner":    foreignToken,
+		"above high-water": {owner: owner, seq: owner.tokenHighWater + 1},
+	}
+	for name, bad := range badTokens {
+		if got := testOwnerKind(t, owner.Finalize(bad)); got != PendingOutpointInternal {
+			t.Fatalf("Finalize(%s) kind=%d, want internal", name, got)
+		}
+		if got := testOwnerKind(t, owner.Release(bad)); got != PendingOutpointInternal {
+			t.Fatalf("Release(%s) kind=%d, want internal", name, got)
+		}
+	}
+
+	// Partial live mismatch: one row was overwritten, so the release must
+	// delete nothing at all.
+	owner.byOutpoint[testOutpoint(2)] = pendingOutpointRow{token: PendingOutpointToken{owner: owner, seq: 2}, txid: [32]byte{0xff}}
+	if got := testOwnerKind(t, owner.Release(token)); got != PendingOutpointInternal {
+		t.Fatalf("partial-mismatch Release kind=%d, want internal", got)
+	}
+	if _, ok := owner.byOutpoint[testOutpoint(1)]; !ok {
+		t.Fatal("partial-mismatch Release deleted a row")
+	}
+	owner.byOutpoint[testOutpoint(2)] = pendingOutpointRow{token: token, txid: [32]byte{0x01}}
+
+	if err := owner.Release(token); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if err := owner.Release(token); err != nil {
+		t.Fatalf("exact Release retry: %v", err)
+	}
+	if len(owner.byOutpoint) != 0 || len(owner.byToken) != 0 {
+		t.Fatalf("release left state: outpoints=%d claims=%d", len(owner.byOutpoint), len(owner.byToken))
+	}
+	if got := testOwnerKind(t, owner.Finalize(token)); got != PendingOutpointUnavailable {
+		t.Fatalf("Finalize after release kind=%d, want unavailable", got)
+	}
+}
+
+// TestPendingOutpointOwnerTransitionClosesPublicationAndKeepsHighWaters pins
+// the transition rows: Reserve and Finalize are unavailable while a transition
+// is active, exact Release stays valid, an old-generation Finalize publishes
+// nothing, and an abort keeps both high-waters advanced.
+func TestPendingOutpointOwnerTransitionClosesPublicationAndKeepsHighWaters(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	reserved := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(1))
+	snapshot := owner.snapshot()
+
+	generation, err := owner.beginTransition()
+	if err != nil || generation != 1 {
+		t.Fatalf("beginTransition=(%d,%v), want generation 1", generation, err)
+	}
+	if _, err := owner.beginTransition(); testOwnerKind(t, err) != PendingOutpointUnavailable {
+		t.Fatalf("re-entrant beginTransition = %v, want unavailable", err)
+	}
+	if got := testOwnerKind(t, owner.Finalize(reserved)); got != PendingOutpointUnavailable {
+		t.Fatalf("Finalize during transition kind=%d, want unavailable", got)
+	}
+	if owner.byToken[reserved].finalized {
+		t.Fatal("Finalize during transition published the claim")
+	}
+	if err := owner.Release(reserved); err != nil {
+		t.Fatalf("exact Release during transition: %v", err)
+	}
+
+	owner.mu.Lock()
+	candidate, restoreErr := owner.buildRestoreLocked(snapshot)
+	if restoreErr == nil {
+		owner.publishRestoreLocked(snapshot, candidate)
+	}
+	owner.mu.Unlock()
+	if restoreErr != nil {
+		t.Fatalf("buildRestoreLocked: %v", restoreErr)
+	}
+	owner.endTransitionAborted()
+	if owner.tokenHighWater != 1 || owner.generation != 1 {
+		t.Fatalf("abort regressed high-waters: token=%d gen=%d", owner.tokenHighWater, owner.generation)
+	}
+	if got := testOwnerKind(t, owner.Finalize(reserved)); got != PendingOutpointUnavailable {
+		t.Fatalf("old-generation Finalize kind=%d, want unavailable", got)
+	}
+	if owner.byToken[reserved].finalized {
+		t.Fatal("old-generation Finalize published the claim")
+	}
+	next := mustReserve(t, owner, [32]byte{0x02}, testOutpoint(2))
+	if next.seq != 2 {
+		t.Fatalf("post-abort reservation seq=%d, want 2 (no sequence reuse)", next.seq)
+	}
+}
+
+// TestPendingOutpointOwnerAdmissionContext pins the read-only downstream seam:
+// the exact stable tip paired with the current generation while stable, and a
+// fail-closed unavailable result for a nil owner, an active transition, or an
+// exhausted generation space. It also pins the cache-validity property the seam
+// exists for — the initial context and every begun transition carry distinct
+// generations, and neither a commit back to an earlier tip (A->B->A) nor an
+// aborted transition can reproduce an earlier context.
+func TestPendingOutpointOwnerAdmissionContext(t *testing.T) {
+	tipA := PendingOutpointTip{HasTip: true, Height: 4, Hash: [32]byte{0x0a}}
+	tipB := PendingOutpointTip{HasTip: true, Height: 5, Hash: [32]byte{0x0b}}
+
+	var nilOwner *PendingOutpointOwner
+	if ctx, ok := nilOwner.AdmissionContext(); ok {
+		t.Fatalf("nil owner reported %+v, want unavailable", ctx)
+	}
+
+	owner := newPendingOutpointOwner(tipA)
+	initial, ok := owner.AdmissionContext()
+	if !ok || initial != (PendingOutpointAdmissionContext{StableTip: tipA, Generation: 0}) {
+		t.Fatalf("initial context=(%+v,%v), want stable tipA at generation 0", initial, ok)
+	}
+	// A reservation is not an observable canonical move: same context.
+	token := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(1))
+	if again, ok := owner.AdmissionContext(); !ok || again != initial {
+		t.Fatalf("context after Reserve=(%+v,%v), want %+v unchanged", again, ok, initial)
+	}
+	if err := owner.Finalize(token); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	// A->B: a begun transition is unavailable, and its commit publishes the new
+	// tip on a fresh generation.
+	if _, err := owner.beginTransition(); err != nil {
+		t.Fatalf("beginTransition(A->B): %v", err)
+	}
+	if ctx, ok := owner.AdmissionContext(); ok {
+		t.Fatalf("context during transition=%+v, want unavailable", ctx)
+	}
+	if err := owner.commitStableTip(tipB); err != nil {
+		t.Fatalf("commitStableTip(B): %v", err)
+	}
+	atB, ok := owner.AdmissionContext()
+	if !ok || atB != (PendingOutpointAdmissionContext{StableTip: tipB, Generation: 1}) {
+		t.Fatalf("context at B=(%+v,%v), want tipB at generation 1", atB, ok)
+	}
+
+	// B->A: the tip is identical to the initial one, the generation is not, so a
+	// generation-keyed cache cannot mistake this for the pre-reorg context.
+	if _, err := owner.beginTransition(); err != nil {
+		t.Fatalf("beginTransition(B->A): %v", err)
+	}
+	if err := owner.commitStableTip(tipA); err != nil {
+		t.Fatalf("commitStableTip(A): %v", err)
+	}
+	backAtA, ok := owner.AdmissionContext()
+	if !ok || backAtA.StableTip != tipA || backAtA.Generation != 2 {
+		t.Fatalf("context back at A=(%+v,%v), want tipA at generation 2", backAtA, ok)
+	}
+	if backAtA == initial {
+		t.Fatal("A->B->A reproduced the pre-reorg admission context")
+	}
+
+	// A failed transition keeps the tip and still advances the generation.
+	if _, err := owner.beginTransition(); err != nil {
+		t.Fatalf("beginTransition(failed): %v", err)
+	}
+	owner.endTransitionAborted()
+	afterAbort, ok := owner.AdmissionContext()
+	if !ok || afterAbort.StableTip != tipA || afterAbort.Generation != 3 {
+		t.Fatalf("context after abort=(%+v,%v), want tipA at generation 3", afterAbort, ok)
+	}
+
+	// Generation exhaustion is fail-closed: no further transition can be
+	// distinguished, so no context is reported at all.
+	owner.mu.Lock()
+	owner.generation = ^uint64(0)
+	owner.mu.Unlock()
+	if ctx, ok := owner.AdmissionContext(); ok {
+		t.Fatalf("exhausted generation reported %+v, want unavailable", ctx)
+	}
+}
+
+// TestPendingOutpointOwnerAdmissionContextRacingTransitionBeginIsNeverInconsistent
+// pins the hostile row: a reader racing a transition begin observes either the
+// prior stable context or unavailability, never a stable context paired with an
+// active transition, and never the fresh generation before the transition ends.
+func TestPendingOutpointOwnerAdmissionContextRacingTransitionBeginIsNeverInconsistent(t *testing.T) {
+	tip := PendingOutpointTip{HasTip: true, Height: 9, Hash: [32]byte{0x09}}
+	for round := 0; round < 64; round++ {
+		owner := newPendingOutpointOwner(tip)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var observed PendingOutpointAdmissionContext
+		var available bool
+		go func() { defer wg.Done(); observed, available = owner.AdmissionContext() }()
+		go func() {
+			defer wg.Done()
+			if _, err := owner.beginTransition(); err != nil {
+				t.Errorf("beginTransition: %v", err)
+			}
+		}()
+		wg.Wait()
+		if available && observed != (PendingOutpointAdmissionContext{StableTip: tip, Generation: 0}) {
+			t.Fatalf("round %d: observed %+v, want the prior stable context or unavailable", round, observed)
+		}
+		// The transition is still active, so the reader is closed out now
+		// regardless of which side won the race.
+		if ctx, ok := owner.AdmissionContext(); ok {
+			t.Fatalf("round %d: context %+v available during the active transition", round, ctx)
+		}
+	}
+}
+
+// TestPendingOutpointOwnerRestoreRejectsInconsistentSnapshots pins all three
+// snapshot rejection rows — a foreign token, a duplicate outpoint, and a
+// sequence above the snapshot's own high-water — and proves a refused restore
+// publishes no map.
+func TestPendingOutpointOwnerRestoreRejectsInconsistentSnapshots(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	foreign := newPendingOutpointOwner(PendingOutpointTip{})
+	dup := testOutpoint(1)
+	cases := map[string]pendingOutpointSnapshot{
+		"foreign token": {
+			claims:         []pendingOutpointClaim{{token: PendingOutpointToken{owner: foreign, seq: 1}, domain: PendingOutpointStandardMempool, txid: [32]byte{0x01}, inputs: []consensus.Outpoint{dup}}},
+			tokenHighWater: 1,
+		},
+		"duplicate outpoint": {
+			claims: []pendingOutpointClaim{
+				{token: PendingOutpointToken{owner: owner, seq: 1}, domain: PendingOutpointStandardMempool, txid: [32]byte{0x01}, inputs: []consensus.Outpoint{dup}},
+				{token: PendingOutpointToken{owner: owner, seq: 2}, domain: PendingOutpointStandardMempool, txid: [32]byte{0x02}, inputs: []consensus.Outpoint{dup}},
+			},
+			tokenHighWater: 2,
+		},
+		"sequence above snapshot high-water": {
+			claims:         []pendingOutpointClaim{{token: PendingOutpointToken{owner: owner, seq: 4}, domain: PendingOutpointStandardMempool, txid: [32]byte{0x01}, inputs: []consensus.Outpoint{dup}}},
+			tokenHighWater: 1,
+		},
+	}
+	for name, snap := range cases {
+		t.Run(name, func(t *testing.T) {
+			owner.mu.Lock()
+			_, err := owner.buildRestoreLocked(snap)
+			owner.mu.Unlock()
+			if testOwnerKind(t, err) != PendingOutpointInternal {
+				t.Fatalf("buildRestoreLocked accepted %s: %v", name, err)
+			}
+			if len(owner.byOutpoint) != 0 {
+				t.Fatalf("refused restore published %d rows", len(owner.byOutpoint))
+			}
+		})
+	}
+}
+
+// TestPendingOutpointOwnerDomainsShareOneAuthority proves the DA domain value
+// exists, reserves through the same single owner, and creates no separate DA
+// record or index: a DA claim occupies the same by-outpoint authority a
+// standard claim does, so the two can never both hold one outpoint.
+func TestPendingOutpointOwnerDomainsShareOneAuthority(t *testing.T) {
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	daToken, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointDA, [32]byte{0xda}, []consensus.Outpoint{testOutpoint(1)})
+	if err != nil {
+		t.Fatalf("DA Reserve: %v", err)
+	}
+	if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{testOutpoint(1)}); testOwnerKind(t, err) != PendingOutpointConflict {
+		t.Fatalf("standard Reserve over a DA claim = %v, want conflict", err)
+	}
+	// A DA claim is not a standard record: the standard binding check refuses
+	// to bind it to a mempool entry.
+	owner.mu.Lock()
+	bindErr := owner.validateEntryClaimLocked([32]byte{0xda}, []consensus.Outpoint{testOutpoint(1)}, daToken, false)
+	owner.mu.Unlock()
+	if testOwnerKind(t, bindErr) != PendingOutpointInternal {
+		t.Fatalf("DA claim bound as a standard record: %v", bindErr)
+	}
+}
+
+// TestPendingOutpointOwnerConcurrentContendersProduceOneWinner runs the two
+// concurrent-Reserve rows under -race: two contenders sharing an input in either
+// schedule yield exactly one complete winner and one complete loser, and
+// contenders over independent outpoints all admit.
+func TestPendingOutpointOwnerConcurrentContendersProduceOneWinner(t *testing.T) {
+	for round := 0; round < 64; round++ {
+		owner := newPendingOutpointOwner(PendingOutpointTip{})
+		shared := testOutpoint(1)
+		var mu sync.Mutex
+		winners := 0
+		conflicts := 0
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				txid := [32]byte{byte(0x10 + i)}
+				_, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, txid,
+					[]consensus.Outpoint{shared, testOutpoint(uint32(100 + i))})
+				var ownerErr *PendingOutpointError
+				mu.Lock()
+				defer mu.Unlock()
+				switch {
+				case err == nil:
+					winners++
+				case errors.As(err, &ownerErr) && ownerErr.Kind == PendingOutpointConflict:
+					conflicts++
+				default:
+					// t.Errorf, never t.Fatalf: runtime.Goexit from a spawned
+					// goroutine would abandon the WaitGroup.
+					t.Errorf("round %d: unexpected contender error: %v", round, err)
+				}
+			}(i)
+		}
+		wg.Wait()
+		if winners != 1 || conflicts != 1 {
+			t.Fatalf("round %d: winners=%d conflicts=%d, want exactly one of each", round, winners, conflicts)
+		}
+		// The loser installed nothing, so only the winner's two inputs are held.
+		if len(owner.byOutpoint) != 2 || len(owner.byToken) != 1 {
+			t.Fatalf("round %d: outpoints=%d claims=%d, want a single complete winner", round, len(owner.byOutpoint), len(owner.byToken))
+		}
+	}
+	t.Run("independent outpoints admit concurrently", func(t *testing.T) {
+		const contenders = 8
+		owner := newPendingOutpointOwner(PendingOutpointTip{})
+		var wg sync.WaitGroup
+		for i := 0; i < contenders; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				if _, err := owner.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool,
+					[32]byte{byte(0x20 + i)}, []consensus.Outpoint{testOutpoint(uint32(200 + i))}); err != nil {
+					t.Errorf("independent contender %d: %v", i, err)
+				}
+			}(i)
+		}
+		wg.Wait()
+		if len(owner.byOutpoint) != contenders || len(owner.byToken) != contenders || owner.tokenHighWater != contenders {
+			t.Fatalf("outpoints=%d claims=%d high_water=%d, want %d of each",
+				len(owner.byOutpoint), len(owner.byToken), owner.tokenHighWater, contenders)
+		}
+	})
+}
+
+// TestPendingOutpointOwnerStaleReleaseCannotDeleteNewerClaim pins the hostile
+// row from both directions: through the public API, where a release issued for
+// an already-dropped claim races a newer claim over the same outpoint, and
+// directly against the compare-delete guard that makes it safe.
+func TestPendingOutpointOwnerStaleReleaseCannotDeleteNewerClaim(t *testing.T) {
+	for round := 0; round < 64; round++ {
+		owner := newPendingOutpointOwner(PendingOutpointTip{})
+		shared := testOutpoint(1)
+		stale := mustReserve(t, owner, [32]byte{0x01}, shared)
+		if err := owner.Release(stale); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+		newer := mustReserve(t, owner, [32]byte{0x02}, shared)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = owner.Release(stale) }()
+		go func() { defer wg.Done(); _ = owner.Finalize(newer) }()
+		wg.Wait()
+		got, ok := owner.txidForOutpoint(shared)
+		if !ok || got != [32]byte{0x02} {
+			t.Fatalf("round %d: stale release deleted the newer claim (got %x ok=%v)", round, got, ok)
+		}
+	}
+
+	// The loop above exits Release early: the stale claim is gone from byToken,
+	// so claimForToken returns (nil, nil) and dropClaimLocked is never entered.
+	// Its compare-delete guard is unreachable through the public API — Release's
+	// own row check rejects a partially owned claim first — so it is pinned
+	// directly. Deleting `row.token == token` fails this assertion.
+	owner := newPendingOutpointOwner(PendingOutpointTip{})
+	shared := testOutpoint(1)
+	stale := mustReserve(t, owner, [32]byte{0x01}, shared)
+	owner.mu.Lock()
+	newer := PendingOutpointToken{owner: owner, seq: owner.tokenHighWater + 1}
+	owner.byOutpoint[shared] = pendingOutpointRow{token: newer, txid: [32]byte{0x02}}
+	owner.dropClaimLocked(stale)
+	row, ok := owner.byOutpoint[shared]
+	_, staleLive := owner.byToken[stale]
+	owner.mu.Unlock()
+	if !ok || row.token != newer {
+		t.Fatalf("dropClaimLocked deleted a row owned by a newer token: row=%+v ok=%v", row, ok)
+	}
+	if staleLive {
+		t.Fatal("dropClaimLocked left the stale claim live")
+	}
+}
+
+// TestPendingOutpointOwnerFinalizeRacingTransitionBeginPublishesNothingStale
+// pins the hostile row: a Finalize concurrent with a transition begin either
+// wins before the generation advances or is refused; it never publishes a claim
+// bound to the superseded generation.
+func TestPendingOutpointOwnerFinalizeRacingTransitionBeginPublishesNothingStale(t *testing.T) {
+	for round := 0; round < 64; round++ {
+		owner := newPendingOutpointOwner(PendingOutpointTip{})
+		token := mustReserve(t, owner, [32]byte{0x01}, testOutpoint(1))
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var finalizeErr error
+		go func() { defer wg.Done(); finalizeErr = owner.Finalize(token) }()
+		go func() {
+			defer wg.Done()
+			if _, err := owner.beginTransition(); err != nil {
+				t.Errorf("beginTransition: %v", err)
+			}
+		}()
+		wg.Wait()
+		owner.mu.Lock()
+		published := owner.byToken[token].finalized
+		owner.mu.Unlock()
+		if published != (finalizeErr == nil) {
+			t.Fatalf("round %d: published=%v finalize_err=%v, want publication exactly on success", round, published, finalizeErr)
+		}
+		// The transition won the generation either way, so the claim is now
+		// bound to the superseded one and can never be published later.
+		if err := owner.Finalize(token); testOwnerKind(t, err) != PendingOutpointUnavailable {
+			t.Fatalf("round %d: post-begin Finalize = %v, want unavailable", round, err)
+		}
+	}
+}
+
+// assertCandidateExactlyReleased pins the shared post-slot rule for a candidate
+// a LATER admission check rejected: the original cause is returned unchanged,
+// no entry is published, the entry's token is zeroed, no outpoint of the
+// candidate is still claimed, and the issued sequence stays consumed.
+func assertCandidateExactlyReleased(t *testing.T, mp *Mempool, entry *mempoolEntry, err error, wantKind TxAdmitErrorKind, wantMsg string) {
+	t.Helper()
+	// Each dimension reports independently so a regression shows every rule it
+	// broke, not only the first one checked.
+	var admitErr *TxAdmitError
+	if !errors.As(err, &admitErr) || admitErr.Kind != wantKind || admitErr.Message != wantMsg {
+		t.Errorf("admission error %v, want %s TxAdmitError %q", err, wantKind, wantMsg)
+	}
+	var zero PendingOutpointToken
+	if entry.token != zero {
+		t.Errorf("rejected candidate token=%+v, want the zero token after exact release", entry.token)
+	}
+	if len(mp.txs) != 0 {
+		t.Errorf("rejected candidate published %d record(s), want none", len(mp.txs))
+	}
+	owner := mp.pendingOutpoints
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	for _, op := range entry.inputs {
+		if row, ok := owner.byOutpoint[op]; ok {
+			t.Errorf("outpoint %v still claimed by %+v after exact release", op, row)
+		}
+	}
+	if len(owner.byToken) != 0 || len(owner.byOutpoint) != 0 {
+		t.Errorf("owner holds claims=%d outpoints=%d after exact release, want none", len(owner.byToken), len(owner.byOutpoint))
+	}
+	if owner.tokenHighWater != 1 {
+		t.Errorf("token high-water=%d, want the one issued sequence retained", owner.tokenHighWater)
+	}
+}
+
+// TestMempoolPendingOutpointAdmissionSeqExhaustionReleasesReservation pins the
+// first of the two post-slot release categories that no capacity-class test
+// covers: validateAdmissionSeqLocked fires AFTER the conflict slot issued a
+// token, so dropping its release would strand a claim over the candidate's
+// outpoints with no record behind it. The 2^64-wide sequence space makes this
+// row unreachable from AddTx, so the exhausted counter is set directly.
+func TestMempoolPendingOutpointAdmissionSeqExhaustionReleasesReservation(t *testing.T) {
+	entry := &mempoolEntry{
+		txid:   [32]byte{0x0c},
+		wtxid:  [32]byte{0x0d},
+		inputs: []consensus.Outpoint{testOutpoint(1), testOutpoint(2)},
+		fee:    1, weight: 1, size: 1,
+	}
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, lastAdmissionSeq: ^uint64(0)}
+	mp.mu.Lock()
+	err := mp.addEntryLocked(entry)
+	mp.mu.Unlock()
+	assertCandidateExactlyReleased(t, mp, entry, err, TxAdmitUnavailable, "mempool admission sequence exhausted")
+}
+
+// TestMempoolPendingOutpointLiveFloorRecheckReleasesReservation pins the second
+// uncovered post-slot release category: the live rolling-floor recheck inside
+// validateCapacityAdmissionLocked. It is driven package-internally because the
+// public path cannot reach it — addTxWithSource's cheap pre-slot precheck
+// already rejects everything below the SNAPPED floor, and the locked recheck
+// exists exactly for a floor RAISE between snap and lock. Passing the stale
+// snapped floor against a raised live floor is that race, deterministically.
+func TestMempoolPendingOutpointLiveFloorRecheckReleasesReservation(t *testing.T) {
+	entry := &mempoolEntry{
+		txid:   [32]byte{0x1c},
+		wtxid:  [32]byte{0x1d},
+		inputs: []consensus.Outpoint{testOutpoint(3)},
+		fee:    DefaultMempoolMinFeeRate, weight: 1, size: 1,
+	}
+	// The snap admits this fee rate; the live floor raised past it does not.
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: DefaultMempoolMinFeeRate + 1}
+	mp.mu.Lock()
+	err := mp.addEntryLockedWithFloor(entry, DefaultMempoolMinFeeRate)
+	mp.mu.Unlock()
+	assertCandidateExactlyReleased(t, mp, entry, err, TxAdmitUnavailable,
+		"mempool fee below rolling minimum: fee=1 weight=1 min_fee_rate=2")
+}

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -475,34 +475,113 @@ func (s *SyncEngine) targetContextForCandidate(parentHash [32]byte, candidateHei
 	return targetContextForCandidate(s.blockStore, s.cfg, parentHash, candidateHeight)
 }
 
-// SetMempool binds the mempool whose pending-outpoint owner this engine drives.
-// It serializes on mutationMu so a canonical transition can never observe the
-// pointer set change under it. A non-nil mempool bound to a DIFFERENT ChainState
-// than this engine is NOT installed and changes neither engine nor candidate
-// state: a transition must own one pointer-identical ChainState, Mempool and
-// owner for its whole duration.
+// SetMempool binds, EXACTLY ONCE, the mempool whose pending-outpoint owner this
+// engine drives, serializing on mutationMu so a canonical transition can never
+// observe the pointer set change under it. Initialization-only is the contract,
+// not a convenience: a pool detached at tip A, held while the engine advances,
+// and handed back at an apparently equal tip carries records and claims bound to
+// a canonical history this engine no longer has, and a pointer comparison cannot
+// see that. So only a fresh empty pool at the guarded live tip binds, and
+// afterwards only the exact same pointer is accepted; a rejection mutates
+// neither the engine nor the candidate's policy, records, indexes, owner state
+// or high-waters.
 func (s *SyncEngine) SetMempool(mempool *Mempool) {
 	if s == nil {
 		return
 	}
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
-	if mempool != nil && mempool.chainState != s.chainState {
+	if err := s.mutationAllowed(); err != nil {
+		s.reportMempoolBindingRejected(err)
 		return
 	}
+	if err := s.bindMempoolUnderMutation(mempool); err != nil {
+		s.reportMempoolBindingRejected(err)
+	}
+}
+
+// bindMempoolUnderMutation performs the initialization-only binding under the
+// caller's mutationMu, holding the live admission read guard CONTINUOUSLY from
+// the live tip read through the install. Lock order is mutationMu,
+// admissionMu.RLock, then s.mu before Mempool.mu before owner.mu — never the
+// reverse; the candidate's context is read with owner.mu released, before
+// Mempool.mu is taken.
+func (s *SyncEngine) bindMempoolUnderMutation(mempool *Mempool) error {
+	s.chainState.admissionMu.RLock()
+	defer s.chainState.admissionMu.RUnlock()
+	settled, err := s.checkMempoolRebinding(mempool)
+	if settled || err != nil {
+		return err
+	}
+	if mempool.chainState != s.chainState {
+		return errors.New("mempool candidate is bound to a different chainstate")
+	}
+	liveTip := pendingOutpointTipOf(s.chainState)
+	admission, ok := mempool.PendingOutpointOwner().AdmissionContext()
+	if !ok {
+		return errors.New("mempool candidate owner has no available admission context")
+	}
+	if admission.StableTip != liveTip {
+		return errors.New("mempool candidate owner is bound to a different canonical tip")
+	}
+	return s.installInitialMempool(mempool, admission)
+}
+
+// checkMempoolRebinding resolves every already-decided case, reporting
+// settled=true for a call that must do nothing: an exact same-pointer rebind, or
+// a nil call before anything was bound. Every other post-binding call — a nil
+// unbind, or ANY different pointer — is an error.
+func (s *SyncEngine) checkMempoolRebinding(mempool *Mempool) (bool, error) {
+	s.mu.RLock()
+	bound := s.mempool
+	s.mu.RUnlock()
+	if bound == nil {
+		return mempool == nil, nil
+	}
+	if mempool == bound {
+		return true, nil
+	}
+	if mempool == nil {
+		return false, errors.New("mempool unbinding is not supported after the initial binding")
+	}
+	return false, errors.New("mempool replacement is not supported after the initial binding")
+}
+
+// installInitialMempool rechecks the candidate's emptiness and its admission
+// context under s.mu, Mempool.mu and owner.mu — in that order — and only then
+// fills the missing policy providers and installs the pointer. Everything
+// fallible runs before the first write, so a refused candidate is unchanged.
+func (s *SyncEngine) installInitialMempool(mempool *Mempool, admission PendingOutpointAdmissionContext) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if mempool != nil {
-		mempool.mu.Lock()
-		if mempool.policy.RotationProvider == nil {
-			mempool.policy.RotationProvider = s.cfg.RotationProvider
-		}
-		if mempool.policy.SuiteRegistry == nil {
-			mempool.policy.SuiteRegistry = s.cfg.SuiteRegistry
-		}
-		mempool.mu.Unlock()
+	mempool.mu.Lock()
+	defer mempool.mu.Unlock()
+	if err := mempool.checkEmptyForBindingLocked(); err != nil {
+		return err
+	}
+	owner := mempool.pendingOutpointOwnerLocked()
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if err := owner.checkNoClaimsLocked(); err != nil {
+		return err
+	}
+	if current, ok := owner.admissionContextLocked(); !ok || current != admission {
+		return errors.New("mempool candidate admission context moved during binding")
+	}
+	if mempool.policy.RotationProvider == nil {
+		mempool.policy.RotationProvider = s.cfg.RotationProvider
+	}
+	if mempool.policy.SuiteRegistry == nil {
+		mempool.policy.SuiteRegistry = s.cfg.SuiteRegistry
 	}
 	s.mempool = mempool
+	return nil
+}
+
+// reportMempoolBindingRejected makes a refused binding visible: the engine keeps
+// its previous binding, otherwise indistinguishable from an unwired caller.
+func (s *SyncEngine) reportMempoolBindingRejected(err error) {
+	_, _ = fmt.Fprintf(s.stderr, "sync: mempool binding rejected, engine binding unchanged: %v\n", err)
 }
 
 // SetStderr sets the writer for non-fatal error diagnostics (e.g. mempool
@@ -635,19 +714,15 @@ func (s *SyncEngine) captureRollbackStateWithIndex(canonicalIndex []string) (syn
 // every canonical mutation serialize on mutationMu, which the entry point holds
 // throughout, so no reread can observe a different pointer set.
 type canonicalTransition struct {
-	engine     *SyncEngine
-	chainState *ChainState
-	mempool    *Mempool
-	owner      *PendingOutpointOwner
-	generation uint64
-	rollback   syncRollbackState
-	// suppressInnerCleanup is set by the preferred-branch reorg, which
-	// pre-cleans the whole prepared branch once instead of running the
-	// per-block cleanup inside each row.
-	suppressInnerCleanup bool
-	appliedHeight        uint64
-	appliedTimestamp     uint64
-	applied              bool
+	engine           *SyncEngine
+	chainState       *ChainState
+	mempool          *Mempool
+	owner            *PendingOutpointOwner
+	generation       uint64
+	rollback         syncRollbackState
+	appliedHeight    uint64
+	appliedTimestamp uint64
+	applied          bool
 }
 
 // beginCanonicalTransition takes the live admission guard, binds the pointer
@@ -1068,12 +1143,12 @@ func (s *SyncEngine) commitPreparedBlockUnderGuard(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 ) error {
-	if err := s.recheckLiveTipIdentity(tr, ctx); err != nil {
+	if err := s.recheckLiveTipIdentity(tr, chainTipScalarsOf(ctx.prevState)); err != nil {
 		return s.rollbackApplyBlock(err, tr.rollback)
 	}
 	// Cleanup precedes publication: the standard records and their exact
 	// claims are gone before any observer can see the new canonical tip.
-	if !tr.suppressInnerCleanup && tr.mempool != nil {
+	if tr.mempool != nil {
 		if err := tr.mempool.applyConnectedBlockParsed(pb); err != nil {
 			_, _ = fmt.Fprintf(s.stderr, "sync: standard mempool cleanup failed at height %d, rolling back: %v\n", ctx.blockHeight, err)
 			return s.rollbackApplyBlock(err, tr.rollback)
@@ -1085,22 +1160,37 @@ func (s *SyncEngine) commitPreparedBlockUnderGuard(
 	return s.finalizeAppliedBlock(summary, ctx.blockHash, pb, blockBytes, ctx.prevState, tr.rollback)
 }
 
+// canonicalTipScalars is the exact tip identity a prepared candidate was
+// validated against, and the identity its commit publishes. It is the ONLY
+// chain-state data a prepared preferred-branch row keeps.
+type canonicalTipScalars struct {
+	hasTip           bool
+	height           uint64
+	tipHash          [32]byte
+	alreadyGenerated uint64
+}
+
+func chainTipScalarsOf(state *ChainState) canonicalTipScalars {
+	view := state.view()
+	return canonicalTipScalars{hasTip: view.hasTip, height: view.height, tipHash: view.tipHash, alreadyGenerated: view.alreadyGenerated}
+}
+
 // recheckLiveTipIdentity proves, under the transition guard, that the live
 // ChainState AND the live BlockStore canonical tip are still exactly the state
 // the candidate was prepared against. mutationMu already serializes canonical
 // mutation in-process, so both halves are defense in depth.
-func (s *SyncEngine) recheckLiveTipIdentity(tr *canonicalTransition, ctx canonicalBlockApplyContext) error {
+func (s *SyncEngine) recheckLiveTipIdentity(tr *canonicalTransition, prior canonicalTipScalars) error {
 	live := tr.chainState.view()
-	if live.hasTip != ctx.prevState.HasTip || live.height != ctx.prevState.Height || live.tipHash != ctx.prevState.TipHash {
+	if live.hasTip != prior.hasTip || live.height != prior.height || live.tipHash != prior.tipHash {
 		return errors.New("live chainstate tip moved during canonical apply")
 	}
-	return s.recheckLiveStoreTipIdentity(ctx)
+	return s.recheckLiveStoreTipIdentity(prior)
 }
 
 // recheckLiveStoreTipIdentity is the BlockStore half of recheckLiveTipIdentity.
 // An engine with no store has no second tip to disagree with, so it passes. The
 // check only reads the store and mutates nothing.
-func (s *SyncEngine) recheckLiveStoreTipIdentity(ctx canonicalBlockApplyContext) error {
+func (s *SyncEngine) recheckLiveStoreTipIdentity(prior canonicalTipScalars) error {
 	if s.blockStore == nil {
 		return nil
 	}
@@ -1108,7 +1198,7 @@ func (s *SyncEngine) recheckLiveStoreTipIdentity(ctx canonicalBlockApplyContext)
 	if err != nil {
 		return err
 	}
-	if storeHasTip != ctx.prevState.HasTip || (storeHasTip && (storeHeight != ctx.prevState.Height || storeHash != ctx.prevState.TipHash)) {
+	if storeHasTip != prior.hasTip || (storeHasTip && (storeHeight != prior.height || storeHash != prior.tipHash)) {
 		return errors.New("live blockstore tip moved during canonical apply")
 	}
 	return nil

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -475,8 +475,19 @@ func (s *SyncEngine) targetContextForCandidate(parentHash [32]byte, candidateHei
 	return targetContextForCandidate(s.blockStore, s.cfg, parentHash, candidateHeight)
 }
 
+// SetMempool binds the mempool whose pending-outpoint owner this engine drives.
+// It serializes on mutationMu so a canonical transition can never observe the
+// pointer set change under it. A non-nil mempool bound to a DIFFERENT ChainState
+// than this engine is NOT installed and changes neither engine nor candidate
+// state: a transition must own one pointer-identical ChainState, Mempool and
+// owner for its whole duration.
 func (s *SyncEngine) SetMempool(mempool *Mempool) {
 	if s == nil {
+		return
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	if mempool != nil && mempool.chainState != s.chainState {
 		return
 	}
 	s.mu.Lock()
@@ -566,18 +577,35 @@ type syncRollbackState struct {
 	reorgCount      uint64
 }
 
+// canonicalIndexPreflight performs the FALLIBLE half of the rollback snapshot —
+// reading the canonical index — while the caller holds mutationMu and BEFORE any
+// clone, ConnectBlock or preferred-branch consensus validation. That order keeps
+// a corrupt local index reported ahead of a candidate's consensus error.
+// mutationMu serializes canonical mutation and admission never touches the
+// canonical index, so the value stays exact until the transition begins.
+func (s *SyncEngine) canonicalIndexPreflight() ([]string, error) {
+	if s == nil || s.blockStore == nil {
+		return nil, nil
+	}
+	return s.blockStore.CanonicalIndexSnapshot()
+}
+
+// captureRollbackState is the standalone form: it runs the preflight itself and
+// then captures the rest. Canonical transitions do NOT use it — they run
+// canonicalIndexPreflight up front and pass the result to
+// captureRollbackStateWithIndex.
 func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
+	canonicalIndex, err := s.canonicalIndexPreflight()
+	if err != nil {
+		return syncRollbackState{}, err
+	}
+	return s.captureRollbackStateWithIndex(canonicalIndex)
+}
+
+func (s *SyncEngine) captureRollbackStateWithIndex(canonicalIndex []string) (syncRollbackState, error) {
 	snapshot := cloneChainState(s.chainState)
 	if snapshot == nil {
 		return syncRollbackState{}, errors.New("nil chainstate")
-	}
-	var err error
-	var canonicalIndex []string
-	if s.blockStore != nil {
-		canonicalIndex, err = s.blockStore.CanonicalIndexSnapshot()
-		if err != nil {
-			return syncRollbackState{}, err
-		}
 	}
 	mempoolState, err := snapshotMempool(s.mempool)
 	if err != nil {
@@ -596,8 +624,197 @@ func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
 	}, nil
 }
 
+// canonicalTransition is one canonical state transition. It owns
+// ChainState.admissionMu continuously from generation begin through stable
+// commit or exact abort, so neither admission nor a public terminal removal can
+// escape the rollback snapshot captured inside it.
+//
+// The ChainState, Mempool and owner pointers are captured ONCE at begin. Helpers
+// the transition calls (captureRollbackStateWithIndex, restoreRollbackChainState)
+// still read s.chainState / s.mempool; that is safe ONLY because SetMempool and
+// every canonical mutation serialize on mutationMu, which the entry point holds
+// throughout, so no reread can observe a different pointer set.
+type canonicalTransition struct {
+	engine     *SyncEngine
+	chainState *ChainState
+	mempool    *Mempool
+	owner      *PendingOutpointOwner
+	generation uint64
+	rollback   syncRollbackState
+	// suppressInnerCleanup is set by the preferred-branch reorg, which
+	// pre-cleans the whole prepared branch once instead of running the
+	// per-block cleanup inside each row.
+	suppressInnerCleanup bool
+	appliedHeight        uint64
+	appliedTimestamp     uint64
+	applied              bool
+}
+
+// beginCanonicalTransition takes the live admission guard, binds the pointer
+// set, advances the owner generation, and captures the exact rollback snapshot
+// under the guard. The caller holds mutationMu and MUST already have run
+// canonicalIndexPreflight, whose result it passes here: the fallible index read
+// belongs before any clone or consensus validation, not inside the guard.
+func (s *SyncEngine) beginCanonicalTransition(canonicalIndex []string) (*canonicalTransition, error) {
+	if err := s.mutationAllowed(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	mempool := s.mempool
+	s.mu.RUnlock()
+	chainState := s.chainState
+	if mempool != nil && mempool.chainState != chainState {
+		return nil, errors.New("mempool is bound to a different chainstate")
+	}
+	owner := mempool.PendingOutpointOwner()
+	chainState.admissionMu.Lock()
+	generation, err := owner.beginTransition()
+	if err != nil {
+		chainState.admissionMu.Unlock()
+		return nil, err
+	}
+	rollback, err := s.captureRollbackStateWithIndex(canonicalIndex)
+	if err != nil {
+		owner.endTransitionAborted()
+		chainState.admissionMu.Unlock()
+		return nil, err
+	}
+	return &canonicalTransition{
+		engine:     s,
+		chainState: chainState,
+		mempool:    mempool,
+		owner:      owner,
+		generation: generation,
+		rollback:   rollback,
+	}, nil
+}
+
+// finish commits the owner stable tip from the live ChainState as the LAST
+// state change of the transition, reopens admission, and only then records the
+// runtime accepted-tip metrics.
+func (t *canonicalTransition) finish() error {
+	err := t.owner.commitStableTip(pendingOutpointTipOf(t.chainState))
+	t.chainState.admissionMu.Unlock()
+	if err != nil {
+		return err
+	}
+	if t.applied {
+		t.engine.recordAppliedBlock(t.appliedHeight, t.appliedTimestamp)
+	}
+	return nil
+}
+
+// abort reopens admission after the caller has proven the exact restore. The
+// stable tip keeps its pre-transition value; high-waters stay advanced.
+func (t *canonicalTransition) abort() {
+	t.owner.endTransitionAborted()
+	t.chainState.admissionMu.Unlock()
+}
+
+// end closes the transition for cause, and is the ONLY place that decides
+// between reopening admission and latching it shut.
+//
+// cause == nil commits the stable tip and reopens admission.
+//
+// TWO causes are terminal and fail-closed, because neither leaves the live and
+// persistent states both provable: an already-latched ambiguous atomic
+// POST-COMMIT persistence fault, and a rollback whose exact restore FAILED
+// (*rollbackRestoreFault). Either leaves the owner transition-active,
+// AdmissionContext unavailable and admissionMu deliberately NOT released, and
+// latches the engine fault so later mutators fail closed too. Waiters block
+// until the required restart, which beats reopening over an unproven state.
+//
+// admissionMu is the ONLY lock retained across that terminal state. mutationMu
+// is released by the calling entry point's own deferred unlock as this returns,
+// so a later SyncEngine mutator acquires it and gets the latched fault from
+// mutationAllowed instead of waiting forever.
+//
+// Any other cause is an ordinary abort: the caller has already proven the exact
+// restore, so admission reopens with high-waters left advanced.
+func (t *canonicalTransition) end(cause error) error {
+	if cause == nil {
+		return t.finish()
+	}
+	if t.engine.persistenceFaulted() {
+		t.engine.reportTerminalTransition("post-commit persistence fault", cause)
+		return cause
+	}
+	var restoreFault *rollbackRestoreFault
+	if errors.As(cause, &restoreFault) {
+		t.engine.latchTerminalFault(cause)
+		t.engine.reportTerminalTransition("rollback restore failed", cause)
+		return cause
+	}
+	t.abort()
+	return cause
+}
+
+// latchTerminalFault installs cause as the engine's terminal storage-persistence
+// fault when none is latched yet. It is the SAME latch handlePersistenceError
+// installs — no new recovery mechanism, no new state machine — so mutationAllowed
+// returns it to every later mutator exactly as after an ambiguous write.
+func (s *SyncEngine) latchTerminalFault(cause error) {
+	s.persistenceFaultMu.Lock()
+	defer s.persistenceFaultMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.persistenceFault == nil {
+		s.persistenceFault = &storagePersistenceFault{cause: cause}
+	}
+}
+
+// reportTerminalTransition makes the fail-closed latch visible to an operator:
+// without it a latched node is indistinguishable from a merely hung one.
+func (s *SyncEngine) reportTerminalTransition(reason string, cause error) {
+	_, _ = fmt.Fprintf(s.stderr, "sync: canonical transition terminal (%s), admission stays closed until restart: %v\n", reason, cause)
+}
+
+// rollbackRestoreFault marks a transition failure whose EXACT restore could not
+// be proven. It keeps the historical "cause (rollback failed: ...)" message; the
+// type exists so end() can route it into the fail-closed terminal latch.
+type rollbackRestoreFault struct {
+	cause      error
+	restoreErr error
+}
+
+func (e *rollbackRestoreFault) Error() string {
+	return fmt.Sprintf("%v (rollback failed: %v)", e.cause, e.restoreErr)
+}
+
+func (e *rollbackRestoreFault) Unwrap() error { return e.cause }
+
+// publishPreparedChainState copies a fully prepared chain state onto the live
+// ChainState under ChainState.mu only.
+//
+// The canonical transition already owns ChainState.admissionMu, and
+// ChainState.replaceFrom reacquires that same non-reentrant lock, so calling it
+// from under the guard would self-deadlock. Every restore and publication that
+// can run under the guard MUST use this helper instead.
+func publishPreparedChainState(dst *ChainState, src *ChainState) error {
+	snapshot := cloneChainState(src)
+	if dst == nil || snapshot == nil {
+		return errors.New("nil chainstate publication")
+	}
+	dst.mu.Lock()
+	defer dst.mu.Unlock()
+	dst.Utxos = snapshot.Utxos
+	dst.Height = snapshot.Height
+	dst.AlreadyGenerated = snapshot.AlreadyGenerated
+	dst.TipHash = snapshot.TipHash
+	dst.HasTip = snapshot.HasTip
+	dst.Rotation = snapshot.Rotation
+	dst.Registry = snapshot.Registry
+	return nil
+}
+
 func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) error {
 	if s.persistenceFaulted() {
+		return cause
+	}
+	var restoreFault *rollbackRestoreFault
+	if errors.As(cause, &restoreFault) {
+		// An inner restore already failed: retrying cannot make the state
+		// provable, and would mask the original fault. Propagate it to end().
 		return cause
 	}
 	restoreErr := s.restoreRollbackPersistentState(state)
@@ -608,7 +825,7 @@ func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) er
 	}
 	s.restoreRollbackRuntimeState(state)
 	if restoreErr != nil {
-		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
+		return &rollbackRestoreFault{cause: cause, restoreErr: restoreErr}
 	}
 	return cause
 }
@@ -673,19 +890,28 @@ func (s *SyncEngine) reloadVisiblePersistenceState(reloadStore, reloadState bool
 	if !reloadState || chainStatePath == "" {
 		return reloadErr
 	}
-	loaded, err := LoadChainState(chainStatePath)
-	if err != nil {
+	if err := reloadVisibleChainState(state, chainStatePath); err != nil {
 		return firstRollbackRestoreErr(reloadErr, err)
 	}
+	return reloadErr
+}
+
+// reloadVisibleChainState re-reads the persisted chainstate from path and
+// republishes it into state, carrying the live rotation and registry fields
+// across. It touches no Mempool and no pending-outpoint owner.
+func reloadVisibleChainState(state *ChainState, path string) error {
+	loaded, err := LoadChainState(path)
+	if err != nil {
+		return err
+	}
 	if state == nil {
-		return firstRollbackRestoreErr(reloadErr, errors.New("nil chainstate destination"))
+		return errors.New("nil chainstate destination")
 	}
 	state.mu.RLock()
 	loaded.Rotation = state.Rotation
 	loaded.Registry = state.Registry
 	state.mu.RUnlock()
-	state.replaceFrom(loaded)
-	return reloadErr
+	return publishPreparedChainState(state, loaded)
 }
 
 func (s *SyncEngine) restoreRollbackPersistentState(state syncRollbackState) error {
@@ -731,8 +957,7 @@ func (s *SyncEngine) restoreRollbackChainState(state syncRollbackState) error {
 	if recovered == nil {
 		return errors.New("nil rollback chainstate")
 	}
-	s.chainState.replaceFrom(recovered)
-	return nil
+	return publishPreparedChainState(s.chainState, recovered)
 }
 
 func (s *SyncEngine) applyCanonicalParsedBlock(
@@ -753,10 +978,18 @@ type canonicalBlockApplyContext struct {
 	blockHeight    uint64
 	blockHash      [32]byte
 	expectedTarget *[32]byte
-	rollbackState  syncRollbackState
 	prevState      *ChainState
+	// canonicalIndex is the rollback preflight result, read before the clone
+	// below was connected so a local index fault outranks a consensus one.
+	canonicalIndex []string
 }
 
+// applyCanonicalParsedBlockTracked fully validates one direct-connect candidate
+// against a PRIVATE cloned ChainState — the live ChainState, BlockStore
+// canonical state, Mempool and owner are untouched until the block is proven —
+// and only then opens a canonical transition and commits it. A preferred-branch
+// reorg does not come through here: it prepares every row the same way in
+// preparePreferredBranch and commits them all inside ONE transition.
 func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
@@ -767,7 +1000,18 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	if err != nil {
 		return nil, outcome, err
 	}
-	summary, err := s.connectCanonicalBlock(blockBytes, prevTimestamps, ctx.expectedTarget)
+	prepared := cloneChainState(ctx.prevState)
+	if prepared == nil {
+		return nil, blockApplyMetricNone, errors.New("nil prepared chainstate")
+	}
+	summary, err := prepared.ConnectBlockWithSuiteContext(
+		blockBytes,
+		ctx.expectedTarget,
+		prevTimestamps,
+		s.cfg.ChainID,
+		s.cfg.RotationProvider,
+		s.cfg.SuiteRegistry,
+	)
 	s.runPVShadowIfActive(blockBytes, prevTimestamps, ctx, err, summary)
 	if err != nil {
 		return nil, blockApplyMetricRejected, err
@@ -778,17 +1022,96 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	// no re-parse, no retained bytes — and only AFTER the connect succeeded, so
 	// an over-cap or malformed DA layout is rejected by consensus with its own
 	// public error code before this ever runs. Any error here is therefore a
-	// defensive assertion; it rolls the apply back rather than committing a
-	// block whose canonical-applied report could not be built.
+	// defensive assertion; it happens before the transition begins, so nothing
+	// has been mutated and there is nothing to roll back.
 	daIDs, err := CompleteDASetIDsFromParsedBlock(pb)
 	if err != nil {
-		return nil, blockApplyMetricNone, s.rollbackApplyBlock(err, ctx.rollbackState)
+		return nil, blockApplyMetricNone, err
 	}
 	summary.CanonicalAppliedBlocks = []CanonicalAppliedBlock{{Hash: ctx.blockHash, CompleteDAIDs: daIDs}}
-	if err := s.finalizeAppliedBlock(summary, ctx.blockHash, pb, blockBytes, ctx.prevState, ctx.rollbackState); err != nil {
+	if err := s.commitPreparedBlock(prepared, summary, ctx, pb, blockBytes); err != nil {
 		return nil, blockApplyMetricNone, err
 	}
 	return summary, blockApplyMetricAccepted, nil
+}
+
+// commitPreparedBlock opens the transition for a direct connect and runs the
+// mutating half of the apply inside it.
+func (s *SyncEngine) commitPreparedBlock(
+	prepared *ChainState,
+	summary *ChainStateConnectSummary,
+	ctx canonicalBlockApplyContext,
+	pb *consensus.ParsedBlock,
+	blockBytes []byte,
+) error {
+	tr, err := s.beginCanonicalTransition(ctx.canonicalIndex)
+	if err != nil {
+		return err
+	}
+	err = s.commitPreparedBlockUnderGuard(tr, prepared, summary, ctx, pb, blockBytes)
+	if err == nil {
+		tr.appliedHeight, tr.appliedTimestamp, tr.applied = summary.BlockHeight, pb.Header.Timestamp, true
+	}
+	return tr.end(err)
+}
+
+// commitPreparedBlockUnderGuard commits one already-validated block under an
+// open transition: live tip recheck, standard cleanup BEFORE any observable
+// canonical tip change, prepared-state publication, then persistence. No parse,
+// ConnectBlock, signature verification or consensus validation runs here, and
+// every error it returns has already been through rollback.
+func (s *SyncEngine) commitPreparedBlockUnderGuard(
+	tr *canonicalTransition,
+	prepared *ChainState,
+	summary *ChainStateConnectSummary,
+	ctx canonicalBlockApplyContext,
+	pb *consensus.ParsedBlock,
+	blockBytes []byte,
+) error {
+	if err := s.recheckLiveTipIdentity(tr, ctx); err != nil {
+		return s.rollbackApplyBlock(err, tr.rollback)
+	}
+	// Cleanup precedes publication: the standard records and their exact
+	// claims are gone before any observer can see the new canonical tip.
+	if !tr.suppressInnerCleanup && tr.mempool != nil {
+		if err := tr.mempool.applyConnectedBlockParsed(pb); err != nil {
+			_, _ = fmt.Fprintf(s.stderr, "sync: standard mempool cleanup failed at height %d, rolling back: %v\n", ctx.blockHeight, err)
+			return s.rollbackApplyBlock(err, tr.rollback)
+		}
+	}
+	if err := publishPreparedChainState(tr.chainState, prepared); err != nil {
+		return s.rollbackApplyBlock(err, tr.rollback)
+	}
+	return s.finalizeAppliedBlock(summary, ctx.blockHash, pb, blockBytes, ctx.prevState, tr.rollback)
+}
+
+// recheckLiveTipIdentity proves, under the transition guard, that the live
+// ChainState AND the live BlockStore canonical tip are still exactly the state
+// the candidate was prepared against. mutationMu already serializes canonical
+// mutation in-process, so both halves are defense in depth.
+func (s *SyncEngine) recheckLiveTipIdentity(tr *canonicalTransition, ctx canonicalBlockApplyContext) error {
+	live := tr.chainState.view()
+	if live.hasTip != ctx.prevState.HasTip || live.height != ctx.prevState.Height || live.tipHash != ctx.prevState.TipHash {
+		return errors.New("live chainstate tip moved during canonical apply")
+	}
+	return s.recheckLiveStoreTipIdentity(ctx)
+}
+
+// recheckLiveStoreTipIdentity is the BlockStore half of recheckLiveTipIdentity.
+// An engine with no store has no second tip to disagree with, so it passes. The
+// check only reads the store and mutates nothing.
+func (s *SyncEngine) recheckLiveStoreTipIdentity(ctx canonicalBlockApplyContext) error {
+	if s.blockStore == nil {
+		return nil
+	}
+	storeHeight, storeHash, storeHasTip, err := s.blockStore.Tip()
+	if err != nil {
+		return err
+	}
+	if storeHasTip != ctx.prevState.HasTip || (storeHasTip && (storeHeight != ctx.prevState.Height || storeHash != ctx.prevState.TipHash)) {
+		return errors.New("live blockstore tip moved during canonical apply")
+	}
+	return nil
 }
 
 func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, target *canonicalApplyTarget) (canonicalBlockApplyContext, blockApplyMetricOutcome, error) {
@@ -810,16 +1133,24 @@ func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, targe
 	if outcome, err := s.validateGenesisIdentity(blockHeight, blockHash); err != nil {
 		return canonicalBlockApplyContext{}, outcome, err
 	}
-	rollbackState, err := s.captureRollbackState()
+	// The fallible canonical-index rollback preflight sits exactly where it sat
+	// before the transition existed: after the genesis-identity guard and BEFORE
+	// the clone below is connected, so a corrupt local index is reported ahead of
+	// the candidate's consensus error rather than behind it.
+	canonicalIndex, err := s.canonicalIndexPreflight()
 	if err != nil {
 		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
+	}
+	prevState := cloneChainState(s.chainState)
+	if prevState == nil {
+		return canonicalBlockApplyContext{}, blockApplyMetricNone, errors.New("nil chainstate")
 	}
 	return canonicalBlockApplyContext{
 		blockHeight:    blockHeight,
 		blockHash:      blockHash,
 		expectedTarget: expectedTarget,
-		rollbackState:  rollbackState,
-		prevState:      cloneChainState(rollbackState.chainState),
+		prevState:      prevState,
+		canonicalIndex: canonicalIndex,
 	}, blockApplyMetricNone, nil
 }
 
@@ -835,7 +1166,7 @@ func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, targe
 // candidate to one WINDOW_SIZE walk instead of two. Otherwise the selected
 // parent is the canonical tip from nextBlockContext; at height 0 nothing is
 // derived and the published-genesis path is unchanged. All of it is read-only
-// and runs before captureRollbackState, therefore before any mutation.
+// and runs before the canonical transition opens, therefore before any mutation.
 func (s *SyncEngine) resolveCanonicalApplyTarget(target *canonicalApplyTarget, canonicalTip *[32]byte, blockHeight uint64) (*[32]byte, error) {
 	if target != nil {
 		return target.expected, nil
@@ -859,19 +1190,4 @@ func (s *SyncEngine) validateCanonicalBlockApplyReady(pb *consensus.ParsedBlock)
 		return errors.New("nil parsed block")
 	}
 	return nil
-}
-
-func (s *SyncEngine) connectCanonicalBlock(
-	blockBytes []byte,
-	prevTimestamps []uint64,
-	expectedTarget *[32]byte,
-) (*ChainStateConnectSummary, error) {
-	return s.chainState.ConnectBlockWithSuiteContext(
-		blockBytes,
-		expectedTarget,
-		prevTimestamps,
-		s.cfg.ChainID,
-		s.cfg.RotationProvider,
-		s.cfg.SuiteRegistry,
-	)
 }

--- a/clients/go/node/sync_disconnect.go
+++ b/clients/go/node/sync_disconnect.go
@@ -5,9 +5,14 @@ import (
 )
 
 type disconnectTipContext struct {
-	storedBlock     verifiedStoredBlock
-	undo            *BlockUndo
-	rollbackState   syncRollbackState
+	storedBlock verifiedStoredBlock
+	undo        *BlockUndo
+	// tipHeight is the canonical height of the block being disconnected, read
+	// fresh per block. The canonical index must be truncated relative to the
+	// CURRENT tip: a preferred-branch reorg disconnects several blocks inside
+	// ONE transition, so a length taken from the shared rollback snapshot would
+	// truncate every iteration back to the same original height.
+	tipHeight       uint64
 	newTipTimestamp uint64
 }
 
@@ -20,23 +25,67 @@ func (s *SyncEngine) DisconnectTip() (*ChainStateDisconnectSummary, error) {
 	return s.disconnectTip()
 }
 
+// disconnectTip runs a standalone disconnect as ONE canonical transition: it
+// advances a single generation, commits the prepared stable tip under the same
+// guard, and adds no requeue and no full-Mempool revalidation policy.
 func (s *SyncEngine) disconnectTip() (*ChainStateDisconnectSummary, error) {
+	canonicalIndex, err := s.canonicalIndexPreflight()
+	if err != nil {
+		return nil, err
+	}
 	ctx, err := s.prepareDisconnectTip()
 	if err != nil {
 		return nil, err
 	}
-	return s.disconnectPreparedTip(ctx)
-}
-
-func (s *SyncEngine) disconnectPreparedTip(ctx disconnectTipContext) (*ChainStateDisconnectSummary, error) {
-	summary, err := s.chainState.disconnectVerifiedStoredBlock(ctx.storedBlock, ctx.undo)
+	tr, err := s.beginCanonicalTransition(canonicalIndex)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.finalizeDisconnectState(ctx.rollbackState, ctx.newTipTimestamp); err != nil {
+	summary, err := s.disconnectPreparedTip(ctx, tr.rollback)
+	if endErr := tr.end(err); endErr != nil {
+		return nil, endErr
+	}
+	return summary, nil
+}
+
+// disconnectPreparedTip disconnects one prepared tip under the caller's already
+// open canonical transition. It takes that transition's rollback state by value
+// rather than the transition itself: nothing else here is transition-scoped, and
+// a value cannot be nil-dereferenced on the validity path.
+func (s *SyncEngine) disconnectPreparedTip(ctx disconnectTipContext, rollback syncRollbackState) (*ChainStateDisconnectSummary, error) {
+	summary, err := s.disconnectVerifiedUnderTransition(ctx.storedBlock, ctx.undo)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.finalizeDisconnectState(rollback, ctx.tipHeight, ctx.newTipTimestamp); err != nil {
 		return nil, err
 	}
 	return summary, nil
+}
+
+// disconnectVerifiedUnderTransition mirrors ChainState.disconnectVerifiedStoredBlock
+// without its admissionMu acquisition. The canonical transition already owns
+// that lock and sync.RWMutex is not reentrant, so calling the public wrapper
+// from under the guard would self-deadlock. Validation order and the shared
+// already-validated locked mutation primitive are unchanged.
+func (s *SyncEngine) disconnectVerifiedUnderTransition(storedBlock verifiedStoredBlock, undo *BlockUndo) (*ChainStateDisconnectSummary, error) {
+	state := s.chainState
+	if state == nil {
+		return nil, errors.New("nil chainstate")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if !state.HasTip {
+		return nil, errors.New("chainstate has no tip")
+	}
+	if undo == nil {
+		return nil, errors.New("nil block undo")
+	}
+	pb, err := validateVerifiedDisconnectStoredBlock(storedBlock, undo, state.TipHash, state.Height)
+	if err != nil {
+		return nil, err
+	}
+	return state.disconnectParsedBlockLocked(pb, storedBlock.lookupHash, undo)
 }
 
 func (s *SyncEngine) prepareDisconnectTip() (disconnectTipContext, error) {
@@ -98,10 +147,6 @@ func (s *SyncEngine) prepareDisconnectTipContext(tipHeight uint64, tipHash [32]b
 	if storedBlock.parsed == nil {
 		return disconnectTipContext{}, errors.New("nil verified stored block")
 	}
-	rollbackState, err := s.captureRollbackState()
-	if err != nil {
-		return disconnectTipContext{}, err
-	}
 	newTipTimestamp, err := s.getParentTimestamp(tipHeight, storedBlock.parsed.Header.PrevBlockHash)
 	if err != nil {
 		return disconnectTipContext{}, err
@@ -109,7 +154,7 @@ func (s *SyncEngine) prepareDisconnectTipContext(tipHeight uint64, tipHash [32]b
 	return disconnectTipContext{
 		storedBlock:     storedBlock,
 		undo:            undo,
-		rollbackState:   rollbackState,
+		tipHeight:       tipHeight,
 		newTipTimestamp: newTipTimestamp,
 	}, nil
 }
@@ -124,7 +169,7 @@ func (s *SyncEngine) validateDisconnectTipReady() error {
 	return nil
 }
 
-func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64, preparedBlocks []verifiedStoredBlock) error {
+func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64, preparedBlocks []verifiedStoredBlock, rollback syncRollbackState) error {
 	if err := s.validatePreparedDisconnectBlocks(commonAncestorHeight, preparedBlocks); err != nil {
 		return err
 	}
@@ -133,7 +178,7 @@ func (s *SyncEngine) disconnectCanonicalToAncestor(commonAncestorHeight uint64, 
 		if err != nil {
 			return err
 		}
-		if _, err := s.disconnectPreparedTip(ctx); err != nil {
+		if _, err := s.disconnectPreparedTip(ctx, rollback); err != nil {
 			return err
 		}
 	}
@@ -229,8 +274,8 @@ func (s *SyncEngine) getParentTimestamp(tipHeight uint64, prevBlockHash [32]byte
 }
 
 // finalizeDisconnectState updates chain state after disconnect.
-func (s *SyncEngine) finalizeDisconnectState(rollbackState syncRollbackState, newTipTimestamp uint64) error {
-	if err := s.blockStore.TruncateCanonical(uint64(len(rollbackState.canonicalIndex)) - 1); err != nil {
+func (s *SyncEngine) finalizeDisconnectState(rollbackState syncRollbackState, disconnectedHeight uint64, newTipTimestamp uint64) error {
+	if err := s.blockStore.TruncateCanonical(disconnectedHeight); err != nil {
 		if isAtomicWritePostCommit(err) {
 			return s.handlePersistenceError(err, true, false)
 		}

--- a/clients/go/node/sync_disconnect_test.go
+++ b/clients/go/node/sync_disconnect_test.go
@@ -102,9 +102,14 @@ func TestDisconnectPreparedTipUsesRetainedVerifiedBlock(t *testing.T) {
 	}
 	writeRawStoreBlockFile(t, store, summary.BlockHash, []byte("not a block"))
 
-	disconnected, err := engine.disconnectPreparedTip(ctx)
+	tr := mustBeginCanonicalTransition(t, engine)
+	disconnected, err := engine.disconnectPreparedTip(ctx, tr.rollback)
 	if err != nil {
+		tr.abort()
 		t.Fatalf("disconnectPreparedTip reread or reparsed the block: %v", err)
+	}
+	if err := tr.finish(); err != nil {
+		t.Fatalf("canonical transition finish: %v", err)
 	}
 	if disconnected.BlockHash != summary.BlockHash || engine.chainState.Height != 0 || engine.chainState.TipHash != devnetGenesisBlockHash {
 		t.Fatalf("disconnect summary=%+v state=(%d,%x)", disconnected, engine.chainState.Height, engine.chainState.TipHash)
@@ -153,8 +158,13 @@ func TestPreparedCanonicalDisconnectRetainsPreviewedBlocks(t *testing.T) {
 		writeRawStoreBlockFile(t, store, storedBlock.lookupHash, []byte("replaced after preview"))
 	}
 
-	if err := engine.disconnectCanonicalToAncestor(0, prepared); err != nil {
+	tr := mustBeginCanonicalTransition(t, engine)
+	if err := engine.disconnectCanonicalToAncestor(0, prepared, tr.rollback); err != nil {
+		tr.abort()
 		t.Fatalf("disconnectCanonicalToAncestor reread a prepared block: %v", err)
+	}
+	if err := tr.finish(); err != nil {
+		t.Fatalf("canonical transition finish: %v", err)
 	}
 	if engine.chainState.Height != 0 || engine.chainState.TipHash != devnetGenesisBlockHash {
 		t.Fatalf("chainstate after retained disconnect=(%d,%x), want genesis", engine.chainState.Height, engine.chainState.TipHash)
@@ -191,7 +201,7 @@ func TestPreparedDisconnectValidationErrors(t *testing.T) {
 	}{
 		{"prepare uninitialized", "sync engine is not initialized", func() error { _, err := uninitialized.prepareDisconnectTipFromVerified(stored); return err }},
 		{"prepare empty store", "blockstore has no canonical tip", func() error { _, err := empty.prepareDisconnectTipFromVerified(stored); return err }},
-		{"ancestor above tip", "common ancestor is above canonical tip", func() error { return engine.disconnectCanonicalToAncestor(2, prepared) }},
+		{"ancestor above tip", "common ancestor is above canonical tip", func() error { return engine.disconnectCanonicalToAncestor(2, prepared, syncRollbackState{}) }},
 		{"validate uninitialized", "sync engine is not initialized", func() error { return uninitialized.validatePreparedDisconnectBlocks(0, nil) }},
 		{"validate empty store", "blockstore has no canonical tip", func() error { return empty.validatePreparedDisconnectBlocks(0, nil) }},
 		{"wrong count", "prepared disconnect block count mismatch", func() error { return engine.validatePreparedDisconnectBlocks(0, nil) }},
@@ -209,4 +219,99 @@ func TestPreparedDisconnectValidationErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDisconnectTipPendingOutpointAdvancesOneGenerationWithoutRequeue proves the
+// standalone-disconnect row: each disconnect runs as ONE canonical transition
+// that advances exactly one generation and commits the parent as the owner's
+// stable tip, it leaves resident records and their exact tokens untouched, and
+// it invents no requeue policy — a transaction carried by the disconnected
+// block does not reappear in the standard mempool.
+func TestDisconnectTipPendingOutpointAdvancesOneGenerationWithoutRequeue(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight, f.alreadyGenerated
+	spend := f.spend(t, 700, 1)
+	spendID := txID(t, spend)
+
+	subsidy101 := consensus.BlockSubsidy(forkHeight+1, forkGenerated)
+	plain := buildSingleTxBlock(t, forkHash, f.target, 202, reorgTestCoinbaseForAddress(t, forkHeight+1, subsidy101, f.sourceAddress))
+	if _, err := f.engine.ApplyBlock(plain, nil); err != nil {
+		t.Fatalf("ApplyBlock(plain 101): %v", err)
+	}
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	f.mempool.mu.Lock()
+	residentToken := f.mempool.txs[spendID].token
+	f.mempool.mu.Unlock()
+	beforeDisconnect := mustAdmissionContext(t, f.owner, "before the standalone disconnect")
+
+	if _, err := f.engine.DisconnectTip(); err != nil {
+		t.Fatalf("DisconnectTip(plain 101): %v", err)
+	}
+
+	afterDisconnect := mustAdmissionContext(t, f.owner, "after the standalone disconnect")
+	if afterDisconnect.Generation != beforeDisconnect.Generation+1 {
+		t.Fatalf("generation after disconnect=%d, want exactly one advance from %d", afterDisconnect.Generation, beforeDisconnect.Generation)
+	}
+	if afterDisconnect.StableTip.Hash != forkHash || afterDisconnect.StableTip.Height != forkHeight {
+		t.Fatalf("stable tip after disconnect=%+v, want the parent (%d,%x)", afterDisconnect.StableTip, forkHeight, forkHash)
+	}
+	entry, claim := residentClaim(t, f.mempool, spendID)
+	if entry.token != residentToken {
+		t.Fatalf("resident token seq=%d after disconnect, want the exact seq %d", entry.token.seq, residentToken.seq)
+	}
+	if claim == nil || !claim.finalized {
+		t.Fatalf("resident claim=%+v after disconnect, want it untouched and finalized", claim)
+	}
+	if got := f.mempool.Len(); got != 1 {
+		t.Fatalf("mempool len after disconnect=%d, want the single untouched resident", got)
+	}
+
+	// Now disconnect a block that DID carry the transaction: the connect
+	// released its token, and the disconnect must not requeue it.
+	including := f.blockIncluding(t, forkHash, forkHeight+1, forkGenerated, 203, spend)
+	if _, err := f.engine.ApplyBlock(including, nil); err != nil {
+		t.Fatalf("ApplyBlock(including spend): %v", err)
+	}
+	if got := f.mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after the including connect=%d, want 0", got)
+	}
+	beforeSecond := mustAdmissionContext(t, f.owner, "before the second disconnect")
+	if _, err := f.engine.DisconnectTip(); err != nil {
+		t.Fatalf("DisconnectTip(including 101): %v", err)
+	}
+	afterSecond := mustAdmissionContext(t, f.owner, "after the second disconnect")
+	if afterSecond.Generation != beforeSecond.Generation+1 {
+		t.Fatalf("second disconnect generation=%d, want exactly one advance from %d", afterSecond.Generation, beforeSecond.Generation)
+	}
+	if afterSecond.StableTip.Hash != forkHash {
+		t.Fatalf("stable tip after the second disconnect=%+v, want the parent %x", afterSecond.StableTip, forkHash)
+	}
+	if got := f.mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after the second disconnect=%d, want 0: standalone disconnect adds no requeue", got)
+	}
+	outpoints, claims, highWater := ownerClaimCount(f.owner)
+	if outpoints != 0 || claims != 0 {
+		t.Fatalf("owner holds outpoints=%d claims=%d after the disconnects, want none", outpoints, claims)
+	}
+	if highWater != 1 {
+		t.Fatalf("token high-water=%d, want the single consumed sequence retained", highWater)
+	}
+}
+
+// mustBeginCanonicalTransition runs the canonical-index preflight and opens a
+// transition in the same order production does, so a test never opens one with
+// an unread rollback index.
+func mustBeginCanonicalTransition(t *testing.T, engine *SyncEngine) *canonicalTransition {
+	t.Helper()
+	canonicalIndex, err := engine.canonicalIndexPreflight()
+	if err != nil {
+		t.Fatalf("canonicalIndexPreflight: %v", err)
+	}
+	tr, err := engine.beginCanonicalTransition(canonicalIndex)
+	if err != nil {
+		t.Fatalf("beginCanonicalTransition: %v", err)
+	}
+	return tr
 }

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -9,11 +9,17 @@ import (
 )
 
 type mempoolSnapshot struct {
-	entries           []mempoolEntry
+	entries []mempoolEntry
+	// pending is the same-owner pending-outpoint image captured with the
+	// entries: every live claim, the stable tip, and both high-waters.
+	pending           pendingOutpointSnapshot
 	lastAdmissionSeq  uint64
 	currentMinFeeRate uint64
 }
 
+// snapshotMempool captures the exact rollback image: cloned entries with their
+// exact tokens plus the owner's claims, stable tip and high-waters. Lock order
+// is Mempool.mu then owner.mu.
 func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
 	if m == nil {
 		return mempoolSnapshot{}, nil
@@ -31,9 +37,20 @@ func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
 	if currentMinFeeRate < DefaultMempoolMinFeeRate {
 		currentMinFeeRate = DefaultMempoolMinFeeRate
 	}
-	return mempoolSnapshot{entries: entries, lastAdmissionSeq: m.lastAdmissionSeq, currentMinFeeRate: currentMinFeeRate}, nil
+	return mempoolSnapshot{
+		entries:           entries,
+		pending:           m.pendingOutpoints.snapshot(),
+		lastAdmissionSeq:  m.lastAdmissionSeq,
+		currentMinFeeRate: currentMinFeeRate,
+	}, nil
 }
 
+// restoreMempoolSnapshot rebuilds the records and the owner claims of the SAME
+// owner from snapshot. It builds every temporary map first, cross-checks each
+// record against its exact finalized standard claim in both directions, and
+// only then publishes all maps or none. Token and generation high-waters are
+// retained at their advanced values, so an aborted transition can never hand
+// out a sequence twice.
 func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	if m == nil {
 		return nil
@@ -43,20 +60,60 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	if m.maxTxs <= 0 || m.maxBytes <= 0 {
 		return fmt.Errorf("invalid mempool snapshot restore limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes)
 	}
-	txs, wtxids, spenders, maxAdmissionSeq, usedBytes, err := buildMempoolRestoreMaps(snapshot.entries, m.maxTxs, m.maxBytes)
+	txs, wtxids, maxAdmissionSeq, usedBytes, err := buildMempoolRestoreMaps(snapshot.entries, m.maxTxs, m.maxBytes)
 	if err != nil {
 		return err
 	}
 	if snapshot.lastAdmissionSeq < maxAdmissionSeq {
 		return fmt.Errorf("mempool snapshot admission high-watermark below restored max: last=%d max=%d", snapshot.lastAdmissionSeq, maxAdmissionSeq)
 	}
+	owner := m.pendingOutpointOwnerLocked()
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	candidate, err := owner.buildRestoreLocked(snapshot.pending)
+	if err != nil {
+		return err
+	}
+	if err := validateRestoredClaimBinding(txs, candidate); err != nil {
+		return err
+	}
+	// Everything fallible is done. Both locks are held, so the owner image and
+	// the records below become visible to any reader as one step.
+	owner.publishRestoreLocked(snapshot.pending, candidate)
 	m.txs = txs
 	m.wtxids = wtxids
-	m.spenders = spenders
 	m.usedBytes = usedBytes
 	m.lastAdmissionSeq = snapshot.lastAdmissionSeq
 	m.currentMinFeeRate = snapshot.currentMinFeeRate
 	m.ensureMinFeeRateLocked()
+	return nil
+}
+
+// validateRestoredClaimBinding proves the bijection between the records about to
+// be installed and the CANDIDATE finalized standard claims that would be
+// published alongside them: every record with inputs holds exactly one finalized
+// standard claim carrying its exact token, txid, domain and ordered inputs, and
+// no finalized standard claim is left without a record. Both sides are still
+// unpublished, so a rejection leaves live owner and records untouched.
+func validateRestoredClaimBinding(txs map[[32]byte]*mempoolEntry, candidate pendingOutpointIndex) error {
+	finalized := 0
+	for _, claim := range candidate.byToken {
+		if claim.domain == PendingOutpointStandardMempool && claim.finalized {
+			finalized++
+		}
+	}
+	claimed := 0
+	for _, entry := range txs {
+		if err := candidate.validateEntryClaim(entry.txid, entry.inputs, entry.token, true); err != nil {
+			return err
+		}
+		if len(entry.inputs) > 0 {
+			claimed++
+		}
+	}
+	if claimed != finalized {
+		return pendingOutpointInternal(fmt.Sprintf("mempool snapshot claim count mismatch: records=%d finalized_claims=%d", claimed, finalized))
+	}
 	return nil
 }
 
@@ -82,6 +139,7 @@ func cloneMempoolEntry(entry *mempoolEntry) mempoolEntry {
 		txid:         entry.txid,
 		wtxid:        entry.wtxid,
 		inputs:       append([]consensus.Outpoint(nil), entry.inputs...),
+		token:        entry.token,
 		fee:          entry.fee,
 		weight:       entry.weight,
 		size:         entry.size,
@@ -90,29 +148,24 @@ func cloneMempoolEntry(entry *mempoolEntry) mempoolEntry {
 	}
 }
 
-// buildMempoolRestoreMaps builds txid/wtxid/spender/admission maps from snapshot entries.
+// buildMempoolRestoreMaps builds txid/wtxid/admission maps from snapshot
+// entries. Outpoint uniqueness is no longer checked here: the owner's
+// restoreLocked rejects a duplicate outpoint across claims, and
+// validateRestoredClaimBinding then binds every record to its exact claim.
 func buildMempoolRestoreMaps(snapshotEntries []mempoolEntry, maxTxs int, maxBytes int) (
 	txs map[[32]byte]*mempoolEntry,
 	wtxids map[[32]byte][32]byte,
-	spenders map[consensus.Outpoint][32]byte,
 	maxAdmissionSeq uint64,
 	usedBytes int,
 	err error,
 ) {
 	txs = make(map[[32]byte]*mempoolEntry, len(snapshotEntries))
 	wtxids = make(map[[32]byte][32]byte, len(snapshotEntries))
-	spenders = make(map[consensus.Outpoint][32]byte)
 	admissionSeqs := make(map[uint64][32]byte, len(snapshotEntries))
 	for _, item := range snapshotEntries {
 		entry := cloneMempoolEntry(&item)
 		if err := validateMempoolRestoreEntry(entry, txs, wtxids, admissionSeqs, len(txs), usedBytes, maxTxs, maxBytes); err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		for _, op := range entry.inputs {
-			if existing, exists := spenders[op]; exists {
-				return nil, nil, nil, 0, 0, fmt.Errorf("duplicate mempool snapshot spender txid=%x vout=%d existing=%x new=%x", op.Txid, op.Vout, existing, entry.txid)
-			}
-			spenders[op] = entry.txid
+			return nil, nil, 0, 0, err
 		}
 		entryCopy := entry
 		txs[entryCopy.txid] = &entryCopy

--- a/clients/go/node/sync_persistence_fault_test.go
+++ b/clients/go/node/sync_persistence_fault_test.go
@@ -151,19 +151,61 @@ func TestSyncEnginePostCommitFailuresReloadVisibleStateWithoutCompensation(t *te
 	requireAtomicTest(t, nilFault.Unwrap() == nil, "nil fault unwrap")
 }
 
-func TestSyncEnginePostCommitFaultLatchesBeforeCapturedStateReplacement(t *testing.T) {
+// TestSyncEnginePostCommitFaultKeepsAdmissionClosedAfterLatch pins the terminal
+// fail-closed contract for an ambiguous atomic POST-COMMIT persistence failure:
+// the fault is latched, the owner stays transition-active so AdmissionContext
+// stays unavailable, the continuous admission guard is never released so a
+// standard-admission waiter cannot pass it, and a later SyncEngine mutator
+// acquires mutationMu and returns the latched fault instead of blocking forever.
+//
+// The controlling goroutine deliberately NEVER acquires admissionMu before it
+// releases the injected block: the transition holds that guard across
+// persistence by design, so taking it here would deadlock the test rather than
+// observe anything. Everything below is proven from the owner and the engine
+// instead, and the admission waiter runs on its own goroutine.
+func TestSyncEnginePostCommitFaultKeepsAdmissionClosedAfterLatch(t *testing.T) {
 	engine, store, _ := newPersistenceFaultEngine(t)
+	mempool, err := NewMempool(engine.chainState, store, devnetGenesisChainID)
+	mustAtomic(t, err)
+	engine.SetMempool(mempool)
+	owner := mempool.PendingOutpointOwner()
+	if _, ok := owner.AdmissionContext(); !ok {
+		t.Fatal("owner was not stable before the blocked apply")
+	}
+
 	release, result := startBlockedApply(t, engine, store, nil)
-	engine.chainState.admissionMu.Lock()
+	// The transition began before persistence ran, so the owner is already
+	// transition-active while the apply is parked inside the injected failure.
+	if _, ok := owner.AdmissionContext(); ok {
+		t.Error("AdmissionContext was available during an active transition")
+	}
 	close(release)
-	for deadline := time.Now().Add(time.Second); !engine.persistenceFaulted() && time.Now().Before(deadline); {
-		time.Sleep(time.Millisecond)
-	}
-	if !engine.persistenceFaulted() {
-		t.Error("persistence fault was not published before replacement")
-	}
-	engine.chainState.admissionMu.Unlock()
 	requirePersistenceFault(t, awaitPersistenceResult(t, result, "failed apply"), atomicWriteCreateIfAbsent)
+
+	if !engine.persistenceFaulted() {
+		t.Fatal("persistence fault was not latched")
+	}
+	if ctx, ok := owner.AdmissionContext(); ok {
+		t.Errorf("AdmissionContext became available after the latched fault: %+v", ctx)
+	}
+
+	// The guard is still held, so a standard-admission attempt blocks. It is
+	// left parked on purpose: nothing in-process may release that guard.
+	admitted := make(chan error, 1)
+	go func() { admitted <- mempool.AddTx(DevnetGenesisBlockBytes()) }()
+	select {
+	case err := <-admitted:
+		t.Errorf("standard admission passed the latched guard: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// mutationMu, unlike admissionMu, was released when the failed transition
+	// returned, so a later mutator reports the latched fault rather than hanging.
+	queued := make(chan error, 1)
+	go func() { _, err := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil); queued <- err }()
+	if err := awaitPersistenceResult(t, queued, "queued mutator"); !errors.Is(err, errStoragePersistenceFault) {
+		t.Fatalf("queued mutator=%v, want the latched persistence fault", err)
+	}
 }
 
 func TestSyncEngineQueuesMutatorsUntilPostCommitFaultIsPublished(t *testing.T) {

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -86,18 +86,39 @@ func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []ui
 	}
 }
 
+// pvShadowActive reports whether a shadow run would happen right now.
+func (s *SyncEngine) pvShadowActive() bool {
+	return (s.pvMode == pvModeShadow || s.pvMode == pvModeOn) && s.isInIBDUnchecked()
+}
+
+// pvShadowPreState clones state ONLY when a shadow run will actually consume it.
+// The preferred-branch preparation rolls one private state forward in place, so
+// it has no per-row pre-image to hand the shadow unless one is taken here. A nil
+// result keeps that clone off the default path and lets the caller decide once
+// rather than re-evaluate a time-dependent predicate after the connect.
+func (s *SyncEngine) pvShadowPreState(state *ChainState) *ChainState {
+	if !s.pvShadowActive() {
+		return nil
+	}
+	return cloneChainState(state)
+}
+
+// runPVShadow runs the shadow for a caller that already decided it is active.
+func (s *SyncEngine) runPVShadow(blockBytes []byte, prevTimestamps []uint64, ctx canonicalBlockApplyContext, seqErr error, seqSummary *ChainStateConnectSummary) {
+	if seqErr != nil {
+		s.runPVShadowOnError(blockBytes, prevTimestamps, ctx, seqErr)
+		return
+	}
+	s.runPVShadowOnSuccess(blockBytes, prevTimestamps, ctx, seqSummary)
+}
+
 // runPVShadowIfActive runs the appropriate PV shadow validation.
 func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uint64, ctx canonicalBlockApplyContext, seqErr error, seqSummary *ChainStateConnectSummary) {
-	pvActive := (s.pvMode == pvModeShadow || s.pvMode == pvModeOn) && s.isInIBDUnchecked()
-	if !pvActive {
+	if !s.pvShadowActive() {
 		s.pvTelemetry.RecordBlockSkipped()
 		return
 	}
-	if seqErr != nil {
-		s.runPVShadowOnError(blockBytes, prevTimestamps, ctx, seqErr)
-	} else {
-		s.runPVShadowOnSuccess(blockBytes, prevTimestamps, ctx, seqSummary)
-	}
+	s.runPVShadow(blockBytes, prevTimestamps, ctx, seqErr, seqSummary)
 }
 
 // finalizeAppliedBlock persists the already-published canonical block.
@@ -111,30 +132,38 @@ func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uin
 func (s *SyncEngine) finalizeAppliedBlock(summary *ChainStateConnectSummary, blockHash [32]byte, pb *consensus.ParsedBlock, blockBytes []byte, prevState *ChainState, rollbackState syncRollbackState) error {
 	commitStart := time.Now()
 	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
-		if isAtomicWritePostCommit(err) {
-			var atomicErr *atomicWriteError
-			errors.As(err, &atomicErr)
-			if s.blockStore != nil && atomicErr.destination == s.blockStore.indexPath {
-				return s.handlePersistenceError(err, true, false)
-			}
-			if atomicErr.destination == s.cfg.ChainStatePath {
-				return s.handlePersistenceError(err, false, true)
-			}
-			fault := s.handlePersistenceError(err, false, false)
-			// The standard cleanup already ran, so reverting only the tip would
-			// freeze a cleaned Mempool against a pre-apply canonical tip. The
-			// frozen state is unobservable behind the retained guard, but it is
-			// the state a restart reconciles against, so restore both halves.
-			if restoreErr := errors.Join(
-				publishPreparedChainState(s.chainState, rollbackState.chainState),
-				restoreMempoolSnapshot(s.mempool, rollbackState.mempool),
-			); restoreErr != nil {
-				return errors.Join(fault, restoreErr)
-			}
-			return fault
-		}
-		return s.rollbackApplyBlock(err, rollbackState)
+		return s.classifyPersistenceFailure(err, rollbackState)
 	}
 	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))
 	return nil
+}
+
+// classifyPersistenceFailure is the SINGLE classifier for a persistence failure
+// on an already-published canonical block, shared by the direct-connect path and
+// by each preferred-branch row so neither can drift into a different error class
+// or a different rollback rule.
+func (s *SyncEngine) classifyPersistenceFailure(err error, rollbackState syncRollbackState) error {
+	if !isAtomicWritePostCommit(err) {
+		return s.rollbackApplyBlock(err, rollbackState)
+	}
+	var atomicErr *atomicWriteError
+	errors.As(err, &atomicErr)
+	if s.blockStore != nil && atomicErr.destination == s.blockStore.indexPath {
+		return s.handlePersistenceError(err, true, false)
+	}
+	if atomicErr.destination == s.cfg.ChainStatePath {
+		return s.handlePersistenceError(err, false, true)
+	}
+	fault := s.handlePersistenceError(err, false, false)
+	// The standard cleanup already ran, so reverting only the tip would
+	// freeze a cleaned Mempool against a pre-apply canonical tip. The
+	// frozen state is unobservable behind the retained guard, but it is
+	// the state a restart reconciles against, so restore both halves.
+	if restoreErr := errors.Join(
+		publishPreparedChainState(s.chainState, rollbackState.chainState),
+		restoreMempoolSnapshot(s.mempool, rollbackState.mempool),
+	); restoreErr != nil {
+		return errors.Join(fault, restoreErr)
+	}
+	return fault
 }

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -100,7 +100,14 @@ func (s *SyncEngine) runPVShadowIfActive(blockBytes []byte, prevTimestamps []uin
 	}
 }
 
-// finalizeAppliedBlock commits persistence, records metrics, and updates mempool.
+// finalizeAppliedBlock persists the already-published canonical block.
+//
+// The standard Mempool and owner cleanup has ALREADY run, before the live
+// canonical tip changed (commitPreparedBlockUnderGuard), and a cleanup failure
+// there propagates into exact rollback instead of being logged over a committed
+// tip. Runtime accepted-tip recording is likewise NOT done here: it happens
+// only after this persistence AND the owner stable-tip commit succeed, in
+// canonicalTransition.finish.
 func (s *SyncEngine) finalizeAppliedBlock(summary *ChainStateConnectSummary, blockHash [32]byte, pb *consensus.ParsedBlock, blockBytes []byte, prevState *ChainState, rollbackState syncRollbackState) error {
 	commitStart := time.Now()
 	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
@@ -114,17 +121,20 @@ func (s *SyncEngine) finalizeAppliedBlock(summary *ChainStateConnectSummary, blo
 				return s.handlePersistenceError(err, false, true)
 			}
 			fault := s.handlePersistenceError(err, false, false)
-			s.chainState.replaceFrom(rollbackState.chainState)
+			// The standard cleanup already ran, so reverting only the tip would
+			// freeze a cleaned Mempool against a pre-apply canonical tip. The
+			// frozen state is unobservable behind the retained guard, but it is
+			// the state a restart reconciles against, so restore both halves.
+			if restoreErr := errors.Join(
+				publishPreparedChainState(s.chainState, rollbackState.chainState),
+				restoreMempoolSnapshot(s.mempool, rollbackState.mempool),
+			); restoreErr != nil {
+				return errors.Join(fault, restoreErr)
+			}
 			return fault
 		}
 		return s.rollbackApplyBlock(err, rollbackState)
 	}
 	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))
-	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
-	if s.mempool != nil {
-		if err := s.mempool.applyConnectedBlockParsed(pb); err != nil {
-			_, _ = fmt.Fprintf(s.stderr, "mempool: apply-connected-block: %v\n", err)
-		}
-	}
 	return nil
 }

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -220,15 +221,37 @@ func (s *SyncEngine) shouldSwitchToBranch(
 	}
 }
 
-// preparedBranchBlock is one fully validated preferred-branch row: its prepared
-// post-state, that connect's summary, and the canonical context it was validated
-// against. Retaining all three is what keeps the in-guard commit free of any
-// repeated parse, ConnectBlock, signature verification or fallible preparation.
+// preparedBranchBlock is one fully validated preferred-branch row. It retains NO
+// ChainState: only the parsed block and bytes the existing path already carried,
+// that connect's summary, the exact prior-tip scalars the commit rechecks, the
+// precomputed BlockUndo, and the compact block-local UTXO delta — bounded by the
+// branch's own inputs and outputs, never by branch depth times the UTXO set. The
+// whole branch is validated against ONE rolling private clone, the mechanism
+// Bitcoin Core's DisconnectTip/ConnectTip and btcd's reorganizeChain use when
+// they roll a single coins view with per-block undo. Everything the in-guard
+// commit needs is here, so it repeats no parse, no ConnectBlock, no signature
+// verification and no fallible preparation.
 type preparedBranchBlock struct {
 	item     reorgBranchBlock
-	prepared *ChainState
 	summary  *ChainStateConnectSummary
-	ctx      canonicalBlockApplyContext
+	priorTip canonicalTipScalars
+	undo     *BlockUndo
+	delta    chainStateDelta
+}
+
+// chainStateDelta is the compact block-local change one prepared row publishes:
+// the pre-existing outpoints the block spends, the outpoints it leaves created,
+// and the post-block scalars. One created AND spent inside the same block
+// appears in neither list — the live chainstate never observes it.
+type chainStateDelta struct {
+	spent   []consensus.Outpoint
+	created []createdUtxo
+	post    canonicalTipScalars
+}
+
+type createdUtxo struct {
+	outpoint consensus.Outpoint
+	entry    consensus.UtxoEntry
 }
 
 // applyPreferredBranch applies the candidate branch selected by fork choice —
@@ -255,7 +278,6 @@ func (s *SyncEngine) applyPreferredBranch(
 	if err != nil {
 		return nil, err
 	}
-	tr.suppressInnerCleanup = true
 	summary, canonicalBlocks, err := s.applyPreferredBranchUnderGuard(tr, rows, commonAncestorHeight, preparedDisconnectedBlocks)
 	if endErr := tr.end(err); endErr != nil {
 		return nil, endErr
@@ -270,7 +292,8 @@ func (s *SyncEngine) applyPreferredBranch(
 }
 
 // applyPreferredBranchUnderGuard is commit-only: pre-clean, disconnect to the
-// common ancestor, then publish and persist each already-prepared row.
+// common ancestor, then publish and persist each already-prepared row. Nothing
+// suppresses the per-block inner cleanup — this path never calls it.
 func (s *SyncEngine) applyPreferredBranchUnderGuard(
 	tr *canonicalTransition,
 	rows []preparedBranchBlock,
@@ -287,7 +310,7 @@ func (s *SyncEngine) applyPreferredBranchUnderGuard(
 	canonicalBlocks := make([]CanonicalAppliedBlock, 0, len(rows))
 	for i := range rows {
 		row := &rows[i]
-		if err := s.commitPreparedBlockUnderGuard(tr, row.prepared, row.summary, row.ctx, row.item.parsed, row.item.blockBytes); err != nil {
+		if err := s.commitPreparedRowUnderGuard(tr, row); err != nil {
 			return nil, nil, err
 		}
 		tr.appliedHeight, tr.appliedTimestamp, tr.applied = row.summary.BlockHeight, row.item.header.Timestamp, true
@@ -311,18 +334,22 @@ func (s *SyncEngine) precleanPreferredBranch(tr *canonicalTransition, rows []pre
 	return tr.mempool.applyConnectedBlocksParsed(blocks)
 }
 
-// preparePreferredBranch validates the whole winning branch against private
-// clones and retains every prepared post-state, summary and canonical context.
-// It touches no live state, and nothing it does repeats once the guard is held.
+// preparePreferredBranch validates the whole winning branch against ONE rolling
+// private clone and retains only the compact per-row commit record. It touches
+// no live state, nothing it does repeats once the guard is held, and it rejects
+// no branch for its depth — retained memory does not grow with depth, so there
+// is nothing to cap. A failed row aborts the whole preparation and discards the
+// rolling clone with it, which is why connecting into that clone IN PLACE is
+// safe even though a rejected connect may leave it partially advanced.
 func (s *SyncEngine) preparePreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
 ) ([]preparedBranchBlock, []verifiedStoredBlock, uint64, error) {
-	previewState := cloneChainState(s.chainState)
-	if previewState == nil {
+	rolling := cloneChainState(s.chainState)
+	if rolling == nil {
 		return nil, nil, 0, errors.New("nil preview chainstate")
 	}
-	preparedDisconnectedBlocks, reorgDepth, err := s.previewDisconnectCanonicalToAncestor(previewState, commonAncestorHeight)
+	preparedDisconnectedBlocks, reorgDepth, err := s.previewDisconnectCanonicalToAncestor(rolling, commonAncestorHeight)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -335,30 +362,28 @@ func (s *SyncEngine) preparePreferredBranch(
 		return nil, nil, 0, err
 	}
 	rows := make([]preparedBranchBlock, 0, len(branch))
-	// Row i's prev state is row i-1's prepared post-state, matching exactly
-	// what the guard publishes one row at a time.
-	prev := previewState
 	for i, item := range branch {
-		row, rowErr := s.prepareBranchRow(prev, item, commonAncestorHeight+1+uint64(i), slidingTs)
+		// The rolling state carries row i-1's post-state into row i, matching
+		// exactly what the guard publishes one row at a time.
+		row, rowErr := s.prepareBranchRow(rolling, item, commonAncestorHeight+1+uint64(i), slidingTs)
 		if rowErr != nil {
 			return nil, nil, 0, rowErr
 		}
 		rows = append(rows, row)
-		prev = row.prepared
 		slidingTs = advancePrevTimestamps(slidingTs, item.header.Timestamp)
 	}
 	return rows, preparedDisconnectedBlocks, reorgDepth, nil
 }
 
-// prepareBranchRow fully validates one branch row against a private clone of its
-// predecessor's prepared post-state and retains everything the commit needs.
+// prepareBranchRow fully validates one branch row by connecting it into the
+// caller's single rolling private state, then retains only what the commit needs.
 //
 // Per-row target derivation: a branch can cross a retarget boundary. Unlike the
 // MTP window it needs no sliding workaround — it reads headers by hash, never
 // the canonical index, and every ancestor it needs is already stored. Target
 // context resolves first, so its failure short-circuits before the connect.
 func (s *SyncEngine) prepareBranchRow(
-	prevState *ChainState,
+	rolling *ChainState,
 	item reorgBranchBlock,
 	height uint64,
 	prevTimestamps []uint64,
@@ -367,17 +392,18 @@ func (s *SyncEngine) prepareBranchRow(
 	if err != nil {
 		return preparedBranchBlock{}, err
 	}
+	priorTip := chainTipScalarsOf(rolling)
+	// The undo needs the pre-block image of every spent outpoint, and the
+	// sequential connect below overwrites the rolling map in place, so the
+	// touched entries — and ONLY those — are read out first.
+	preImages := capturePreImages(rolling, item.parsed)
 	ctx := canonicalBlockApplyContext{
 		blockHeight:    height,
 		blockHash:      item.hash,
 		expectedTarget: targetCtx.expected,
-		prevState:      prevState,
+		prevState:      s.pvShadowPreState(rolling),
 	}
-	prepared := cloneChainState(prevState)
-	if prepared == nil {
-		return preparedBranchBlock{}, errors.New("nil prepared branch chainstate")
-	}
-	summary, err := prepared.ConnectBlockWithSuiteContext(
+	summary, err := rolling.ConnectBlockWithSuiteContext(
 		item.blockBytes,
 		ctx.expectedTarget,
 		prevTimestamps,
@@ -385,11 +411,30 @@ func (s *SyncEngine) prepareBranchRow(
 		s.cfg.RotationProvider,
 		s.cfg.SuiteRegistry,
 	)
-	s.runPVShadowIfActive(item.blockBytes, prevTimestamps, ctx, err, summary)
+	if ctx.prevState != nil {
+		s.runPVShadow(item.blockBytes, prevTimestamps, ctx, err, summary)
+	} else {
+		s.pvTelemetry.RecordBlockSkipped()
+	}
 	if err != nil {
 		// No apply-outcome metric: a branch row rejected during preparation was
 		// never a canonical apply attempt, matching the pre-transition behavior
 		// where the preview rejected before any per-row apply was counted.
+		return preparedBranchBlock{}, err
+	}
+	return prepareCommitRow(item, summary, priorTip, preImages, rolling)
+}
+
+// prepareCommitRow turns one already-connected row into its compact commit
+// record — precomputed undo, block-local delta, DA-set summary — reading only
+// the captured pre-entries and the rolling post-state.
+func prepareCommitRow(item reorgBranchBlock, summary *ChainStateConnectSummary, priorTip canonicalTipScalars, preImages map[consensus.Outpoint]consensus.UtxoEntry, post *ChainState) (preparedBranchBlock, error) {
+	undo, err := buildPreparedBlockUndo(preImages, item.parsed, summary.BlockHeight, priorTip.alreadyGenerated)
+	if err != nil {
+		return preparedBranchBlock{}, err
+	}
+	delta, err := deriveChainStateDelta(preImages, post, undo, item.parsed)
+	if err != nil {
 		return preparedBranchBlock{}, err
 	}
 	daIDs, err := CompleteDASetIDsFromParsedBlock(item.parsed)
@@ -397,7 +442,198 @@ func (s *SyncEngine) prepareBranchRow(
 		return preparedBranchBlock{}, err
 	}
 	summary.CanonicalAppliedBlocks = []CanonicalAppliedBlock{{Hash: item.hash, CompleteDAIDs: daIDs}}
-	return preparedBranchBlock{item: item, prepared: prepared, summary: summary, ctx: ctx}, nil
+	return preparedBranchBlock{item: item, summary: summary, priorTip: priorTip, undo: undo, delta: delta}, nil
+}
+
+// capturePreImages reads the pre-block UTXO entry of every outpoint the block's
+// non-coinbase transactions spend, and nothing else — that is what lets undo and
+// delta be derived without copying the whole UTXO map per row. An input absent
+// here was created earlier in the SAME block, which the undo builder resolves
+// from its own block-local map.
+func capturePreImages(state *ChainState, pb *consensus.ParsedBlock) map[consensus.Outpoint]consensus.UtxoEntry {
+	preImages := make(map[consensus.Outpoint]consensus.UtxoEntry)
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	for i := 1; i < len(pb.Txs); i++ {
+		tx := pb.Txs[i]
+		if tx == nil {
+			continue
+		}
+		for _, in := range tx.Inputs {
+			op := outpointFromInput(in)
+			if entry, ok := state.Utxos[op]; ok {
+				preImages[op] = copyUtxoEntry(entry)
+			}
+		}
+	}
+	return preImages
+}
+
+// buildPreparedBlockUndo builds exactly the BlockUndo buildBlockUndo builds, from
+// the captured touched entries instead of a full UTXO-set copy. buildTxUndos adds
+// each transaction's created outputs to its work map as it goes, so an input
+// spending a same-block output resolves identically under either work map.
+func buildPreparedBlockUndo(preImages map[consensus.Outpoint]consensus.UtxoEntry, pb *consensus.ParsedBlock, blockHeight, previousAlreadyGenerated uint64) (*BlockUndo, error) {
+	if pb == nil {
+		return nil, errors.New("nil parsed block")
+	}
+	if len(pb.Txs) != len(pb.Txids) {
+		return nil, errors.New("parsed block txid length mismatch")
+	}
+	work := make(map[consensus.Outpoint]consensus.UtxoEntry, len(preImages))
+	for op, entry := range preImages {
+		work[op] = copyUtxoEntry(entry)
+	}
+	txUndos, err := buildTxUndos(work, pb, blockHeight)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockUndo{
+		BlockHeight:              blockHeight,
+		PreviousAlreadyGenerated: previousAlreadyGenerated,
+		Txs:                      txUndos,
+	}, nil
+}
+
+// deriveChainStateDelta reports the net change the live chainstate must observe
+// for one already-validated row: every spend whose outpoint existed BEFORE the
+// block, and every output the connected post-state still holds. Both halves come
+// from the block's own ordered inputs and outputs plus the touched entries —
+// never a scan or a copy of the UTXO map.
+func deriveChainStateDelta(preImages map[consensus.Outpoint]consensus.UtxoEntry, post *ChainState, undo *BlockUndo, pb *consensus.ParsedBlock) (chainStateDelta, error) {
+	if undo == nil || pb == nil || post == nil || len(pb.Txs) != len(pb.Txids) {
+		return chainStateDelta{}, errors.New("nil or malformed prepared row delta source")
+	}
+	created, err := deriveCreatedUtxos(post, pb)
+	if err != nil {
+		return chainStateDelta{}, err
+	}
+	return chainStateDelta{
+		spent:   derivePreExistingSpends(preImages, undo),
+		created: created,
+		post:    chainTipScalarsOf(post),
+	}, nil
+}
+
+// derivePreExistingSpends lists, in undo order, the outpoints this block spends
+// that ALSO existed before it; one created and spent inside it is absent.
+func derivePreExistingSpends(preImages map[consensus.Outpoint]consensus.UtxoEntry, undo *BlockUndo) []consensus.Outpoint {
+	var spent []consensus.Outpoint
+	for _, txUndo := range undo.Txs {
+		for _, item := range txUndo.Spent {
+			if _, existed := preImages[item.Outpoint]; existed {
+				spent = append(spent, item.Outpoint)
+			}
+		}
+	}
+	return spent
+}
+
+// deriveCreatedUtxos lists every output the connected post-state still holds,
+// with its exact entry read back from that state, so no output-encoding rule is
+// restated here: one the connect did not index, or one a later transaction in
+// the same block already spent, is simply absent.
+func deriveCreatedUtxos(post *ChainState, pb *consensus.ParsedBlock) ([]createdUtxo, error) {
+	var created []createdUtxo
+	post.mu.RLock()
+	defer post.mu.RUnlock()
+	for i, tx := range pb.Txs {
+		if tx == nil {
+			return nil, fmt.Errorf("nil tx at index %d", i)
+		}
+		for outputIndex := range tx.Outputs {
+			op := consensus.Outpoint{Txid: pb.Txids[i], Vout: uint32(outputIndex)}
+			if entry, ok := post.Utxos[op]; ok {
+				created = append(created, createdUtxo{outpoint: op, entry: copyUtxoEntry(entry)})
+			}
+		}
+	}
+	return created, nil
+}
+
+// commitPreparedRowUnderGuard publishes and persists ONE already-validated
+// preferred-branch row: live tip recheck, the compact delta onto the single live
+// ChainState, then that row's precomputed undo through the existing persistence
+// path. ChainState and BlockStore therefore correspond at every successfully
+// persisted row, rather than the store running ahead of a chainstate published
+// once at the end. Nothing here parses, connects, verifies or revalidates.
+func (s *SyncEngine) commitPreparedRowUnderGuard(tr *canonicalTransition, row *preparedBranchBlock) error {
+	if err := s.recheckLiveTipIdentity(tr, row.priorTip); err != nil {
+		return s.rollbackApplyBlock(err, tr.rollback)
+	}
+	if err := applyPreparedRowDelta(tr.chainState, row.delta); err != nil {
+		return s.rollbackApplyBlock(err, tr.rollback)
+	}
+	commitStart := time.Now()
+	if err := s.persistPreparedRow(row); err != nil {
+		return s.classifyPersistenceFailure(err, tr.rollback)
+	}
+	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))
+	return nil
+}
+
+// applyPreparedRowDelta publishes one compact row onto the live ChainState under
+// ChainState.mu only: the transition already owns the non-reentrant admissionMu,
+// so the ChainState wrappers that reacquire it must not be called here. Every
+// precondition is checked BEFORE the first write, so a live map that is not what
+// the row was prepared against fails into the exact rollback, not half-applied.
+func applyPreparedRowDelta(dst *ChainState, delta chainStateDelta) error {
+	if dst == nil {
+		return errors.New("nil chainstate delta destination")
+	}
+	dst.mu.Lock()
+	defer dst.mu.Unlock()
+	if dst.Utxos == nil {
+		dst.Utxos = make(map[consensus.Outpoint]consensus.UtxoEntry)
+	}
+	if err := checkPreparedRowDeltaLocked(dst, delta); err != nil {
+		return err
+	}
+	for _, op := range delta.spent {
+		delete(dst.Utxos, op)
+	}
+	for _, created := range delta.created {
+		dst.Utxos[created.outpoint] = created.entry
+	}
+	dst.HasTip, dst.Height = delta.post.hasTip, delta.post.height
+	dst.TipHash, dst.AlreadyGenerated = delta.post.tipHash, delta.post.alreadyGenerated
+	return nil
+}
+
+// checkPreparedRowDeltaLocked proves the live map is exactly the pre-image the
+// row was prepared against, for every outpoint it touches. Spent and created are
+// disjoint by construction, so no ordering is implied. The caller holds dst.mu.
+func checkPreparedRowDeltaLocked(dst *ChainState, delta chainStateDelta) error {
+	for _, op := range delta.spent {
+		if _, live := dst.Utxos[op]; !live {
+			return fmt.Errorf("prepared row spends %x:%d which the live chainstate does not hold", op.Txid, op.Vout)
+		}
+	}
+	for _, created := range delta.created {
+		if _, live := dst.Utxos[created.outpoint]; live {
+			return fmt.Errorf("prepared row creates %x:%d which the live chainstate already holds", created.outpoint.Txid, created.outpoint.Vout)
+		}
+	}
+	return nil
+}
+
+// persistPreparedRow commits one prepared row through the existing
+// BlockStore.CommitCanonicalBlock and ChainState.Save semantics, changing no
+// persistence format and no error class: the ONLY difference from
+// persistAppliedBlock is the precomputed undo.
+func (s *SyncEngine) persistPreparedRow(row *preparedBranchBlock) error {
+	if row.undo == nil {
+		return errors.New("nil prepared block undo")
+	}
+	if s.blockStore != nil {
+		if err := s.blockStore.CommitCanonicalBlock(row.summary.BlockHeight, row.item.hash, row.item.parsed.HeaderBytes, row.item.blockBytes, row.undo); err != nil {
+			return err
+		}
+	}
+	if s.cfg.ChainStatePath != "" && (s.blockStore == nil || shouldPersistChainStateSnapshot(s.chainState, row.summary)) {
+		return s.chainState.Save(s.cfg.ChainStatePath)
+	}
+	return nil
 }
 
 // advancePrevTimestamps prepends newTs to prev and keeps at most 11 entries,

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -220,42 +220,48 @@ func (s *SyncEngine) shouldSwitchToBranch(
 	}
 }
 
-// applyPreferredBranch applies the candidate branch selected by fork choice:
-// greater ChainWork, or equal ChainWork with a lexicographically lower tip hash.
+// preparedBranchBlock is one fully validated preferred-branch row: its prepared
+// post-state, that connect's summary, and the canonical context it was validated
+// against. Retaining all three is what keeps the in-guard commit free of any
+// repeated parse, ConnectBlock, signature verification or fallible preparation.
+type preparedBranchBlock struct {
+	item     reorgBranchBlock
+	prepared *ChainState
+	summary  *ChainStateConnectSummary
+	ctx      canonicalBlockApplyContext
+}
+
+// applyPreferredBranch applies the candidate branch selected by fork choice —
+// greater ChainWork, or equal ChainWork with a lexicographically lower tip hash
+// — inside EXACTLY ONE canonical transition: one generation for the whole
+// winning branch, one standard pre-clean for the final prepared branch, every
+// per-block inner cleanup suppressed, and the existing deterministic requeue
+// running only after the final stable owner tip is committed. Every row is fully
+// validated BEFORE the transition opens, so nothing under the guard re-runs
+// consensus or re-verifies a signature.
 func (s *SyncEngine) applyPreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
 ) (*ChainStateConnectSummary, error) {
-	rollbackState, err := s.captureRollbackState()
+	canonicalIndex, err := s.canonicalIndexPreflight()
 	if err != nil {
 		return nil, err
 	}
-	preparedDisconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight, rollbackState)
+	rows, preparedDisconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.disconnectCanonicalToAncestor(commonAncestorHeight, preparedDisconnectedBlocks); err != nil {
-		return nil, s.rollbackApplyBlock(err, rollbackState)
+	tr, err := s.beginCanonicalTransition(canonicalIndex)
+	if err != nil {
+		return nil, err
 	}
-
-	var summary *ChainStateConnectSummary
-	var pendingAccepted uint64
-	var canonicalBlocks []CanonicalAppliedBlock
-	for i, item := range branch {
-		var outcome blockApplyMetricOutcome
-		summary, outcome, err = s.applyBranchBlock(item, commonAncestorHeight+1+uint64(i))
-		if err != nil {
-			return nil, s.rollbackBranchBlockApply(err, rollbackState, outcome)
-		}
-		if outcome == blockApplyMetricAccepted {
-			pendingAccepted++
-		}
-		if summary != nil && len(summary.CanonicalAppliedBlocks) > 0 {
-			canonicalBlocks = append(canonicalBlocks, summary.CanonicalAppliedBlocks[0])
-		}
+	tr.suppressInnerCleanup = true
+	summary, canonicalBlocks, err := s.applyPreferredBranchUnderGuard(tr, rows, commonAncestorHeight, preparedDisconnectedBlocks)
+	if endErr := tr.end(err); endErr != nil {
+		return nil, endErr
 	}
 	s.requeueVerifiedDisconnectedTransactions(preparedDisconnectedBlocks)
-	s.noteBlockApplyAcceptedN(pendingAccepted)
+	s.noteBlockApplyAcceptedN(uint64(len(rows)))
 	s.noteReorg(reorgDepth)
 	if summary != nil {
 		summary.CanonicalAppliedBlocks = canonicalBlocks
@@ -263,49 +269,62 @@ func (s *SyncEngine) applyPreferredBranch(
 	return summary, nil
 }
 
-// applyBranchBlock commits one row of the preferred branch at its caller-owned
-// height. Both context windows are re-derived per iteration: the canonical
-// index moved when the previous row committed, and a branch can cross a
-// retarget boundary (the target half of the B.9 / issue #1166 argument). Target
-// context first, so a target-context failure short-circuits before the MTP
-// window is read.
-func (s *SyncEngine) applyBranchBlock(item reorgBranchBlock, nextHeight uint64) (*ChainStateConnectSummary, blockApplyMetricOutcome, error) {
-	targetCtx, err := s.targetContextForCandidate(item.header.PrevBlockHash, nextHeight)
-	if err != nil {
-		return nil, blockApplyMetricNone, err
+// applyPreferredBranchUnderGuard is commit-only: pre-clean, disconnect to the
+// common ancestor, then publish and persist each already-prepared row.
+func (s *SyncEngine) applyPreferredBranchUnderGuard(
+	tr *canonicalTransition,
+	rows []preparedBranchBlock,
+	commonAncestorHeight uint64,
+	preparedDisconnectedBlocks []verifiedStoredBlock,
+) (*ChainStateConnectSummary, []CanonicalAppliedBlock, error) {
+	if err := s.precleanPreferredBranch(tr, rows); err != nil {
+		return nil, nil, s.rollbackApplyBlock(err, tr.rollback)
 	}
-	freshTs, err := prevTimestampsFromStore(s.blockStore, nextHeight)
-	if err != nil {
-		return nil, blockApplyMetricNone, err
+	if err := s.disconnectCanonicalToAncestor(commonAncestorHeight, preparedDisconnectedBlocks, tr.rollback); err != nil {
+		return nil, nil, s.rollbackApplyBlock(err, tr.rollback)
 	}
-	return s.applyCanonicalParsedBlockTracked(item.parsed, item.blockBytes, freshTs, targetCtx)
+	var summary *ChainStateConnectSummary
+	canonicalBlocks := make([]CanonicalAppliedBlock, 0, len(rows))
+	for i := range rows {
+		row := &rows[i]
+		if err := s.commitPreparedBlockUnderGuard(tr, row.prepared, row.summary, row.ctx, row.item.parsed, row.item.blockBytes); err != nil {
+			return nil, nil, err
+		}
+		tr.appliedHeight, tr.appliedTimestamp, tr.applied = row.summary.BlockHeight, row.item.header.Timestamp, true
+		summary = row.summary
+		canonicalBlocks = append(canonicalBlocks, row.summary.CanonicalAppliedBlocks...)
+	}
+	return summary, canonicalBlocks, nil
 }
 
-func (s *SyncEngine) rollbackBranchBlockApply(
-	err error,
-	rollbackState syncRollbackState,
-	outcome blockApplyMetricOutcome,
-) error {
-	rollbackErr := s.rollbackApplyBlock(err, rollbackState)
-	if outcome == blockApplyMetricRejected {
-		s.noteBlockApplyRejected()
+// precleanPreferredBranch removes, in one standard-domain commit, every entry
+// the final prepared branch includes or conflicts with, before any live
+// ChainState or BlockStore canonical tip change.
+func (s *SyncEngine) precleanPreferredBranch(tr *canonicalTransition, rows []preparedBranchBlock) error {
+	if tr.mempool == nil {
+		return nil
 	}
-	return rollbackErr
+	blocks := make([]*consensus.ParsedBlock, 0, len(rows))
+	for i := range rows {
+		blocks = append(blocks, rows[i].item.parsed)
+	}
+	return tr.mempool.applyConnectedBlocksParsed(blocks)
 }
 
+// preparePreferredBranch validates the whole winning branch against private
+// clones and retains every prepared post-state, summary and canonical context.
+// It touches no live state, and nothing it does repeats once the guard is held.
 func (s *SyncEngine) preparePreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
-	rollbackState syncRollbackState,
-) ([]verifiedStoredBlock, uint64, error) {
-	previewState := cloneChainState(rollbackState.chainState)
+) ([]preparedBranchBlock, []verifiedStoredBlock, uint64, error) {
+	previewState := cloneChainState(s.chainState)
 	if previewState == nil {
-		return nil, 0, errors.New("nil preview chainstate")
+		return nil, nil, 0, errors.New("nil preview chainstate")
 	}
-	var err error
 	preparedDisconnectedBlocks, reorgDepth, err := s.previewDisconnectCanonicalToAncestor(previewState, commonAncestorHeight)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
 	// Build a sliding MTP window: start from pre-fork timestamps, advance
 	// after each block.  The blockstore index is NOT updated during preview,
@@ -313,31 +332,72 @@ func (s *SyncEngine) preparePreferredBranch(
 	// re-deriving from the store each iteration (B.9 fix).
 	slidingTs, err := prevTimestampsFromStore(s.blockStore, commonAncestorHeight+1)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
+	rows := make([]preparedBranchBlock, 0, len(branch))
+	// Row i's prev state is row i-1's prepared post-state, matching exactly
+	// what the guard publishes one row at a time.
+	prev := previewState
 	for i, item := range branch {
-		// Per-row derivation: a branch can cross a retarget boundary. Unlike
-		// the MTP window this needs no sliding workaround — it reads headers
-		// by hash and never consults the canonical index, and every ancestor
-		// it needs is already stored (collectBranchToCanonical fetched
-		// branch[0..len-2] from the store; the common ancestor is canonical).
-		targetCtx, targetErr := s.targetContextForCandidate(item.header.PrevBlockHash, commonAncestorHeight+1+uint64(i))
-		if targetErr != nil {
-			return nil, 0, targetErr
+		row, rowErr := s.prepareBranchRow(prev, item, commonAncestorHeight+1+uint64(i), slidingTs)
+		if rowErr != nil {
+			return nil, nil, 0, rowErr
 		}
-		if _, err := previewState.ConnectBlockWithSuiteContext(
-			item.blockBytes,
-			targetCtx.expected,
-			slidingTs,
-			s.cfg.ChainID,
-			s.cfg.RotationProvider,
-			s.cfg.SuiteRegistry,
-		); err != nil {
-			return nil, 0, err
-		}
+		rows = append(rows, row)
+		prev = row.prepared
 		slidingTs = advancePrevTimestamps(slidingTs, item.header.Timestamp)
 	}
-	return preparedDisconnectedBlocks, reorgDepth, nil
+	return rows, preparedDisconnectedBlocks, reorgDepth, nil
+}
+
+// prepareBranchRow fully validates one branch row against a private clone of its
+// predecessor's prepared post-state and retains everything the commit needs.
+//
+// Per-row target derivation: a branch can cross a retarget boundary. Unlike the
+// MTP window it needs no sliding workaround — it reads headers by hash, never
+// the canonical index, and every ancestor it needs is already stored. Target
+// context resolves first, so its failure short-circuits before the connect.
+func (s *SyncEngine) prepareBranchRow(
+	prevState *ChainState,
+	item reorgBranchBlock,
+	height uint64,
+	prevTimestamps []uint64,
+) (preparedBranchBlock, error) {
+	targetCtx, err := s.targetContextForCandidate(item.header.PrevBlockHash, height)
+	if err != nil {
+		return preparedBranchBlock{}, err
+	}
+	ctx := canonicalBlockApplyContext{
+		blockHeight:    height,
+		blockHash:      item.hash,
+		expectedTarget: targetCtx.expected,
+		prevState:      prevState,
+	}
+	prepared := cloneChainState(prevState)
+	if prepared == nil {
+		return preparedBranchBlock{}, errors.New("nil prepared branch chainstate")
+	}
+	summary, err := prepared.ConnectBlockWithSuiteContext(
+		item.blockBytes,
+		ctx.expectedTarget,
+		prevTimestamps,
+		s.cfg.ChainID,
+		s.cfg.RotationProvider,
+		s.cfg.SuiteRegistry,
+	)
+	s.runPVShadowIfActive(item.blockBytes, prevTimestamps, ctx, err, summary)
+	if err != nil {
+		// No apply-outcome metric: a branch row rejected during preparation was
+		// never a canonical apply attempt, matching the pre-transition behavior
+		// where the preview rejected before any per-row apply was counted.
+		return preparedBranchBlock{}, err
+	}
+	daIDs, err := CompleteDASetIDsFromParsedBlock(item.parsed)
+	if err != nil {
+		return preparedBranchBlock{}, err
+	}
+	summary.CanonicalAppliedBlocks = []CanonicalAppliedBlock{{Hash: item.hash, CompleteDAIDs: daIDs}}
+	return preparedBranchBlock{item: item, prepared: prepared, summary: summary, ctx: ctx}, nil
 }
 
 // advancePrevTimestamps prepends newTs to prev and keeps at most 11 entries,
@@ -524,6 +584,10 @@ func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte
 	s.requeueParsedDisconnectedTransactions(parsedBlocks)
 }
 
+// requeueParsedDisconnectedTransactions MUST NOT be called under the canonical
+// transition guard: it routes to Mempool.AddReorgTx, which takes
+// ChainState.admissionMu.RLock, and sync.RWMutex is not reentrant. Its only
+// caller runs it after the transition released that guard.
 func (s *SyncEngine) requeueParsedDisconnectedTransactions(disconnectedBlocks []*consensus.ParsedBlock) {
 	if s == nil || s.mempool == nil || len(disconnectedBlocks) == 0 {
 		return

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -3477,3 +3477,183 @@ func TestApplyBlockWithReorgPendingOutpointRestoresExactTokensOnFailure(t *testi
 		t.Fatalf("generation after the failed reorg=%d, want the advanced high-water %d", afterReorg.Generation, beforeReorg.Generation+1)
 	}
 }
+
+// storedSideBranch builds and stores a side branch of depth blocks on top of
+// prevHash, oldest-first, the shape collectBranchToCanonical hands preparation.
+func (f *pendingOutpointSyncFixture) storedSideBranch(t *testing.T, prevHash [32]byte, height, alreadyGenerated uint64, depth int) []reorgBranchBlock {
+	t.Helper()
+	branch := make([]reorgBranchBlock, 0, depth)
+	for i := 0; i < depth; i++ {
+		blockHeight := height + uint64(i)
+		subsidy := consensus.BlockSubsidy(blockHeight, alreadyGenerated)
+		coinbase := reorgTestCoinbaseForAddress(t, blockHeight, subsidy, f.destAddress)
+		blockBytes := buildSingleTxBlock(t, prevHash, f.target, 300+blockHeight, coinbase)
+		parsed, hash := mustParseReorgBlockForTest(t, blockBytes)
+		if err := f.store.StoreBlock(hash, parsed.HeaderBytes, blockBytes); err != nil {
+			t.Fatalf("StoreBlock(side height %d): %v", blockHeight, err)
+		}
+		branch = append(branch, reorgBranchBlock{hash: hash, blockBytes: blockBytes, parsed: parsed, header: parsed.Header})
+		prevHash, alreadyGenerated = hash, alreadyGenerated+subsidy
+	}
+	return branch
+}
+
+// applyForkBlock applies one canonical block on the fixture tip, so the side
+// branch below has a canonical block to disconnect.
+func (f *pendingOutpointSyncFixture) applyForkBlock(t *testing.T) *ChainStateConnectSummary {
+	t.Helper()
+	subsidy := consensus.BlockSubsidy(f.tipHeight+1, f.alreadyGenerated)
+	coinbase := reorgTestCoinbaseForAddress(t, f.tipHeight+1, subsidy, f.sourceAddress)
+	summary, err := f.engine.ApplyBlock(buildSingleTxBlock(t, f.tipHash, f.target, 202, coinbase), nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(fork block): %v", err)
+	}
+	return summary
+}
+
+// TestPreparePreferredBranchRetainsCompactRowsWithoutUtxoSnapshots pins the
+// preparation memory shape: a prepared row carries no ChainState, no UTXO map
+// and nothing else that scales with the UTXO set — only the block data the path
+// already carried, the summary, the prior-tip scalars, the precomputed undo and
+// a delta bounded by the block's own inputs and outputs. Retained full-state
+// memory is O(1) in branch depth, which is what lets an arbitrarily deep valid
+// branch prepare without a depth cap.
+func TestPreparePreferredBranchRetainsCompactRowsWithoutUtxoSnapshots(t *testing.T) {
+	chainStatePtr := reflect.TypeOf((*ChainState)(nil))
+	for _, structType := range []reflect.Type{reflect.TypeOf(preparedBranchBlock{}), reflect.TypeOf(chainStateDelta{})} {
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			if field.Type == chainStatePtr || field.Type.Kind() == reflect.Map {
+				t.Fatalf("%s.%s is %v: a prepared row must retain no chainstate and no map",
+					structType.Name(), field.Name, field.Type)
+			}
+		}
+	}
+
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight, f.alreadyGenerated
+	summaryA := f.applyForkBlock(t)
+	liveUtxos, liveUtxoHash := len(f.engine.chainState.Utxos), f.engine.chainState.UtxoSetHash()
+
+	branch := f.storedSideBranch(t, forkHash, forkHeight+1, forkGenerated, 2)
+	rows, disconnected, reorgDepth, err := f.engine.preparePreferredBranch(branch, forkHeight)
+	if err != nil {
+		t.Fatalf("preparePreferredBranch: %v", err)
+	}
+	if len(rows) != 2 || len(disconnected) != 1 || reorgDepth != 1 {
+		t.Fatalf("rows=%d disconnected=%d depth=%d, want 2/1/1", len(rows), len(disconnected), reorgDepth)
+	}
+
+	prior := canonicalTipScalars{hasTip: true, height: forkHeight, tipHash: forkHash, alreadyGenerated: forkGenerated}
+	for i := range rows {
+		row := &rows[i]
+		if row.priorTip != prior {
+			t.Fatalf("row %d prior tip=%+v, want %+v", i, row.priorTip, prior)
+		}
+		if row.delta.post.height != forkHeight+1+uint64(i) || row.delta.post.tipHash != branch[i].hash || !row.delta.post.hasTip {
+			t.Fatalf("row %d delta post=%+v, want its own block at height %d", i, row.delta.post, forkHeight+1+uint64(i))
+		}
+		if row.undo == nil || row.undo.BlockHeight != row.delta.post.height || row.undo.PreviousAlreadyGenerated != prior.alreadyGenerated {
+			t.Fatalf("row %d undo=%+v, want the precomputed undo for that row", i, row.undo)
+		}
+		// A coinbase-only branch block spends nothing and creates one indexed
+		// output: the retained delta tracks the block, not the UTXO set.
+		if len(row.delta.spent) != 0 || len(row.delta.created) != 1 || len(row.delta.created) >= liveUtxos {
+			t.Fatalf("row %d delta spent=%d created=%d against a %d-entry live set, want 0/1 and compact",
+				i, len(row.delta.spent), len(row.delta.created), liveUtxos)
+		}
+		prior = row.delta.post
+	}
+
+	// Preparation touches no live state.
+	if f.engine.chainState.TipHash != summaryA.BlockHash || f.engine.chainState.UtxoSetHash() != liveUtxoHash {
+		t.Fatalf("preparation mutated the live chainstate: tip=%x", f.engine.chainState.TipHash)
+	}
+	if storeHeight, storeHash, ok, err := f.store.Tip(); err != nil || !ok || storeHash != summaryA.BlockHash || storeHeight != summaryA.BlockHeight {
+		t.Fatalf("preparation moved the blockstore tip to (%d,%x,ok=%v,err=%v)", storeHeight, storeHash, ok, err)
+	}
+}
+
+// TestApplyBlockWithReorgPendingOutpointCompactRowsPersistAndUndo pins the
+// commit half of the compact-row reorg: each already-validated row is applied to
+// the ONE live ChainState and persisted with its own precomputed undo before the
+// next row starts, so chainstate and blockstore correspond at every persisted
+// row; a failure on the second row restores the live UTXO SET exactly, not just
+// the tip; and the per-row undo is real — disconnecting the branch afterwards
+// returns the chainstate to the fork point byte for byte.
+func TestApplyBlockWithReorgPendingOutpointCompactRowsPersistAndUndo(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight, f.alreadyGenerated
+	forkUtxoHash := f.engine.chainState.UtxoSetHash()
+	summaryA := f.applyForkBlock(t)
+	beforeReorgUtxoHash := f.engine.chainState.UtxoSetHash()
+	branch := f.storedSideBranch(t, forkHash, forkHeight+1, forkGenerated, 2)
+	candidate := branch[len(branch)-1]
+
+	// Observe the live chainstate at every canonical-index write and fail the
+	// third — the second row's commit, after the first row was applied and
+	// persisted. Writes 1..3 are the disconnect truncation and the two rows.
+	type indexObservation struct {
+		height uint64
+		hash   [32]byte
+	}
+	prevWrite := writeFileAtomicFn
+	t.Cleanup(func() { writeFileAtomicFn = prevWrite })
+	observed, failThirdWrite, injected := []indexObservation{}, true, false
+	writeFileAtomicFn = func(path string, data []byte, mode os.FileMode) error {
+		if path == f.store.indexPath {
+			view := f.engine.chainState.view()
+			observed = append(observed, indexObservation{height: view.height, hash: view.tipHash})
+			if failThirdWrite && len(observed) == 3 {
+				injected = true
+				return os.ErrPermission
+			}
+		}
+		return prevWrite(path, data, mode)
+	}
+
+	if _, err := f.engine.ApplyBlockWithReorg(candidate.blockBytes, nil); err == nil || !injected {
+		t.Fatalf("expected the injected second-row persistence failure (err=%v injected=%v)", err, injected)
+	}
+	if f.engine.chainState.TipHash != summaryA.BlockHash || f.engine.chainState.Height != summaryA.BlockHeight {
+		t.Fatalf("chainstate tip=(%d,%x) after the failed reorg, want A (%d,%x)",
+			f.engine.chainState.Height, f.engine.chainState.TipHash, summaryA.BlockHeight, summaryA.BlockHash)
+	}
+	if got := f.engine.chainState.UtxoSetHash(); got != beforeReorgUtxoHash {
+		t.Fatalf("utxo set hash=%x after the failed reorg, want the exact pre-reorg set %x", got, beforeReorgUtxoHash)
+	}
+
+	// The same branch, with persistence healthy, must now commit.
+	failThirdWrite, observed = false, nil
+	summaryB, err := f.engine.ApplyBlockWithReorg(candidate.blockBytes, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(retry): %v", err)
+	}
+	if summaryB.BlockHash != candidate.hash || summaryB.BlockHeight != forkHeight+2 || len(observed) < 2 {
+		t.Fatalf("reorg summary=(%d,%x) index_writes=%d, want the branch tip (%d,%x) with one write per row",
+			summaryB.BlockHeight, summaryB.BlockHash, len(observed), forkHeight+2, candidate.hash)
+	}
+	// At each row's index write the live chainstate is ALREADY that row's block,
+	// never one behind: the store cannot run ahead of the state.
+	for i, row := range observed[len(observed)-2:] {
+		want := indexObservation{height: forkHeight + 1 + uint64(i), hash: branch[i].hash}
+		if row != want {
+			t.Fatalf("chainstate at row %d's index write=(%d,%x), want (%d,%x)", i, row.height, row.hash, want.height, want.hash)
+		}
+	}
+
+	// The per-row undo persisted above is the real one.
+	for i := range branch {
+		if _, err := f.engine.DisconnectTip(); err != nil {
+			t.Fatalf("DisconnectTip(%d): %v", i, err)
+		}
+	}
+	view := f.engine.chainState.view()
+	if view.height != forkHeight || view.tipHash != forkHash || view.alreadyGenerated != forkGenerated {
+		t.Fatalf("chainstate after disconnecting the branch=(%d,%x,generated=%d), want the fork point (%d,%x,%d)",
+			view.height, view.tipHash, view.alreadyGenerated, forkHeight, forkHash, forkGenerated)
+	}
+	if got := f.engine.chainState.UtxoSetHash(); got != forkUtxoHash {
+		t.Fatalf("utxo set hash after disconnecting the branch=%x, want the fork-point set %x", got, forkUtxoHash)
+	}
+}

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -3342,3 +3342,138 @@ func TestLoadVerifiedStoredBlockReadFailuresAreLocalCorruption(t *testing.T) {
 		assertBranchStoreCorruption(t, err)
 	})
 }
+
+// TestApplyBlockWithReorgPendingOutpointUsesOneGenerationForTheWholeBranch
+// proves the preferred-branch row: the whole winning branch runs inside EXACTLY
+// one canonical transition, so exactly one generation is consumed no matter how
+// many blocks are disconnected and connected; the single pre-clean removes the
+// record and its exact claim for a transaction the final prepared branch
+// includes; and the owner's stable tip is the branch tip.
+func TestApplyBlockWithReorgPendingOutpointUsesOneGenerationForTheWholeBranch(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight, f.alreadyGenerated
+	spend := f.spend(t, 700, 1)
+
+	subsidyA101 := consensus.BlockSubsidy(forkHeight+1, forkGenerated)
+	blockA101 := buildSingleTxBlock(t, forkHash, f.target, 202, reorgTestCoinbaseForAddress(t, forkHeight+1, subsidyA101, f.sourceAddress))
+	summaryA101, err := f.engine.ApplyBlock(blockA101, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A101): %v", err)
+	}
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	beforeReorg := mustAdmissionContext(t, f.owner, "before the reorg")
+	if beforeReorg.StableTip.Hash != summaryA101.BlockHash {
+		t.Fatalf("stable tip before reorg=%+v, want A101 %x", beforeReorg.StableTip, summaryA101.BlockHash)
+	}
+
+	// B101 includes the spend and B102 extends it, so the B branch outweighs A
+	// and the reorg disconnects one block while connecting two.
+	blockB101 := f.blockIncluding(t, forkHash, forkHeight+1, forkGenerated, 203, spend)
+	b101Parsed, b101Hash := mustParseReorgBlockForTest(t, blockB101)
+	if err := f.store.StoreBlock(b101Hash, b101Parsed.HeaderBytes, blockB101); err != nil {
+		t.Fatalf("StoreBlock(B101): %v", err)
+	}
+	subsidyB101 := consensus.BlockSubsidy(forkHeight+1, forkGenerated)
+	subsidyB102 := consensus.BlockSubsidy(forkHeight+2, forkGenerated+subsidyB101)
+	blockB102 := buildSingleTxBlock(t, b101Hash, f.target, 204, reorgTestCoinbaseForAddress(t, forkHeight+2, subsidyB102, f.destAddress))
+	summaryB102, err := f.engine.ApplyBlockWithReorg(blockB102, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(B102): %v", err)
+	}
+
+	afterReorg := mustAdmissionContext(t, f.owner, "after the reorg")
+	if afterReorg.Generation != beforeReorg.Generation+1 {
+		t.Fatalf("generation after reorg=%d, want exactly one advance from %d for the whole branch", afterReorg.Generation, beforeReorg.Generation)
+	}
+	if afterReorg.StableTip.Hash != summaryB102.BlockHash || afterReorg.StableTip.Height != summaryB102.BlockHeight {
+		t.Fatalf("stable tip after reorg=%+v, want B102 (%d,%x)", afterReorg.StableTip, summaryB102.BlockHeight, summaryB102.BlockHash)
+	}
+	if got := f.mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after reorg=%d, want 0 after the single pre-clean", got)
+	}
+	outpoints, claims, highWater := ownerClaimCount(f.owner)
+	if outpoints != 0 || claims != 0 {
+		t.Fatalf("owner still holds outpoints=%d claims=%d after the reorg", outpoints, claims)
+	}
+	if highWater != 1 {
+		t.Fatalf("token high-water=%d after the reorg, want the consumed sequence retained", highWater)
+	}
+}
+
+// TestApplyBlockWithReorgPendingOutpointRestoresExactTokensOnFailure proves the
+// abort row: a reorg that fails after prepared rows restores the record, its
+// exact token and its finalized claim, leaves the owner's stable tip untouched,
+// and still retains the advanced generation high-water so the failed transition
+// can never reproduce an earlier admission context.
+func TestApplyBlockWithReorgPendingOutpointRestoresExactTokensOnFailure(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight, f.alreadyGenerated
+	spend := f.spend(t, 700, 1)
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	spendID := txID(t, spend)
+	f.mempool.mu.Lock()
+	residentToken := f.mempool.txs[spendID].token
+	f.mempool.mu.Unlock()
+
+	subsidyA101 := consensus.BlockSubsidy(forkHeight+1, forkGenerated)
+	blockA101 := buildSingleTxBlock(t, forkHash, f.target, 202, reorgTestCoinbaseForAddress(t, forkHeight+1, subsidyA101, f.sourceAddress))
+	summaryA101, err := f.engine.ApplyBlock(blockA101, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A101): %v", err)
+	}
+	beforeReorg := mustAdmissionContext(t, f.owner, "before the failed reorg")
+
+	// A branch that does NOT include the spend, so the pre-clean removes only
+	// the conflicting record if the reorg commits — and must restore it if not.
+	blockB101 := buildSingleTxBlock(t, forkHash, f.target, 203, reorgTestCoinbaseForAddress(t, forkHeight+1, subsidyA101, f.destAddress))
+	b101Parsed, b101Hash := mustParseReorgBlockForTest(t, blockB101)
+	if err := f.store.StoreBlock(b101Hash, b101Parsed.HeaderBytes, blockB101); err != nil {
+		t.Fatalf("StoreBlock(B101): %v", err)
+	}
+	blockB102 := f.blockIncluding(t, b101Hash, forkHeight+2, forkGenerated+subsidyA101, 204, spend)
+
+	prevWrite := writeFileAtomicFn
+	t.Cleanup(func() { writeFileAtomicFn = prevWrite })
+	indexWrites, injected := 0, false
+	writeFileAtomicFn = func(path string, data []byte, mode os.FileMode) error {
+		if path == f.store.indexPath {
+			indexWrites++
+			if indexWrites == 3 {
+				injected = true
+				return os.ErrPermission
+			}
+		}
+		return prevWrite(path, data, mode)
+	}
+	if _, err := f.engine.ApplyBlockWithReorg(blockB102, nil); err == nil {
+		t.Fatal("expected the injected reorg persistence failure")
+	}
+	if !injected {
+		t.Fatal("the injected canonical-index write failure never fired")
+	}
+
+	if f.engine.chainState.TipHash != summaryA101.BlockHash {
+		t.Fatalf("chainstate tip=%x after the failed reorg, want A101 %x", f.engine.chainState.TipHash, summaryA101.BlockHash)
+	}
+	entry, claim := residentClaim(t, f.mempool, spendID)
+	if entry.token != residentToken {
+		t.Fatalf("restored token seq=%d, want the exact pre-reorg seq %d", entry.token.seq, residentToken.seq)
+	}
+	if claim == nil || !claim.finalized || claim.txid != spendID {
+		t.Fatalf("restored claim=%+v, want the exact finalized claim", claim)
+	}
+	if got, ok := f.owner.txidForOutpoint(f.sourceOutpoint); !ok || got != spendID {
+		t.Fatalf("restored index row=(%x,%v), want %x", got, ok, spendID)
+	}
+	afterReorg := mustAdmissionContext(t, f.owner, "after the failed reorg")
+	if afterReorg.StableTip != beforeReorg.StableTip {
+		t.Fatalf("stable tip after the failed reorg=%+v, want %+v unchanged", afterReorg.StableTip, beforeReorg.StableTip)
+	}
+	if afterReorg.Generation != beforeReorg.Generation+1 {
+		t.Fatalf("generation after the failed reorg=%d, want the advanced high-water %d", afterReorg.Generation, beforeReorg.Generation+1)
+	}
+}

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -1223,7 +1223,7 @@ func mustAdmissionContext(t *testing.T, owner *PendingOutpointOwner, what string
 func (f *pendingOutpointSyncFixture) breakResidentClaim(t *testing.T, txid [32]byte) {
 	t.Helper()
 	foreign := newPendingOutpointOwner(PendingOutpointTip{})
-	token, err := foreign.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{f.sourceOutpoint})
+	token, err := foreign.Reserve(PendingOutpointAdmissionContext{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{f.sourceOutpoint})
 	if err != nil {
 		t.Fatalf("foreign Reserve: %v", err)
 	}
@@ -1343,55 +1343,123 @@ func TestSyncPendingOutpointAdmissionConcurrentWithDirectConnectSmoke(t *testing
 	}
 }
 
-// TestSyncSetMempoolPendingOutpointRejectsForeignChainStateBinding proves a
-// transition can only ever own ONE pointer-identical ChainState, Mempool and
-// owner: a mempool bound to a different ChainState is not installed, and the
-// rejection changes neither the engine's binding nor the candidate's own state.
-func TestSyncSetMempoolPendingOutpointRejectsForeignChainStateBinding(t *testing.T) {
+// boundMempool reads the engine's current binding under the engine lock.
+func boundMempool(engine *SyncEngine) *Mempool {
+	engine.mu.RLock()
+	defer engine.mu.RUnlock()
+	return engine.mempool
+}
+
+// unboundEngineOn builds a SECOND engine over the fixture's exact ChainState and
+// BlockStore, bound to nothing, so the initial-binding rows run against a live
+// chain the fixture already advanced.
+func (f *pendingOutpointSyncFixture) unboundEngineOn(t *testing.T) *SyncEngine {
+	t.Helper()
+	engine, err := NewSyncEngine(f.engine.chainState, f.store, f.engine.cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine(second): %v", err)
+	}
+	if bound := boundMempool(engine); bound != nil {
+		t.Fatalf("fresh engine already bound to %p", bound)
+	}
+	return engine
+}
+
+// newPool builds another mempool over the fixture's exact ChainState and store.
+func (f *pendingOutpointSyncFixture) newPool(t *testing.T) *Mempool {
+	t.Helper()
+	pool, err := NewMempool(f.engine.chainState, f.store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	return pool
+}
+
+// assertBindingRejected drives one refused SetMempool and proves it changed
+// neither the engine binding nor the candidate's owner context.
+func assertBindingRejected(t *testing.T, engine *SyncEngine, candidate, want *Mempool, what string) {
+	t.Helper()
+	var before PendingOutpointAdmissionContext
+	if candidate != nil {
+		before = mustAdmissionContext(t, candidate.PendingOutpointOwner(), "before "+what)
+	}
+	engine.SetMempool(candidate)
+	if bound := boundMempool(engine); bound != want {
+		t.Fatalf("%s: engine mempool=%p, want %p", what, bound, want)
+	}
+	if candidate == nil {
+		return
+	}
+	if got := mustAdmissionContext(t, candidate.PendingOutpointOwner(), "after "+what); got != before {
+		t.Fatalf("%s: candidate context=%+v, want %+v unchanged", what, got, before)
+	}
+}
+
+// TestSyncSetMempoolPendingOutpointConstructOnceAndRejectsStaleOrNonemptyBinding
+// proves SetMempool is initialization-only. A transition must own ONE
+// pointer-identical ChainState, Mempool and owner for its whole duration, and a
+// pointer comparison cannot see that a detached pool's records were validated
+// against a canonical history this engine has already left: so exactly one fresh
+// empty candidate at the guarded live tip binds, an exact same-pointer retry is
+// a no-op, and every stale-tip, nonempty, foreign-ChainState, nil-unbind or
+// different-pointer candidate is refused with no mutation on either side.
+func TestSyncSetMempoolPendingOutpointConstructOnceAndRejectsStaleOrNonemptyBinding(t *testing.T) {
 	f := newPendingOutpointSyncFixture(t)
-	foreignState := NewChainState()
-	foreign, err := NewMempool(foreignState, f.store, devnetGenesisChainID)
+	fixtureContext := mustAdmissionContext(t, f.owner, "on the bound fixture pool")
+
+	// An exact same-pointer rebind is the ONLY accepted post-binding call.
+	f.engine.SetMempool(f.mempool)
+	if bound := boundMempool(f.engine); bound != f.mempool || bound.PendingOutpointOwner() != f.owner {
+		t.Fatalf("same-pointer rebind changed the binding to %p", bound)
+	}
+	if got := mustAdmissionContext(t, f.owner, "after the same-pointer rebind"); got != fixtureContext {
+		t.Fatalf("same-pointer rebind moved the context to %+v, want %+v", got, fixtureContext)
+	}
+	assertBindingRejected(t, f.engine, nil, f.mempool, "nil unbind after the initial binding")
+
+	// A different pointer is refused even when it is fresh, empty, bound to the
+	// same ChainState and reporting the same apparent context.
+	replacement := f.newPool(t)
+	if got := mustAdmissionContext(t, replacement.PendingOutpointOwner(), "on the replacement"); got != fixtureContext {
+		t.Fatalf("replacement context=%+v, want the same apparent context %+v", got, fixtureContext)
+	}
+	assertBindingRejected(t, f.engine, replacement, f.mempool, "different-pointer replacement")
+
+	// Initial-binding rejections, on a second engine that never bound anything.
+	engine := f.unboundEngineOn(t)
+	foreign, err := NewMempool(NewChainState(), f.store, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("NewMempool(foreign): %v", err)
 	}
-	foreignOwner := foreign.PendingOutpointOwner()
-	foreignBefore := mustAdmissionContext(t, foreignOwner, "on the foreign candidate")
+	assertBindingRejected(t, engine, foreign, nil, "foreign-chainstate candidate")
 
-	f.engine.SetMempool(foreign)
-
-	f.engine.mu.RLock()
-	bound := f.engine.mempool
-	f.engine.mu.RUnlock()
-	if bound != f.mempool {
-		t.Fatalf("engine mempool=%p, want the original binding %p", bound, f.mempool)
+	// A nonempty candidate at the exact live tip: its records were admitted
+	// against a canonical tip this engine never guarded.
+	if err := f.mempool.AddTx(f.spend(t, 700, 1)); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
 	}
-	if bound.PendingOutpointOwner() != f.owner {
-		t.Fatal("engine owner changed on a rejected SetMempool")
-	}
-	if got := mustAdmissionContext(t, foreignOwner, "after the rejected SetMempool"); got != foreignBefore {
-		t.Fatalf("rejected candidate context=%+v, want %+v unchanged", got, foreignBefore)
+	assertBindingRejected(t, engine, f.mempool, nil, "nonempty candidate")
+	outpoints, claims, _ := ownerClaimCount(f.owner)
+	if f.mempool.Len() != 1 || outpoints != 1 || claims != 1 {
+		t.Fatalf("rejected nonempty candidate holds len=%d outpoints=%d claims=%d, want its single record untouched",
+			f.mempool.Len(), outpoints, claims)
 	}
 
-	// A nil mempool IS installable — the identity guard applies only to a
-	// non-nil candidate — and a same-ChainState mempool binds.
-	f.engine.SetMempool(nil)
-	f.engine.mu.RLock()
-	bound = f.engine.mempool
-	f.engine.mu.RUnlock()
-	if bound != nil {
-		t.Fatalf("SetMempool(nil) left mempool=%p, want the binding cleared", bound)
+	// A stale candidate: built at the live tip, then left behind while the
+	// canonical tip advanced, so its owner tip no longer matches the guard.
+	stale := f.newPool(t)
+	subsidy := consensus.BlockSubsidy(f.tipHeight+1, f.alreadyGenerated)
+	next := buildSingleTxBlock(t, f.tipHash, f.target, 202, reorgTestCoinbaseForAddress(t, f.tipHeight+1, subsidy, f.sourceAddress))
+	if _, err := f.engine.ApplyBlock(next, nil); err != nil {
+		t.Fatalf("ApplyBlock(next): %v", err)
 	}
+	assertBindingRejected(t, engine, stale, nil, "stale-tip candidate")
 
-	same, err := NewMempool(f.engine.chainState, f.store, devnetGenesisChainID)
-	if err != nil {
-		t.Fatalf("NewMempool(same chainstate): %v", err)
-	}
-	f.engine.SetMempool(same)
-	f.engine.mu.RLock()
-	bound = f.engine.mempool
-	f.engine.mu.RUnlock()
-	if bound != same || bound.PendingOutpointOwner() != same.PendingOutpointOwner() {
-		t.Fatalf("engine mempool=%p, want the same-chainstate mempool %p", bound, same)
+	// And the accepted row: one fresh empty pool at the current guarded tip.
+	fresh := f.newPool(t)
+	engine.SetMempool(fresh)
+	if bound := boundMempool(engine); bound != fresh || bound.PendingOutpointOwner() != fresh.PendingOutpointOwner() {
+		t.Fatalf("engine mempool=%p, want the fresh current-tip candidate %p", bound, fresh)
 	}
 }
 

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -1111,3 +1111,389 @@ func TestValidateMempoolEntryParsedRejectsBadSource(t *testing.T) {
 		})
 	}
 }
+
+// pendingOutpointSyncFixture is the shared canonical-transition test bed: a
+// devnet engine whose chain is long enough for its height-1 coinbase output to
+// be spendable, the single mempool bound to that engine, and the keys needed to
+// build competing spends of that output.
+type pendingOutpointSyncFixture struct {
+	engine           *SyncEngine
+	store            *BlockStore
+	target           [32]byte
+	mempool          *Mempool
+	owner            *PendingOutpointOwner
+	sourceKP         *consensus.MLDSA87Keypair
+	sourceAddress    []byte
+	destAddress      []byte
+	sourceOutpoint   consensus.Outpoint
+	tipHash          [32]byte
+	tipHeight        uint64
+	alreadyGenerated uint64
+}
+
+func newPendingOutpointSyncFixture(t *testing.T) *pendingOutpointSyncFixture {
+	t.Helper()
+	engine, store, target := newReorgTestEngine(t)
+	sourceKP := mustReorgMLDSA87Keypair(t)
+	destKP := mustReorgMLDSA87Keypair(t)
+	f := &pendingOutpointSyncFixture{
+		engine:        engine,
+		store:         store,
+		target:        target,
+		sourceKP:      sourceKP,
+		sourceAddress: consensus.P2PKCovenantDataForPubkey(sourceKP.PubkeyBytes()),
+		destAddress:   consensus.P2PKCovenantDataForPubkey(destKP.PubkeyBytes()),
+		tipHash:       devnetGenesisBlockHash,
+	}
+	// COINBASE_MATURITY blocks so the height-1 coinbase output is spendable.
+	for height := uint64(1); height <= 100; height++ {
+		subsidy := consensus.BlockSubsidy(height, f.alreadyGenerated)
+		coinbase := reorgTestCoinbaseForAddress(t, height, subsidy, f.sourceAddress)
+		summary, err := engine.ApplyBlock(buildSingleTxBlock(t, f.tipHash, target, height+1, coinbase), nil)
+		if err != nil {
+			t.Fatalf("ApplyBlock(height=%d): %v", height, err)
+		}
+		if height == 1 {
+			_, coinbaseTxid, _, _, err := consensus.ParseTx(coinbase)
+			if err != nil {
+				t.Fatalf("ParseTx(coinbase height 1): %v", err)
+			}
+			f.sourceOutpoint = consensus.Outpoint{Txid: coinbaseTxid, Vout: 0}
+		}
+		f.tipHash, f.tipHeight, f.alreadyGenerated = summary.BlockHash, height, f.alreadyGenerated+subsidy
+	}
+	mempool, err := NewMempool(engine.chainState, store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	engine.SetMempool(mempool)
+	f.mempool, f.owner = mempool, mempool.PendingOutpointOwner()
+	return f
+}
+
+// spend builds a signed transfer of the fixture's spendable coinbase output.
+// Distinct nonces produce distinct, mutually conflicting transactions.
+func (f *pendingOutpointSyncFixture) spend(t *testing.T, amount uint64, nonce uint64) []byte {
+	t.Helper()
+	return mustBuildSignedTransferTxForSyncTest(
+		t,
+		f.engine.chainState.Utxos,
+		[]consensus.Outpoint{f.sourceOutpoint},
+		amount,
+		100_000,
+		nonce,
+		f.sourceKP,
+		f.sourceAddress,
+		f.destAddress,
+	)
+}
+
+// blockIncluding builds a canonical block at height carrying tx. alreadyGenerated
+// is the branch-local total issued BEFORE height, so a block built on a side
+// branch gets that branch's subsidy rather than the canonical chain's.
+func (f *pendingOutpointSyncFixture) blockIncluding(t *testing.T, prevHash [32]byte, height uint64, alreadyGenerated uint64, timestamp uint64, tx []byte) []byte {
+	t.Helper()
+	_, _, wtxid, _, err := consensus.ParseTx(tx)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+	subsidy := consensus.BlockSubsidy(height, alreadyGenerated)
+	return buildMultiTxBlock(
+		t,
+		prevHash,
+		f.target,
+		timestamp,
+		reorgTestCoinbaseForWtxids(t, height, subsidy+100_000, f.sourceAddress, [][32]byte{{}, wtxid}),
+		tx,
+	)
+}
+
+func mustAdmissionContext(t *testing.T, owner *PendingOutpointOwner, what string) PendingOutpointAdmissionContext {
+	t.Helper()
+	ctx, ok := owner.AdmissionContext()
+	if !ok {
+		t.Fatalf("AdmissionContext unavailable %s", what)
+	}
+	return ctx
+}
+
+// breakResidentClaim rebinds a resident record to a FOREIGN owner's token —
+// precisely the record/claim inconsistency the typed standard delta refuses to
+// mutate through — so the next canonical cleanup of that record fails.
+func (f *pendingOutpointSyncFixture) breakResidentClaim(t *testing.T, txid [32]byte) {
+	t.Helper()
+	foreign := newPendingOutpointOwner(PendingOutpointTip{})
+	token, err := foreign.Reserve(PendingOutpointTip{}, PendingOutpointStandardMempool, [32]byte{0x01}, []consensus.Outpoint{f.sourceOutpoint})
+	if err != nil {
+		t.Fatalf("foreign Reserve: %v", err)
+	}
+	f.mempool.mu.Lock()
+	defer f.mempool.mu.Unlock()
+	f.mempool.txs[txid].token = token
+}
+
+func ownerClaimCount(owner *PendingOutpointOwner) (outpoints int, claims int, highWater uint64) {
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	return len(owner.byOutpoint), len(owner.byToken), owner.tokenHighWater
+}
+
+// TestSyncPendingOutpointDirectConnectReleasesTokensAndCommitsStableTip proves
+// the direct-connect row end to end: an included transaction's record and its
+// exact claim are both gone after the connect, the owner's stable tip is the new
+// canonical tip, exactly one generation was consumed, and the token high-water
+// stayed advanced so no sequence can be reused.
+func TestSyncPendingOutpointDirectConnectReleasesTokensAndCommitsStableTip(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	spend := f.spend(t, 700, 1)
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	before := mustAdmissionContext(t, f.owner, "before the direct connect")
+	if before.StableTip.Hash != f.tipHash || before.StableTip.Height != f.tipHeight {
+		t.Fatalf("stable tip before=%+v, want the live tip (%d,%x)", before.StableTip, f.tipHeight, f.tipHash)
+	}
+	if outpoints, claims, _ := ownerClaimCount(f.owner); outpoints != 1 || claims != 1 {
+		t.Fatalf("owner state before connect=(%d,%d), want one claim", outpoints, claims)
+	}
+
+	summary, err := f.engine.ApplyBlock(f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend), nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(including spend): %v", err)
+	}
+
+	if got := f.mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after connect=%d, want 0", got)
+	}
+	outpoints, claims, highWater := ownerClaimCount(f.owner)
+	if outpoints != 0 || claims != 0 {
+		t.Fatalf("owner still holds outpoints=%d claims=%d after connect", outpoints, claims)
+	}
+	if highWater != 1 {
+		t.Fatalf("token high-water=%d, want the consumed sequence retained", highWater)
+	}
+	after := mustAdmissionContext(t, f.owner, "after the direct connect")
+	if after.StableTip.Hash != summary.BlockHash || after.StableTip.Height != summary.BlockHeight {
+		t.Fatalf("stable tip after=%+v, want the connected block (%d,%x)", after.StableTip, summary.BlockHeight, summary.BlockHash)
+	}
+	if after.Generation != before.Generation+1 {
+		t.Fatalf("generation after=%d, want exactly one advance from %d", after.Generation, before.Generation)
+	}
+}
+
+// TestSyncPendingOutpointCleanupFailureLeavesCanonicalTipUnmoved pins the
+// sync_pv.go rule that a standard cleanup failure must NOT be logged over a
+// committed tip: it propagates into rollback, so the apply fails and the live
+// canonical tip is exactly where it was.
+func TestSyncPendingOutpointCleanupFailureLeavesCanonicalTipUnmoved(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	spend := f.spend(t, 700, 1)
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	f.breakResidentClaim(t, txID(t, spend))
+
+	beforeHash, beforeHeight := f.engine.chainState.TipHash, f.engine.chainState.Height
+	if _, err := f.engine.ApplyBlock(f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend), nil); err == nil {
+		t.Fatal("apply committed a block whose standard cleanup failed")
+	}
+	if f.engine.chainState.TipHash != beforeHash || f.engine.chainState.Height != beforeHeight {
+		t.Fatalf("canonical tip moved to (%d,%x) despite the cleanup failure, want (%d,%x)",
+			f.engine.chainState.Height, f.engine.chainState.TipHash, beforeHeight, beforeHash)
+	}
+	storeHeight, storeHash, ok, err := f.store.Tip()
+	if err != nil || !ok || storeHash != beforeHash || storeHeight != beforeHeight {
+		t.Fatalf("blockstore tip=(%d,%x,ok=%v,err=%v), want the pre-apply canonical tip (%d,%x)",
+			storeHeight, storeHash, ok, err, beforeHeight, beforeHash)
+	}
+}
+
+// TestSyncPendingOutpointAdmissionConcurrentWithDirectConnectSmoke is a -race
+// smoke over the hostile row, NOT a forced interleaving: there is no seam that
+// pins an admission inside the guard window, so the schedule is whatever the
+// runtime picks. What it does pin, for every schedule, is the outcome invariant
+// — the racing candidate never survives a connect that consumed its outpoint,
+// no claim outlives the connected block, and the owner reopens afterwards.
+func TestSyncPendingOutpointAdmissionConcurrentWithDirectConnectSmoke(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	included := f.spend(t, 700, 1)
+	racing := f.spend(t, 690, 2)
+	block := f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, included)
+
+	admitted := make(chan error, 1)
+	go func() { admitted <- f.mempool.AddTx(racing) }()
+	if _, err := f.engine.ApplyBlock(block, nil); err != nil {
+		t.Fatalf("ApplyBlock: %v", err)
+	}
+	admitErr := <-admitted
+
+	// Whichever side won, the outpoint has exactly one owner afterwards, and it
+	// is never the racing candidate: the block consumed the outpoint on chain.
+	if f.mempool.Contains(txID(t, racing)) {
+		t.Fatalf("racing candidate survived the connect (admit err=%v)", admitErr)
+	}
+	if _, ok := f.owner.txidForOutpoint(f.sourceOutpoint); ok {
+		t.Fatal("a claim on the spent outpoint outlived the connected block")
+	}
+	if got := f.mempool.Len(); got != 0 {
+		t.Fatalf("mempool len=%d after the race, want 0", got)
+	}
+	if _, ok := f.owner.AdmissionContext(); !ok {
+		t.Fatal("owner did not reopen after the connect")
+	}
+}
+
+// TestSyncSetMempoolPendingOutpointRejectsForeignChainStateBinding proves a
+// transition can only ever own ONE pointer-identical ChainState, Mempool and
+// owner: a mempool bound to a different ChainState is not installed, and the
+// rejection changes neither the engine's binding nor the candidate's own state.
+func TestSyncSetMempoolPendingOutpointRejectsForeignChainStateBinding(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	foreignState := NewChainState()
+	foreign, err := NewMempool(foreignState, f.store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool(foreign): %v", err)
+	}
+	foreignOwner := foreign.PendingOutpointOwner()
+	foreignBefore := mustAdmissionContext(t, foreignOwner, "on the foreign candidate")
+
+	f.engine.SetMempool(foreign)
+
+	f.engine.mu.RLock()
+	bound := f.engine.mempool
+	f.engine.mu.RUnlock()
+	if bound != f.mempool {
+		t.Fatalf("engine mempool=%p, want the original binding %p", bound, f.mempool)
+	}
+	if bound.PendingOutpointOwner() != f.owner {
+		t.Fatal("engine owner changed on a rejected SetMempool")
+	}
+	if got := mustAdmissionContext(t, foreignOwner, "after the rejected SetMempool"); got != foreignBefore {
+		t.Fatalf("rejected candidate context=%+v, want %+v unchanged", got, foreignBefore)
+	}
+
+	// A nil mempool IS installable — the identity guard applies only to a
+	// non-nil candidate — and a same-ChainState mempool binds.
+	f.engine.SetMempool(nil)
+	f.engine.mu.RLock()
+	bound = f.engine.mempool
+	f.engine.mu.RUnlock()
+	if bound != nil {
+		t.Fatalf("SetMempool(nil) left mempool=%p, want the binding cleared", bound)
+	}
+
+	same, err := NewMempool(f.engine.chainState, f.store, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool(same chainstate): %v", err)
+	}
+	f.engine.SetMempool(same)
+	f.engine.mu.RLock()
+	bound = f.engine.mempool
+	f.engine.mu.RUnlock()
+	if bound != same || bound.PendingOutpointOwner() != same.PendingOutpointOwner() {
+		t.Fatalf("engine mempool=%p, want the same-chainstate mempool %p", bound, same)
+	}
+}
+
+// TestSyncPendingOutpointUnprovenRestoreLatchesAdmissionClosed pins the
+// fail-closed rule for a rollback whose EXACT restore failed: admission must not
+// reopen over a state nobody can prove. The transition is made to fail at the
+// standard cleanup and its restore is made to fail as well (an invalid mempool
+// capacity limit), so the engine takes the terminal latch, not an ordinary abort.
+func TestSyncPendingOutpointUnprovenRestoreLatchesAdmissionClosed(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	spend := f.spend(t, 700, 1)
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	f.breakResidentClaim(t, txID(t, spend))
+	f.mempool.mu.Lock()
+	f.mempool.maxTxs = 0 // the rollback's mempool restore now fails too
+	f.mempool.mu.Unlock()
+
+	block := f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend)
+	if _, err := f.engine.ApplyBlock(block, nil); err == nil {
+		t.Fatal("apply reported success although its restore could not be proven")
+	}
+	if ctx, ok := f.owner.AdmissionContext(); ok {
+		t.Fatalf("owner reopened at %+v after an unproven restore", ctx)
+	}
+	if _, err := f.engine.DisconnectTip(); !errors.Is(err, errStoragePersistenceFault) {
+		t.Fatalf("later SyncEngine mutator err=%v, want the latched storage persistence fault", err)
+	}
+}
+
+// TestSyncPendingOutpointCorruptCanonicalIndexOutranksConsensusRejection pins
+// the hostile row on BOTH canonical paths. Each subtest applies the SAME
+// consensus-invalid candidate twice: against a healthy index, proving the path
+// really reaches consensus validation, and against a malformed one, where the
+// local index error must win.
+//
+// On the direct path that precedence IS the rollback preflight, and removing it
+// reddens this test. On the reorg path branch collection scans the same index
+// first, so the preflight cannot be observed here; its value there — supplying
+// the EXACT rollback index — is pinned instead by
+// TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile, which
+// fails outright when the preflight is removed.
+func TestSyncPendingOutpointCorruptCanonicalIndexOutranksConsensusRejection(t *testing.T) {
+	// Height 0 is outside every MTP window these candidates read, so the
+	// corruption reaches the preflight rather than an earlier context read.
+	corrupt := func(f *pendingOutpointSyncFixture) {
+		f.store.stateMu.Lock()
+		f.store.index.Canonical[0] = "zz"
+		f.store.stateMu.Unlock()
+	}
+	assertConsensusError := func(t *testing.T, err error) {
+		t.Helper()
+		var txErr *consensus.TxError
+		if !errors.As(err, &txErr) {
+			t.Fatalf("healthy-index err=%v, want a consensus rejection", err)
+		}
+	}
+	assertIndexError := func(t *testing.T, err error) {
+		t.Helper()
+		var txErr *consensus.TxError
+		if err == nil || errors.As(err, &txErr) || !strings.Contains(err.Error(), "canonical[0]") {
+			t.Fatalf("err=%v, want the canonical[0] index error rather than a consensus rejection", err)
+		}
+	}
+	coinbaseAt := func(t *testing.T, f *pendingOutpointSyncFixture, height, alreadyGenerated uint64) []byte {
+		t.Helper()
+		return reorgTestCoinbaseForAddress(t, height, consensus.BlockSubsidy(height, alreadyGenerated), f.sourceAddress)
+	}
+
+	t.Run("direct connect", func(t *testing.T) {
+		f := newPendingOutpointSyncFixture(t)
+		// Timestamp 1 is at or below the canonical MTP: consensus-invalid.
+		invalid := buildSingleTxBlock(t, f.tipHash, f.target, 1, coinbaseAt(t, f, f.tipHeight+1, f.alreadyGenerated))
+		_, err := f.engine.ApplyBlockWithReorg(invalid, nil)
+		assertConsensusError(t, err)
+		corrupt(f)
+		_, err = f.engine.ApplyBlockWithReorg(invalid, nil)
+		assertIndexError(t, err)
+	})
+
+	t.Run("preferred branch reorg", func(t *testing.T) {
+		f := newPendingOutpointSyncFixture(t)
+		height, generated := f.tipHeight+1, f.alreadyGenerated
+		canonical := buildSingleTxBlock(t, f.tipHash, f.target, 500, coinbaseAt(t, f, height, generated))
+		if _, err := f.engine.ApplyBlockWithReorg(canonical, nil); err != nil {
+			t.Fatalf("ApplyBlockWithReorg(canonical): %v", err)
+		}
+		// The losing branch's first block is seeded straight into the store:
+		// through fork choice it would tie on work, and a tie-break win would
+		// make the final block a direct connect instead of the reorg this row
+		// needs. Two blocks then outweigh the one-block canonical extension.
+		side1 := buildSingleTxBlock(t, f.tipHash, f.target, 501, coinbaseAt(t, f, height, generated))
+		parsed1, side1Hash := mustParseReorgBlockForTest(t, side1)
+		if err := f.store.StoreBlock(side1Hash, parsed1.HeaderBytes, side1); err != nil {
+			t.Fatalf("StoreBlock(side1): %v", err)
+		}
+		side2 := buildSingleTxBlock(t, side1Hash, f.target, 1, coinbaseAt(t, f, height+1, generated+consensus.BlockSubsidy(height, generated)))
+		_, err := f.engine.ApplyBlockWithReorg(side2, nil)
+		assertConsensusError(t, err)
+		corrupt(f)
+		_, err = f.engine.ApplyBlockWithReorg(side2, nil)
+		assertIndexError(t, err)
+	})
+}

--- a/clients/go/node/target_schedule_runtime_test.go
+++ b/clients/go/node/target_schedule_runtime_test.go
@@ -862,10 +862,10 @@ func TestTargetScheduleRuntimeCallerDerivesOncePerBlockAndRow(t *testing.T) {
 				t.Fatalf("switching reorg: %v", err)
 			}
 		})
-		// Two rows x two passes: one preview derivation and one commit
-		// derivation per row. Linear, not quadratic, and never twice per pass.
-		if got != 4 {
-			t.Fatalf("derivations=%d for a 2-row branch, want 4 (one per row per pass)", got)
+		// One derivation per prepared row during the complete preflight; the
+		// commit-only publication derives none. Linear, not quadratic.
+		if got != 2 {
+			t.Fatalf("derivations=%d for a 2-row branch, want 2 (one per prepared row during preflight)", got)
 		}
 	})
 


### PR DESCRIPTION
## Issue
- Linear: RUB-1113
- GitHub Issue mirror (non-authoritative): #2826

Refs: Q-GO-PENDING-OUTPOINT-OWNER-01

## Summary
The Go mempool's double-spend authority moves from the flat `spenders` map to a single `PendingOutpointOwner`: admission reads one owner `AdmissionContext` at the exact slot `validateEntryInputsLocked` occupied and passes that complete stable-tip/generation pair to `Reserve`, every resident input-bearing entry carries its finalized token, and every terminal, capacity and canonical-transition path releases record and claim through one typed commit delta with no error-capable step after mutation begins. Canonical connect, preferred reorg and standalone disconnect hold `admissionMu` continuously from generation begin to stable commit, run standard cleanup before the tip becomes observable, and roll back to an exact snapshot; preferred-reorg preparation validates the whole branch against one rolling private clone and retains only compact per-row delta and precomputed undo (O(1) full-state memory in branch depth, no depth rejection), and the commit applies and persists each row so ChainState and BlockStore correspond at every persisted row. A failed restore or ambiguous post-commit persistence fault latches the transition terminally — `mutationMu` is released, `admissionMu` is not, and admission waiters block until restart by design. `SetMempool` is initialization-only: one fresh empty current-tip pool binds under the continuously held admission read guard, a same-pointer retry is a no-op, and every stale, nonempty, nil-unbind or different-pointer candidate is rejected without mutation. Input-less entries keep their existing acceptance with the zero token and no claim.

## Invariant
Every in-flight standard Go Mempool candidate that spends at least one outpoint has exactly one complete StandardMempool reservation, every resident input-bearing standard entry has exactly one finalized claim carrying its exact token, and every standard terminal or canonical-transition path changes the record and its exact claim together before exposing the resulting stable canonical tip.

## Scope
- Changed files: 18
- Surfaces: clients/go
- Non-scope: no shared fixture or corpus change; no Rust implementation or cross-client parity claim; no DA record/state/routing/eviction integration; no generic TxPool interface widening; no RPC or command change; no consensus-validity, public-error, wire, serialization or persistent-schema change; no mining-policy, RBF, CPFP, package-relay or fast-floor-order change; ChainState sources untouched. `target_schedule_runtime_test.go` changes only the sanctioned stale two-pass derivation expectation (4→2).
- Consensus rules unchanged: YES — the owner replaces node-local mempool conflict bookkeeping and transition orchestration; block validity, accept/reject outcomes, public error kinds and their ordering are untouched
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks on head 58a109eb: `go build ./...` — PASS; `go vet ./...` — PASS; `go test -count=1 ./node -run "^(TestPendingOutpointOwner|TestMempoolPendingOutpoint|TestMempoolSnapshotPendingOutpoint|TestSyncPendingOutpoint|TestSyncSetMempoolPendingOutpoint|TestApplyBlockWithReorgPendingOutpoint|TestDisconnectTipPendingOutpoint)"` — PASS; same set under `-race` — PASS; `go test -count=1 ./node/p2p -run "^TestCanonicalMempoolTxPoolPendingOutpointOwner"` — PASS; `go test -count=1 ./node -run "^TestPendingOutpointOwnerAdmissionContext$"` — PASS; `go test -count=1 ./node -run "^(TestPendingOutpointOwnerReserveRejectsStaleAdmissionGenerationWithoutMutation|TestSyncSetMempoolPendingOutpointConstructOnceAndRejectsStaleOrNonemptyBinding|TestPreparePreferredBranchRetainsCompactRowsWithoutUtxoSnapshots|TestApplyBlockWithReorgPendingOutpointCompactRowsPersistAndUndo)$"` — PASS; `go test -count=1 ./node -run "^(TestSyncEnginePostCommitFaultKeepsAdmissionClosedAfterLatch|TestSyncEngineQueuesMutatorsUntilPostCommitFaultIsPublished)$"` — PASS; `go test -count=1 ./node -run "^TestTargetScheduleRuntimeCallerDerivesOncePerBlockAndRow$/^switching_reorg_is_linear_in_branch_length$"` — PASS; `go test -race -count=1 ./node ./node/p2p` — PASS; `go test -count=1 ./...` — PASS; `scripts/node-runtime-total-parity-gate.sh` — PASS; `gofumpt -l` over the allowlist — PASS; `git diff --check` — PASS
- Deterministic static tooling (TOOLING_STAGE=static, new-only) on head 58a109eb — PASS
- Standalone deep soak (TOOLING_STAGE=soak, go-deep) — pending on the final unchanged head

## Follow-ups / Waivers
- RUB-1111
- RUB-1131
- RUB-1122
