### PR TITLE
RUB-1133: isolate operator diagnostics from canonical mutation and expose terminal health

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -71,6 +71,32 @@ type devnetRPCState struct {
 	// atomic.Load on the service side, so /metrics rendering does not
 	// mutate any counter.
 	peerLifecycleExits func() uint64
+	// terminalFault is the read-only terminal-latch projection GET /health
+	// reads. newDevnetRPCState binds it to the SAME *node.SyncEngine stored
+	// in syncEngine above, so production observes the live engine's own
+	// latch; there is no setter, latch installer or failure seam, and
+	// TestDevnetRPCHealthFailsClosedOnTerminalFault pins that binding by
+	// identity.
+	terminalFault terminalFaultReporter
+}
+
+// terminalFaultReporter is the one-method read-only view /health needs of the
+// sync engine's terminal storage-persistence latch. *node.SyncEngine satisfies
+// it directly; the interface exists so the projection is provably bound to the
+// live engine by identity rather than to a closure indistinguishable from a
+// constant.
+type terminalFaultReporter interface {
+	TerminalFaulted() bool
+}
+
+// terminalFaulted reports the live latch, treating a missing state or reporter
+// as "not latched": /health already fails closed with 503 on a nil state or nil
+// sync engine before it consults this.
+func (s *devnetRPCState) terminalFaulted() bool {
+	if s == nil || s.terminalFault == nil {
+		return false
+	}
+	return s.terminalFault.TerminalFaulted()
 }
 
 // chainIdentity is a snapshot of startup-wired chain identity. Fields
@@ -404,8 +430,16 @@ type chainIdentityResponse struct {
 // conflating "no tip" with "RPC failure". The remaining fields are
 // non-optional snapshots of existing node state; renaming or adding
 // fields is out of scope for this PR.
+//
+// terminal_fault / restart_required are the bounded projection of the
+// SyncEngine's terminal storage-persistence latch: both true, ready
+// false and status 503 exactly when that latch is installed, with no
+// cause string, path or error text exposed. A merely not-yet-ready node
+// is NOT a terminal fault — it keeps 200 with both booleans false.
 type healthResponse struct {
 	Ready           bool    `json:"ready"`
+	TerminalFault   bool    `json:"terminal_fault"`
+	RestartRequired bool    `json:"restart_required"`
 	HasTip          bool    `json:"has_tip"`
 	Height          *uint64 `json:"height"`
 	TipHash         *string `json:"tip_hash"`
@@ -473,6 +507,9 @@ func newDevnetRPCState(
 		// observe state-only behavior (observeShutdownLocked's select
 		// default branch returns false because TODO never cancels).
 		gate: newReadinessGate(context.TODO()),
+		// The health projection is bound to the very engine stored above:
+		// one live read-only source, no separate fault authority.
+		terminalFault: syncEngine,
 	}
 }
 
@@ -1597,8 +1634,14 @@ func handleHealth(state *devnetRPCState, w http.ResponseWriter, r *http.Request)
 		})
 		return
 	}
+	// A terminally latched engine is fail-closed: admission stays shut until
+	// restart, so /health must report neither ready nor 200. The rest of the
+	// bounded snapshot still ships — an operator needs a broken node's state.
+	terminalFault := state.terminalFaulted()
 	body := healthResponse{
-		Ready:           state.IsReady(),
+		Ready:           state.IsReady() && !terminalFault,
+		TerminalFault:   terminalFault,
+		RestartRequired: terminalFault,
 		HasTip:          hasTip,
 		BestKnownHeight: state.syncEngine.BestKnownHeight(),
 		InIBD:           state.syncEngine.IsInIBD(state.now()),
@@ -1611,7 +1654,11 @@ func handleHealth(state *devnetRPCState, w http.ResponseWriter, r *http.Request)
 		tipHex := hex.EncodeToString(tipHash[:])
 		body.TipHash = &tipHex
 	}
-	writeJSONResponse(state, route, w, http.StatusOK, body)
+	status := http.StatusOK
+	if terminalFault {
+		status = http.StatusServiceUnavailable
+	}
+	writeJSONResponse(state, route, w, status, body)
 }
 
 // handlePeers serves GET /peers, the deterministic snapshot of

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -3401,7 +3401,11 @@ func TestDevnetRPCHealthFailsClosedOnTerminalFault(t *testing.T) {
 
 	server := httptest.NewServer(newDevnetRPCHandler(state))
 	defer server.Close()
-	resp, err := http.Get(server.URL + "/health")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/health", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := server.Client().Do(req)
 	if err != nil {
 		t.Fatalf("GET /health: %v", err)
 	}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -3326,6 +3326,10 @@ func TestDevnetRPCHealthReportsLiveSnapshot(t *testing.T) {
 	if body.MempoolBytes != len(txBytes) {
 		t.Fatalf("mempool_bytes=%d want %d", body.MempoolBytes, len(txBytes))
 	}
+	if body.TerminalFault || body.RestartRequired {
+		t.Fatalf("terminal_fault=%v restart_required=%v on a healthy ready node, want both false",
+			body.TerminalFault, body.RestartRequired)
+	}
 }
 
 // TestDevnetRPCHealthReportsReadyFalseAsField asserts a
@@ -3359,6 +3363,82 @@ func TestDevnetRPCHealthReportsReadyFalseAsField(t *testing.T) {
 	}
 	if body.Height != nil || body.TipHash != nil {
 		t.Fatalf("height/tip_hash non-nil with has_tip=false: %v / %v", body.Height, body.TipHash)
+	}
+	// Not-yet-ready is a startup state, never a terminal fault.
+	if body.TerminalFault || body.RestartRequired {
+		t.Fatalf("terminal_fault=%v restart_required=%v on a healthy not-yet-ready node, want both false",
+			body.TerminalFault, body.RestartRequired)
+	}
+}
+
+// stubTerminalFaultReporter stands in for the live engine's latch so the
+// projection can be exercised without a real storage failure. TEST-only:
+// production binds the projection to the *node.SyncEngine itself (asserted
+// below), and no seam can install or clear a fault on a real engine.
+type stubTerminalFaultReporter struct{ latched bool }
+
+func (s stubTerminalFaultReporter) TerminalFaulted() bool { return s.latched }
+
+// TestDevnetRPCHealthFailsClosedOnTerminalFault proves the WIRING —
+// newDevnetRPCState binds the /health projection to the very *node.SyncEngine it
+// stores, by identity, so node-side TestSyncEngineTerminalFaultedSnapshot (the
+// latch flips exactly on the two terminal causes) carries over to this endpoint
+// — and then the PROJECTION: a latched engine answers 503 with terminal_fault,
+// restart_required and ready:false even though the readiness gate is Ready,
+// while still reporting the bounded tip/peer/mempool snapshot and no cause text.
+func TestDevnetRPCHealthFailsClosedOnTerminalFault(t *testing.T) {
+	state := mustRPCState(t, true)
+	if state.terminalFault != state.syncEngine {
+		t.Fatal("production construction did not bind the /health terminal-fault projection to the live sync engine")
+	}
+	if state.terminalFaulted() {
+		t.Fatal("a freshly constructed engine reported a terminal fault")
+	}
+	if !state.TryMarkReadyOnStartup() {
+		t.Fatal("TryMarkReadyOnStartup: false on a fresh gate")
+	}
+	state.terminalFault = stubTerminalFaultReporter{latched: true}
+
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503 for a terminally latched engine", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var body healthResponse
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.TerminalFault || !body.RestartRequired {
+		t.Fatalf("terminal_fault=%v restart_required=%v, want both true", body.TerminalFault, body.RestartRequired)
+	}
+	if body.Ready {
+		t.Fatal("ready=true on a terminally latched engine whose gate is Ready")
+	}
+	if !body.HasTip || body.Height == nil || body.TipHash == nil {
+		t.Fatalf("bounded snapshot lost on the latched path: has_tip=%v height=%v tip_hash=%v", body.HasTip, body.Height, body.TipHash)
+	}
+	// The payload stays bounded: booleans only, no cause, path or error text.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	for _, want := range []string{"ready", "terminal_fault", "restart_required", "has_tip", "height", "tip_hash", "best_known_height", "in_ibd", "peer_count", "mempool_txs", "mempool_bytes"} {
+		if _, ok := fields[want]; !ok {
+			t.Fatalf("field %q missing from the latched /health payload: %s", want, raw)
+		}
+		delete(fields, want)
+	}
+	if len(fields) != 0 {
+		t.Fatalf("latched /health payload carries unbounded extra fields: %v", fields)
 	}
 }
 

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -636,13 +636,25 @@ func (s *SyncEngine) reportMempoolBindingRejected(diag *diagnosticBatch, err err
 // post-acceptance failures). A nil writer maps to io.Discard, which is also the
 // default when SetStderr is never called.
 //
-// Contract for the supplied writer, which the engine ENFORCES rather than
-// assumes: it is never invoked while mutationMu, s.mu, the ChainState admission
-// guard, or any ChainState / Mempool / PendingOutpointOwner lock is held (see
-// flushDiagnostics for the single terminal-latch exception). A writer may
-// therefore block or re-enter a non-diagnostic SyncEngine mutation without
-// stalling or deadlocking another mutator, and its Write errors are ignored: a
+// The writer MUST be safe for concurrent use — the conventional io.Writer
+// property that os.Stderr and *os.File already hold. Flushes deliberately run
+// outside mutationMu, so two mutations' flush windows may overlap; serializing
+// them behind a flush lock was rejected because a wedged writer would then stall
+// another mutator's return, which is the very class this design removes.
+//
+// What the engine ENFORCES rather than assumes: the writer is never invoked
+// while mutationMu, s.mu, or any ChainState / Mempool / PendingOutpointOwner
+// lock is held, so it may block or re-enter a non-diagnostic SyncEngine mutation
+// without stalling or deadlocking a mutator. Write errors are ignored: a
 // diagnostic never changes a consensus, persistence, rollback or mempool result.
+//
+// ONE carve-out: the terminal fail-closed latch (canonicalTransition.end)
+// retains the ChainState admission guard until restart, so that single flush
+// runs with that guard held. A writer that blocks or re-enters there must not
+// expect an admission-taking call to complete — nothing can pass that guard
+// again in this process either way, and every mutation entry point refuses at
+// mutationAllowed before touching it.
+//
 // The replacement is a race-free pointer store under s.mu; a flush already in
 // progress keeps the writer it snapshotted.
 func (s *SyncEngine) SetStderr(w io.Writer) {
@@ -931,8 +943,12 @@ func (s *SyncEngine) latchTerminalFault(cause error) {
 // mutationMu and receiving the latched fault. The admission guard that the
 // terminal state retains until restart is NOT released — that is the latch
 // itself, and no mutation path re-acquires it after this point.
+//
+// It is also the one record the batch caps may not evict (diagnoseTerminal):
+// losing it would leave an operator with shadow noise and a content-free
+// truncation marker as the only stderr trace of a node that latched shut.
 func (s *SyncEngine) reportTerminalTransition(diag *diagnosticBatch, reason string, cause error) {
-	s.diagnose(diag, "sync: canonical transition terminal (%s), admission stays closed until restart: %v\n", reason, cause)
+	s.diagnoseTerminal(diag, "sync: canonical transition terminal (%s), admission stays closed until restart: %v\n", reason, cause)
 }
 
 // rollbackRestoreFault marks a transition failure whose EXACT restore could not

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -323,6 +323,10 @@ func (s *SyncEngine) BootstrapCanonicalGenesisIfEmpty() error {
 	if s == nil {
 		return errors.New("sync engine is not initialized")
 	}
+	// Deferred BEFORE the mutationMu unlock so it runs AFTER it: the writer is
+	// invoked with no engine lock held. Every entry point repeats this order.
+	diag := &diagnosticBatch{}
+	defer s.flushDiagnostics(diag)
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
 	if err := s.mutationAllowed(); err != nil {
@@ -331,7 +335,7 @@ func (s *SyncEngine) BootstrapCanonicalGenesisIfEmpty() error {
 	if s.chainState.view().hasTip || s.cfg.ChainID != devnetGenesisChainID {
 		return nil
 	}
-	_, applyErr := s.applyBlock(devnetGenesisBlockBytes, nil)
+	_, applyErr := s.applyBlock(devnetGenesisBlockBytes, nil, diag)
 	if errors.Is(applyErr, errStoragePersistenceFault) || isAtomicWritePostCommit(applyErr) {
 		return applyErr
 	}
@@ -358,12 +362,14 @@ func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*Ch
 	if s == nil {
 		return nil, errors.New("sync engine is not initialized")
 	}
+	diag := &diagnosticBatch{}
+	defer s.flushDiagnostics(diag)
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
-	return s.applyBlock(blockBytes, prevTimestamps)
+	return s.applyBlock(blockBytes, prevTimestamps, diag)
 }
 
-func (s *SyncEngine) applyBlock(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
+func (s *SyncEngine) applyBlock(blockBytes []byte, prevTimestamps []uint64, diag *diagnosticBatch) (*ChainStateConnectSummary, error) {
 	if err := s.mutationAllowed(); err != nil {
 		return nil, err
 	}
@@ -371,7 +377,7 @@ func (s *SyncEngine) applyBlock(blockBytes []byte, prevTimestamps []uint64) (*Ch
 	if err != nil {
 		return nil, err
 	}
-	return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil)
+	return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil, diag)
 }
 
 // StockDevnetTargetSchedule reports whether the exact stock Phase-0 devnet
@@ -493,14 +499,16 @@ func (s *SyncEngine) SetMempool(mempool *Mempool) {
 	if s == nil {
 		return
 	}
+	diag := &diagnosticBatch{}
+	defer s.flushDiagnostics(diag)
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
 	if err := s.mutationAllowed(); err != nil {
-		s.reportMempoolBindingRejected(err)
+		s.reportMempoolBindingRejected(diag, err)
 		return
 	}
 	if err := s.bindMempoolUnderMutation(mempool); err != nil {
-		s.reportMempoolBindingRejected(err)
+		s.reportMempoolBindingRejected(diag, err)
 	}
 }
 
@@ -617,13 +625,26 @@ func checkOwnerNeverUsedLocked(owner *PendingOutpointOwner) error {
 }
 
 // reportMempoolBindingRejected makes a refused binding visible: the engine keeps
-// its previous binding, otherwise indistinguishable from an unwired caller.
-func (s *SyncEngine) reportMempoolBindingRejected(err error) {
-	_, _ = fmt.Fprintf(s.diagnosticWriter(), "sync: mempool binding rejected, engine binding unchanged: %v\n", err)
+// its previous binding, otherwise indistinguishable from an unwired caller. The
+// record is retained by the caller's batch and emitted after mutationMu is
+// released; the rejection itself mutates nothing.
+func (s *SyncEngine) reportMempoolBindingRejected(diag *diagnosticBatch, err error) {
+	s.diagnose(diag, "sync: mempool binding rejected, engine binding unchanged: %v\n", err)
 }
 
 // SetStderr sets the writer for non-fatal error diagnostics (e.g. mempool
-// post-acceptance failures). Defaults to io.Discard when not explicitly set.
+// post-acceptance failures). A nil writer maps to io.Discard, which is also the
+// default when SetStderr is never called.
+//
+// Contract for the supplied writer, which the engine ENFORCES rather than
+// assumes: it is never invoked while mutationMu, s.mu, the ChainState admission
+// guard, or any ChainState / Mempool / PendingOutpointOwner lock is held (see
+// flushDiagnostics for the single terminal-latch exception). A writer may
+// therefore block or re-enter a non-diagnostic SyncEngine mutation without
+// stalling or deadlocking another mutator, and its Write errors are ignored: a
+// diagnostic never changes a consensus, persistence, rollback or mempool result.
+// The replacement is a race-free pointer store under s.mu; a flush already in
+// progress keeps the writer it snapshotted.
 func (s *SyncEngine) SetStderr(w io.Writer) {
 	if s == nil {
 		return
@@ -774,10 +795,13 @@ func (s *SyncEngine) captureRollbackStateWithIndex(canonicalIndex []string) (syn
 // every canonical mutation serialize on mutationMu, which the entry point holds
 // throughout, so no reread can observe a different pointer set.
 type canonicalTransition struct {
-	engine           *SyncEngine
-	chainState       *ChainState
-	mempool          *Mempool
-	owner            *PendingOutpointOwner
+	engine     *SyncEngine
+	chainState *ChainState
+	mempool    *Mempool
+	owner      *PendingOutpointOwner
+	// diag is the entry point's bounded diagnostic batch. Producers under the
+	// guard append to it; nothing under the guard invokes the writer.
+	diag             *diagnosticBatch
 	generation       uint64
 	rollback         syncRollbackState
 	appliedHeight    uint64
@@ -790,7 +814,7 @@ type canonicalTransition struct {
 // under the guard. The caller holds mutationMu and MUST already have run
 // canonicalIndexPreflight, whose result it passes here: the fallible index read
 // belongs before any clone or consensus validation, not inside the guard.
-func (s *SyncEngine) beginCanonicalTransition(canonicalIndex []string) (*canonicalTransition, error) {
+func (s *SyncEngine) beginCanonicalTransition(canonicalIndex []string, diag *diagnosticBatch) (*canonicalTransition, error) {
 	if err := s.mutationAllowed(); err != nil {
 		return nil, err
 	}
@@ -819,6 +843,7 @@ func (s *SyncEngine) beginCanonicalTransition(canonicalIndex []string) (*canonic
 		chainState: chainState,
 		mempool:    mempool,
 		owner:      owner,
+		diag:       diag,
 		generation: generation,
 		rollback:   rollback,
 	}, nil
@@ -871,13 +896,13 @@ func (t *canonicalTransition) end(cause error) error {
 		return t.finish()
 	}
 	if t.engine.persistenceFaulted() {
-		t.engine.reportTerminalTransition("post-commit persistence fault", cause)
+		t.engine.reportTerminalTransition(t.diag, "post-commit persistence fault", cause)
 		return cause
 	}
 	var restoreFault *rollbackRestoreFault
 	if errors.As(cause, &restoreFault) {
 		t.engine.latchTerminalFault(cause)
-		t.engine.reportTerminalTransition("rollback restore failed", cause)
+		t.engine.reportTerminalTransition(t.diag, "rollback restore failed", cause)
 		return cause
 	}
 	t.abort()
@@ -900,8 +925,14 @@ func (s *SyncEngine) latchTerminalFault(cause error) {
 
 // reportTerminalTransition makes the fail-closed latch visible to an operator:
 // without it a latched node is indistinguishable from a merely hung one.
-func (s *SyncEngine) reportTerminalTransition(reason string, cause error) {
-	_, _ = fmt.Fprintf(s.diagnosticWriter(), "sync: canonical transition terminal (%s), admission stays closed until restart: %v\n", reason, cause)
+//
+// The record is retained by the entry point's batch and emitted once mutationMu
+// is released, so a blocked writer cannot stop a later mutator from acquiring
+// mutationMu and receiving the latched fault. The admission guard that the
+// terminal state retains until restart is NOT released — that is the latch
+// itself, and no mutation path re-acquires it after this point.
+func (s *SyncEngine) reportTerminalTransition(diag *diagnosticBatch, reason string, cause error) {
+	s.diagnose(diag, "sync: canonical transition terminal (%s), admission stays closed until restart: %v\n", reason, cause)
 }
 
 // rollbackRestoreFault marks a transition failure whose EXACT restore could not
@@ -1100,11 +1131,12 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	blockBytes []byte,
 	prevTimestamps []uint64,
 	target *canonicalApplyTarget,
+	diag *diagnosticBatch,
 ) (*ChainStateConnectSummary, error) {
 	if err := s.mutationAllowed(); err != nil {
 		return nil, err
 	}
-	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps, target)
+	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps, target, diag)
 	s.noteBlockApplyOutcome(outcome)
 	return summary, err
 }
@@ -1117,6 +1149,10 @@ type canonicalBlockApplyContext struct {
 	// canonicalIndex is the rollback preflight result, read before the clone
 	// below was connected so a local index fault outranks a consensus one.
 	canonicalIndex []string
+	// diag is the owning public mutation's bounded diagnostic batch, or nil for
+	// a caller outside a mutation (which holds no engine lock and may write
+	// directly). The PV shadow producers read it from here.
+	diag *diagnosticBatch
 }
 
 // applyCanonicalParsedBlockTracked fully validates one direct-connect candidate
@@ -1130,8 +1166,9 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	blockBytes []byte,
 	prevTimestamps []uint64,
 	target *canonicalApplyTarget,
+	diag *diagnosticBatch,
 ) (*ChainStateConnectSummary, blockApplyMetricOutcome, error) {
-	ctx, outcome, err := s.prepareCanonicalBlockApply(pb, target)
+	ctx, outcome, err := s.prepareCanonicalBlockApply(pb, target, diag)
 	if err != nil {
 		return nil, outcome, err
 	}
@@ -1179,7 +1216,7 @@ func (s *SyncEngine) commitPreparedBlock(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 ) error {
-	tr, err := s.beginCanonicalTransition(ctx.canonicalIndex)
+	tr, err := s.beginCanonicalTransition(ctx.canonicalIndex, ctx.diag)
 	if err != nil {
 		return err
 	}
@@ -1210,7 +1247,7 @@ func (s *SyncEngine) commitPreparedBlockUnderGuard(
 	// claims are gone before any observer can see the new canonical tip.
 	if tr.mempool != nil {
 		if err := tr.mempool.applyConnectedBlockParsed(pb); err != nil {
-			_, _ = fmt.Fprintf(s.diagnosticWriter(), "sync: standard mempool cleanup failed at height %d, rolling back: %v\n", ctx.blockHeight, err)
+			s.diagnose(tr.diag, "sync: standard mempool cleanup failed at height %d, rolling back: %v\n", ctx.blockHeight, err)
 			return s.rollbackApplyBlock(err, tr.rollback)
 		}
 	}
@@ -1264,7 +1301,7 @@ func (s *SyncEngine) recheckLiveStoreTipIdentity(prior canonicalTipScalars) erro
 	return nil
 }
 
-func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, target *canonicalApplyTarget) (canonicalBlockApplyContext, blockApplyMetricOutcome, error) {
+func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, target *canonicalApplyTarget, diag *diagnosticBatch) (canonicalBlockApplyContext, blockApplyMetricOutcome, error) {
 	if err := s.validateCanonicalBlockApplyReady(pb); err != nil {
 		return canonicalBlockApplyContext{}, blockApplyMetricNone, err
 	}
@@ -1301,6 +1338,7 @@ func (s *SyncEngine) prepareCanonicalBlockApply(pb *consensus.ParsedBlock, targe
 		expectedTarget: expectedTarget,
 		prevState:      prevState,
 		canonicalIndex: canonicalIndex,
+		diag:           diag,
 	}, blockApplyMetricNone, nil
 }
 

--- a/clients/go/node/sync_diagnostics.go
+++ b/clients/go/node/sync_diagnostics.go
@@ -1,0 +1,109 @@
+package node
+
+import "fmt"
+
+// diagnosticBatchMaxRecords and diagnosticBatchMaxBytes bound what ONE public
+// SyncEngine mutation may retain for its post-unlock flush. They cap RETAINED
+// diagnostic output only: no consensus, chainstate, mempool or owner data is
+// bounded, dropped or reordered.
+const (
+	diagnosticBatchMaxRecords = 64
+	diagnosticBatchMaxBytes   = 64 << 10
+)
+
+// diagnosticBatchTruncatedRecord is the ONE fixed record representing every
+// dropped record of a mutation. Its content is deliberately constant: a count or
+// byte total would vary with how far a timing-dependent producer got, making the
+// same mutation emit different bytes across runs.
+const diagnosticBatchTruncatedRecord = "sync: diagnostics truncated for this mutation; later records dropped\n"
+
+// diagnosticBatch is the bounded diagnostic buffer owned by exactly one public
+// SyncEngine mutation. Producers beneath that mutation append to it instead of
+// invoking the configured writer, so a caller-supplied io.Writer that blocks or
+// re-enters the engine cannot run while mutationMu, s.mu, the admission guard,
+// or any ChainState / Mempool / owner lock is held. Below the caps it preserves
+// producer order and per-record bytes exactly: a delay, not a rewrite.
+//
+// It is NOT shared: each entry point stack-allocates its own batch and passes a
+// pointer down its own call tree, so no lock protects it and no second goroutine
+// observes it. There is no ambient, goroutine-local or engine-global "current
+// batch", and the batch confers no mutation authority.
+type diagnosticBatch struct {
+	records   []string
+	bytes     int
+	truncated bool
+	flushed   bool
+}
+
+// append retains one already-formatted record, or drops it and arms the single
+// truncation record. Once either cap is reached the batch is CLOSED: later
+// records are dropped too, so a large record cannot be skipped in favour of a
+// smaller one behind it, which would reorder what an operator reads.
+func (b *diagnosticBatch) append(record string) {
+	if b == nil || b.truncated {
+		return
+	}
+	if len(b.records) >= diagnosticBatchMaxRecords || b.bytes+len(record) > diagnosticBatchMaxBytes {
+		b.truncated = true
+		return
+	}
+	b.records = append(b.records, record)
+	b.bytes += len(record)
+}
+
+// diagnose emits one operator diagnostic. With a batch — every producer reached
+// beneath a public mutation — the record is retained for that mutation's single
+// post-unlock flush and NO caller-supplied writer runs here.
+//
+// With batch == nil the record is written immediately through the synchronized
+// writer snapshot. That direct form is legal ONLY for a caller holding none of
+// the locks in the engine's isolation contract: mutationMu, s.mu, the ChainState
+// admission guard, and any ChainState / Mempool / PendingOutpointOwner lock.
+// Every production producer reaches this through a batch (see the call-site
+// census in sync_stderr_test.go); the direct form serves callers outside a
+// mutation, which hold no engine lock by construction.
+func (s *SyncEngine) diagnose(batch *diagnosticBatch, format string, args ...any) {
+	record := fmt.Sprintf(format, args...)
+	if batch != nil {
+		batch.append(record)
+		return
+	}
+	// fmt.Fprint with one string operand writes exactly the record's bytes in
+	// one Write call, as the pre-existing fmt.Fprintf sites did.
+	_, _ = fmt.Fprint(s.diagnosticWriter(), record)
+}
+
+// flushDiagnostics writes one mutation's retained records, in producer order,
+// through ONE writer snapshot, and is the only place a batched record reaches a
+// caller-supplied io.Writer.
+//
+// The caller MUST have released mutationMu and every inner canonical, admission,
+// state, mempool and owner lock first; entry points arrange that by deferring
+// this BEFORE they defer their mutationMu unlock, so it runs last. A writer that
+// blocks here therefore delays only the originating call — another mutator
+// acquires mutationMu and reaches its own result, and a writer that re-enters a
+// non-diagnostic SyncEngine mutation cannot deadlock. The single exception is the
+// terminal fail-closed latch, which retains the admission guard until restart by
+// pre-existing design (canonicalTransition.end): that flush has mutationMu and
+// s.mu free but the latch still held — nothing can acquire that guard again
+// either way, and every entry point then fails closed through mutationAllowed
+// without touching it.
+//
+// Writer errors stay best-effort — they never replace or alter the mutation
+// result — and flushing is idempotent: a batch is emitted at most once.
+func (s *SyncEngine) flushDiagnostics(batch *diagnosticBatch) {
+	if batch == nil || batch.flushed {
+		return
+	}
+	batch.flushed = true
+	if len(batch.records) == 0 && !batch.truncated {
+		return
+	}
+	writer := s.diagnosticWriter()
+	for _, record := range batch.records {
+		_, _ = fmt.Fprint(writer, record)
+	}
+	if batch.truncated {
+		_, _ = fmt.Fprint(writer, diagnosticBatchTruncatedRecord)
+	}
+}

--- a/clients/go/node/sync_diagnostics.go
+++ b/clients/go/node/sync_diagnostics.go
@@ -1,6 +1,9 @@
 package node
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
 // diagnosticBatchMaxRecords and diagnosticBatchMaxBytes bound what ONE public
 // SyncEngine mutation may retain for its post-unlock flush. They cap RETAINED
@@ -44,7 +47,7 @@ type diagnosticBatch struct {
 
 // append retains one already-formatted record, or drops it and arms the single
 // truncation record. Once either cap is reached the batch is CLOSED: later
-// records are dropped too, so a large record cannot be skipped in favour of a
+// records are dropped too, so a large record cannot be skipped in favor of a
 // smaller one behind it, which would reorder what an operator reads.
 func (b *diagnosticBatch) append(record string) {
 	if b == nil || b.truncated {
@@ -130,15 +133,22 @@ func (s *SyncEngine) flushDiagnostics(batch *diagnosticBatch) {
 	for _, record := range batch.records {
 		_, _ = fmt.Fprint(writer, record)
 	}
-	if batch.truncated {
+	batch.flushTail(writer)
+}
+
+// flushTail emits what follows the retained records: the truncation marker for
+// anything the caps dropped, then the terminal-latch record.
+//
+// The terminal record goes last, which IS its producer order: it is emitted by
+// canonicalTransition.end, after every other producer of that mutation (PV
+// shadow runs before the transition opens, the cleanup report inside it), and
+// the only producer that could follow it — the reorg requeue — is skipped
+// entirely when end returns a terminal cause.
+func (b *diagnosticBatch) flushTail(writer io.Writer) {
+	if b.truncated {
 		_, _ = fmt.Fprint(writer, diagnosticBatchTruncatedRecord)
 	}
-	// The terminal record goes last, which IS its producer order: it is emitted
-	// by canonicalTransition.end, after every other producer of that mutation
-	// (PV shadow runs before the transition opens, the cleanup report inside it),
-	// and the only producer that could follow it — the reorg requeue — is
-	// skipped entirely when end returns a terminal cause.
-	if batch.terminal != "" {
-		_, _ = fmt.Fprint(writer, batch.terminal)
+	if b.terminal != "" {
+		_, _ = fmt.Fprint(writer, b.terminal)
 	}
 }

--- a/clients/go/node/sync_diagnostics.go
+++ b/clients/go/node/sync_diagnostics.go
@@ -33,6 +33,13 @@ type diagnosticBatch struct {
 	bytes     int
 	truncated bool
 	flushed   bool
+	// terminal is the fail-closed latch record, in its OWN slot because it is the
+	// one record the caps must never evict: a >=64-row reorg with systematic
+	// PV-shadow mismatch fills the batch during preparation, and a capped
+	// terminal record would leave stderr showing shadow noise plus a content-free
+	// truncation marker while the node latched shut. It stays bounded — a fixed
+	// format plus the latch cause, and canonicalTransition.end runs once.
+	terminal string
 }
 
 // append retains one already-formatted record, or drops it and arms the single
@@ -59,9 +66,14 @@ func (b *diagnosticBatch) append(record string) {
 // writer snapshot. That direct form is legal ONLY for a caller holding none of
 // the locks in the engine's isolation contract: mutationMu, s.mu, the ChainState
 // admission guard, and any ChainState / Mempool / PendingOutpointOwner lock.
-// Every production producer reaches this through a batch (see the call-site
-// census in sync_stderr_test.go); the direct form serves callers outside a
-// mutation, which hold no engine lock by construction.
+//
+// As of this change the direct form has NO production caller: every production
+// producer is reached beneath a public mutation and therefore carries a batch,
+// and the only batch-free caller of a producer is test code (the raw-byte
+// requeueDisconnectedTransactions has no production call site at all). That is a
+// property of the current call graph — established by grepping every producer's
+// callers, not by any mechanism here — so a new batch-free production caller
+// must re-prove the lock-freedom above.
 func (s *SyncEngine) diagnose(batch *diagnosticBatch, format string, args ...any) {
 	record := fmt.Sprintf(format, args...)
 	if batch != nil {
@@ -70,6 +82,21 @@ func (s *SyncEngine) diagnose(batch *diagnosticBatch, format string, args ...any
 	}
 	// fmt.Fprint with one string operand writes exactly the record's bytes in
 	// one Write call, as the pre-existing fmt.Fprintf sites did.
+	_, _ = fmt.Fprint(s.diagnosticWriter(), record)
+}
+
+// diagnoseTerminal is diagnose for the ONE record class the caps may not evict:
+// the fail-closed terminal-latch report. It bypasses the record and byte caps
+// into the batch's dedicated slot, keeping the retained output bounded because
+// exactly one terminal record exists per mutation. Everything else — the direct
+// write when there is no batch, the bytes, the writer contract — is identical to
+// diagnose.
+func (s *SyncEngine) diagnoseTerminal(batch *diagnosticBatch, format string, args ...any) {
+	record := fmt.Sprintf(format, args...)
+	if batch != nil {
+		batch.terminal = record
+		return
+	}
 	_, _ = fmt.Fprint(s.diagnosticWriter(), record)
 }
 
@@ -96,7 +123,7 @@ func (s *SyncEngine) flushDiagnostics(batch *diagnosticBatch) {
 		return
 	}
 	batch.flushed = true
-	if len(batch.records) == 0 && !batch.truncated {
+	if len(batch.records) == 0 && !batch.truncated && batch.terminal == "" {
 		return
 	}
 	writer := s.diagnosticWriter()
@@ -105,5 +132,13 @@ func (s *SyncEngine) flushDiagnostics(batch *diagnosticBatch) {
 	}
 	if batch.truncated {
 		_, _ = fmt.Fprint(writer, diagnosticBatchTruncatedRecord)
+	}
+	// The terminal record goes last, which IS its producer order: it is emitted
+	// by canonicalTransition.end, after every other producer of that mutation
+	// (PV shadow runs before the transition opens, the cleanup report inside it),
+	// and the only producer that could follow it — the reorg requeue — is
+	// skipped entirely when end returns a terminal cause.
+	if batch.terminal != "" {
+		_, _ = fmt.Fprint(writer, batch.terminal)
 	}
 }

--- a/clients/go/node/sync_disconnect.go
+++ b/clients/go/node/sync_disconnect.go
@@ -20,15 +20,17 @@ func (s *SyncEngine) DisconnectTip() (*ChainStateDisconnectSummary, error) {
 	if s == nil {
 		return nil, errors.New("sync engine is not initialized")
 	}
+	diag := &diagnosticBatch{}
+	defer s.flushDiagnostics(diag)
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
-	return s.disconnectTip()
+	return s.disconnectTip(diag)
 }
 
 // disconnectTip runs a standalone disconnect as ONE canonical transition: it
 // advances a single generation, commits the prepared stable tip under the same
 // guard, and adds no requeue and no full-Mempool revalidation policy.
-func (s *SyncEngine) disconnectTip() (*ChainStateDisconnectSummary, error) {
+func (s *SyncEngine) disconnectTip(diag *diagnosticBatch) (*ChainStateDisconnectSummary, error) {
 	canonicalIndex, err := s.canonicalIndexPreflight()
 	if err != nil {
 		return nil, err
@@ -37,7 +39,7 @@ func (s *SyncEngine) disconnectTip() (*ChainStateDisconnectSummary, error) {
 	if err != nil {
 		return nil, err
 	}
-	tr, err := s.beginCanonicalTransition(canonicalIndex)
+	tr, err := s.beginCanonicalTransition(canonicalIndex, diag)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/go/node/sync_disconnect_test.go
+++ b/clients/go/node/sync_disconnect_test.go
@@ -314,7 +314,7 @@ func mustBeginCanonicalTransition(t *testing.T, engine *SyncEngine) *canonicalTr
 	if err != nil {
 		t.Fatalf("canonicalIndexPreflight: %v", err)
 	}
-	tr, err := engine.beginCanonicalTransition(canonicalIndex)
+	tr, err := engine.beginCanonicalTransition(canonicalIndex, nil)
 	if err != nil {
 		t.Fatalf("beginCanonicalTransition: %v", err)
 	}

--- a/clients/go/node/sync_persistence_fault_test.go
+++ b/clients/go/node/sync_persistence_fault_test.go
@@ -330,3 +330,67 @@ func TestSyncEngineRollbackAndDisconnectPostCommitFaultsDoNotCompensate(t *testi
 		requireAtomicTest(t, err == nil && !ok, "cache tip=%v err=%v", ok, err)
 	})
 }
+
+// TestSyncEngineTerminalFaultedSnapshot pins the read-only terminal-fault status
+// method against the EXISTING latch, for BOTH terminal causes: an ambiguous
+// atomic post-commit persistence fault, and a transition whose exact rollback
+// restore could not be proven. Both project to the same single boolean, which is
+// what GET /health renders as terminal_fault / restart_required.
+//
+// The status method is proven not to be a second fault authority: reading it
+// repeatedly neither installs, clears nor rewrites the latched cause, and a nil
+// engine reports false rather than a fabricated fault.
+func TestSyncEngineTerminalFaultedSnapshot(t *testing.T) {
+	var nilEngine *SyncEngine
+	requireAtomicTest(t, !nilEngine.TerminalFaulted(), "nil engine reported a terminal fault")
+
+	t.Run("post_commit_persistence_fault", func(t *testing.T) {
+		engine, store, _ := newPersistenceFaultEngine(t)
+		requireAtomicTest(t, !engine.TerminalFaulted(), "fresh engine reported a terminal fault")
+		failed := false
+		withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+			sync := ops.syncParent
+			ops.syncParent = func(parent string) error {
+				if !failed && parent == store.rootPath {
+					failed = true
+					return os.ErrPermission
+				}
+				return sync(parent)
+			}
+		})
+		_, applyErr := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil)
+		fault := requirePersistenceFault(t, applyErr, atomicWriteOverwrite)
+		requireAtomicTest(t, failed && engine.TerminalFaulted(), "injected=%v terminal=%v", failed, engine.TerminalFaulted())
+		// Reading the status is not a state transition: the latched fault
+		// pointer and its cause survive repeated reads unchanged.
+		for i := 0; i < 3; i++ {
+			requireAtomicTest(t, engine.TerminalFaulted(), "terminal status flipped on read %d", i)
+		}
+		requireAtomicTest(t, engine.persistenceFault == fault && errors.Is(fault.cause, os.ErrPermission), "fault=%+v", engine.persistenceFault)
+	})
+
+	t.Run("rollback_restore_fault", func(t *testing.T) {
+		engine, store, _ := newPersistenceFaultEngine(t)
+		requireAtomicTest(t, !engine.TerminalFaulted(), "fresh engine reported a terminal fault")
+		blocked := 0
+		withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+			open := ops.openScratch
+			ops.openScratch = func(path string, flag int, mode os.FileMode) (atomicWriteScratchFile, error) {
+				// Both writes fail BEFORE their namespace commit, so neither is
+				// an ambiguous post-commit fault: the block write fails the
+				// apply, and the canonical-index write fails its rollback
+				// restore. That pair is the rollbackRestoreFault latch.
+				if dir := filepath.Dir(path); dir == store.blocksDir || dir == store.rootPath {
+					blocked++
+					return nil, syscall.ENOSPC
+				}
+				return open(path, flag, mode)
+			}
+		})
+		_, applyErr := engine.ApplyBlock(DevnetGenesisBlockBytes(), nil)
+		var restoreFault *rollbackRestoreFault
+		requireAtomicTest(t, blocked >= 2 && errors.As(applyErr, &restoreFault), "blocked=%d apply=%v", blocked, applyErr)
+		requireAtomicTest(t, engine.TerminalFaulted() && engine.persistenceFault != nil, "terminal=%v fault=%+v", engine.TerminalFaulted(), engine.persistenceFault)
+		requireAtomicTest(t, errors.Is(engine.persistenceFault.cause, applyErr), "latched cause=%v, want the rollback restore fault %v", engine.persistenceFault.cause, applyErr)
+	})
+}

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -46,7 +46,7 @@ func (s *SyncEngine) runPVShadowOnError(blockBytes []byte, prevTimestamps []uint
 	seqCode, parCode := txErrCode(seqErr), txErrCode(parErr)
 	if seqCode != parCode {
 		s.recordPVShadowMismatch(fmt.Sprintf("pv_shadow mismatch(height=%d): seq_err=%s par_err=%s", blockHeight, seqCode, parCode))
-		_, _ = fmt.Fprintf(s.diagnosticWriter(), "pv_shadow: mismatch height=%d seq_err=%s par_err=%s\n", blockHeight, seqCode, parCode)
+		s.diagnose(ctx.diag, "pv_shadow: mismatch height=%d seq_err=%s par_err=%s\n", blockHeight, seqCode, parCode)
 		if parErr == nil {
 			s.pvTelemetry.RecordMismatchVerdict()
 		} else {
@@ -77,11 +77,11 @@ func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []ui
 	}
 	if parErr != nil {
 		s.recordPVShadowMismatch(fmt.Sprintf("pv_shadow mismatch(height=%d): seq_ok par_err=%s", blockHeight, txErrCode(parErr)))
-		_, _ = fmt.Fprintf(s.diagnosticWriter(), "pv_shadow: mismatch height=%d seq_ok par_err=%s\n", blockHeight, txErrCode(parErr))
+		s.diagnose(ctx.diag, "pv_shadow: mismatch height=%d seq_ok par_err=%s\n", blockHeight, txErrCode(parErr))
 		s.pvTelemetry.RecordMismatchVerdict()
 	} else if parSummary.PostStateDigest != seqSummary.PostStateDigest {
 		s.recordPVShadowMismatch(fmt.Sprintf("pv_shadow mismatch(height=%d): post_state_digest", blockHeight))
-		_, _ = fmt.Fprintf(s.diagnosticWriter(), "pv_shadow: mismatch height=%d post_state_digest\n", blockHeight)
+		s.diagnose(ctx.diag, "pv_shadow: mismatch height=%d post_state_digest\n", blockHeight)
 		s.pvTelemetry.RecordMismatchState()
 	}
 }

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -29,6 +29,8 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 	if s == nil {
 		return nil, errors.New("sync engine is not initialized")
 	}
+	diag := &diagnosticBatch{}
+	defer s.flushDiagnostics(diag)
 	s.mutationMu.Lock()
 	defer s.mutationMu.Unlock()
 	if err := s.mutationAllowed(); err != nil {
@@ -39,7 +41,7 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 		return nil, err
 	}
 
-	if summary, handled, err := s.applyDirectBlockIfPossible(pb, blockBytes, prevTimestamps); handled {
+	if summary, handled, err := s.applyDirectBlockIfPossible(pb, blockBytes, prevTimestamps, diag); handled {
 		return summary, err
 	}
 	branch, commonAncestorHeight, switchToBranch, candidateHeight, err := s.evaluateSideBranch(blockHash, blockBytes, pb)
@@ -49,7 +51,7 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 	if !switchToBranch {
 		return s.storeSideBlockAndSummary(branch, commonAncestorHeight, candidateHeight)
 	}
-	return s.applyPreferredBranch(branch, commonAncestorHeight)
+	return s.applyPreferredBranch(branch, commonAncestorHeight, diag)
 }
 
 func parseReorgBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, error) {
@@ -138,6 +140,7 @@ func (s *SyncEngine) applyDirectBlockIfPossible(
 	pb *consensus.ParsedBlock,
 	blockBytes []byte,
 	prevTimestamps []uint64,
+	diag *diagnosticBatch,
 ) (*ChainStateConnectSummary, bool, error) {
 	var zero [32]byte
 	view := s.chainState.view()
@@ -146,10 +149,10 @@ func (s *SyncEngine) applyDirectBlockIfPossible(
 		if pb.Header.PrevBlockHash != zero {
 			return nil, true, ErrParentNotFound
 		}
-		summary, err := s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil)
+		summary, err := s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps, nil, diag)
 		return summary, true, err
 	case pb.Header.PrevBlockHash == view.tipHash:
-		summary, err := s.applyDirectTipBlock(pb, blockBytes, view)
+		summary, err := s.applyDirectTipBlock(pb, blockBytes, view, diag)
 		return summary, true, err
 	default:
 		return nil, false, nil
@@ -160,7 +163,7 @@ func (s *SyncEngine) applyDirectBlockIfPossible(
 // Acquisition order is target-then-MTP: the target context must precede the
 // RUB-647 canonical MTP window so a target-context failure short-circuits
 // before any MTP state is read. The height-0 genesis branch never reaches here.
-func (s *SyncEngine) applyDirectTipBlock(pb *consensus.ParsedBlock, blockBytes []byte, view chainStateView) (*ChainStateConnectSummary, error) {
+func (s *SyncEngine) applyDirectTipBlock(pb *consensus.ParsedBlock, blockBytes []byte, view chainStateView, diag *diagnosticBatch) (*ChainStateConnectSummary, error) {
 	nextHeight, _, err := nextBlockContextFromFields(view.hasTip, view.height, view.tipHash)
 	if err != nil {
 		return nil, err
@@ -176,7 +179,7 @@ func (s *SyncEngine) applyDirectTipBlock(pb *consensus.ParsedBlock, blockBytes [
 	if err != nil {
 		return nil, err
 	}
-	return s.applyCanonicalParsedBlock(pb, blockBytes, canonicalPrevTimestamps, targetCtx)
+	return s.applyCanonicalParsedBlock(pb, blockBytes, canonicalPrevTimestamps, targetCtx, diag)
 }
 
 func (s *SyncEngine) shouldSwitchToBranch(
@@ -265,16 +268,17 @@ type createdUtxo struct {
 func (s *SyncEngine) applyPreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
+	diag *diagnosticBatch,
 ) (*ChainStateConnectSummary, error) {
 	canonicalIndex, err := s.canonicalIndexPreflight()
 	if err != nil {
 		return nil, err
 	}
-	rows, preparedDisconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight)
+	rows, preparedDisconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight, diag)
 	if err != nil {
 		return nil, err
 	}
-	tr, err := s.beginCanonicalTransition(canonicalIndex)
+	tr, err := s.beginCanonicalTransition(canonicalIndex, diag)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +286,9 @@ func (s *SyncEngine) applyPreferredBranch(
 	if endErr := tr.end(err); endErr != nil {
 		return nil, endErr
 	}
-	s.requeueVerifiedDisconnectedTransactions(preparedDisconnectedBlocks)
+	// Runs after the transition released the admission guard but still under the
+	// entry point's mutationMu, so its failures join the same batch.
+	s.requeueVerifiedDisconnectedTransactions(preparedDisconnectedBlocks, diag)
 	s.noteBlockApplyAcceptedN(uint64(len(rows)))
 	s.noteReorg(reorgDepth)
 	if summary != nil {
@@ -352,6 +358,7 @@ func (s *SyncEngine) precleanPreferredBranch(tr *canonicalTransition, rows []pre
 func (s *SyncEngine) preparePreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
+	diag *diagnosticBatch,
 ) ([]preparedBranchBlock, []verifiedStoredBlock, uint64, error) {
 	rolling := cloneChainState(s.chainState)
 	if rolling == nil {
@@ -373,7 +380,7 @@ func (s *SyncEngine) preparePreferredBranch(
 	for i, item := range branch {
 		// The rolling state carries row i-1's post-state into row i, matching
 		// exactly what the guard publishes one row at a time.
-		row, rowErr := s.prepareBranchRow(rolling, item, commonAncestorHeight+1+uint64(i), slidingTs)
+		row, rowErr := s.prepareBranchRow(rolling, item, commonAncestorHeight+1+uint64(i), slidingTs, diag)
 		if rowErr != nil {
 			return nil, nil, 0, rowErr
 		}
@@ -408,6 +415,7 @@ func (s *SyncEngine) prepareBranchRow(
 	item reorgBranchBlock,
 	height uint64,
 	prevTimestamps []uint64,
+	diag *diagnosticBatch,
 ) (preparedBranchBlock, error) {
 	targetCtx, err := s.targetContextForCandidate(item.header.PrevBlockHash, height)
 	if err != nil {
@@ -423,6 +431,7 @@ func (s *SyncEngine) prepareBranchRow(
 		blockHash:      item.hash,
 		expectedTarget: targetCtx.expected,
 		prevState:      s.pvShadowPreState(rolling),
+		diag:           diag,
 	}
 	summary, err := rolling.ConnectBlockWithSuiteContext(
 		item.blockBytes,
@@ -820,16 +829,16 @@ func (s *SyncEngine) syntheticSideChainSummary(height uint64, blockHash [32]byte
 	}
 }
 
-func (s *SyncEngine) requeueVerifiedDisconnectedTransactions(disconnectedBlocks []verifiedStoredBlock) {
+func (s *SyncEngine) requeueVerifiedDisconnectedTransactions(disconnectedBlocks []verifiedStoredBlock, diag *diagnosticBatch) {
 	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
 	for _, block := range disconnectedBlocks {
 		parsedBlocks = append(parsedBlocks, block.parsed)
 	}
-	s.requeueParsedDisconnectedTransactions(parsedBlocks)
+	s.requeueParsedDisconnectedTransactions(parsedBlocks, diag)
 }
 
 // requeueDisconnectedTransactions is for raw-byte callers; reorgs retain parses.
-func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte) {
+func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte, diag *diagnosticBatch) {
 	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
 	for _, blockBytes := range disconnectedBlocks {
 		parsed, err := consensus.ParseBlockBytes(blockBytes)
@@ -838,14 +847,18 @@ func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte
 		}
 		parsedBlocks = append(parsedBlocks, parsed)
 	}
-	s.requeueParsedDisconnectedTransactions(parsedBlocks)
+	s.requeueParsedDisconnectedTransactions(parsedBlocks, diag)
 }
 
 // requeueParsedDisconnectedTransactions MUST NOT be called under the canonical
 // transition guard: it routes to Mempool.AddReorgTx, which takes
 // ChainState.admissionMu.RLock, and sync.RWMutex is not reentrant. Its only
 // caller runs it after the transition released that guard.
-func (s *SyncEngine) requeueParsedDisconnectedTransactions(disconnectedBlocks []*consensus.ParsedBlock) {
+//
+// diag is the owning mutation's batch when a public entry point drives this
+// (the reorg path), or nil for a caller outside a mutation, which holds none of
+// the engine's locks and may therefore write directly.
+func (s *SyncEngine) requeueParsedDisconnectedTransactions(disconnectedBlocks []*consensus.ParsedBlock, diag *diagnosticBatch) {
 	if s == nil || s.mempool == nil || len(disconnectedBlocks) == 0 {
 		return
 	}
@@ -857,7 +870,7 @@ func (s *SyncEngine) requeueParsedDisconnectedTransactions(disconnectedBlocks []
 		}
 		for _, txBytes := range txs {
 			if err := s.mempool.AddReorgTx(txBytes); err != nil {
-				_, _ = fmt.Fprintf(s.diagnosticWriter(), "mempool: requeue-tx: %v\n", err)
+				s.diagnose(diag, "mempool: requeue-tx: %v\n", err)
 			}
 		}
 	}

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -838,7 +838,10 @@ func (s *SyncEngine) requeueVerifiedDisconnectedTransactions(disconnectedBlocks 
 }
 
 // requeueDisconnectedTransactions is for raw-byte callers; reorgs retain parses.
-func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte, diag *diagnosticBatch) {
+// It has no production call site — the reorg path uses the verified variant with
+// its mutation's batch — so it takes no batch and emits directly, which is legal
+// exactly because its callers hold none of the engine's locks.
+func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte) {
 	parsedBlocks := make([]*consensus.ParsedBlock, 0, len(disconnectedBlocks))
 	for _, blockBytes := range disconnectedBlocks {
 		parsed, err := consensus.ParseBlockBytes(blockBytes)
@@ -847,7 +850,7 @@ func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte
 		}
 		parsedBlocks = append(parsedBlocks, parsed)
 	}
-	s.requeueParsedDisconnectedTransactions(parsedBlocks, diag)
+	s.requeueParsedDisconnectedTransactions(parsedBlocks, nil)
 }
 
 // requeueParsedDisconnectedTransactions MUST NOT be called under the canonical

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -1067,7 +1067,7 @@ func TestRequeueDisconnectedTransactionsUsesAdmissionFeeFloor(t *testing.T) {
 		txBelowFloor,
 	)
 
-	engine.requeueDisconnectedTransactions([][]byte{block}, nil)
+	engine.requeueDisconnectedTransactions([][]byte{block})
 
 	if !strings.Contains(stderr.String(), "mempool fee below rolling minimum") {
 		t.Fatalf("expected rolling-floor rejection in stderr, got %q", stderr.String())

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -762,7 +762,7 @@ func TestCollectBranchToCanonicalPropagatesNonNotExistErrors(t *testing.T) {
 
 func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 	var nilEngine *SyncEngine
-	if _, err := nilEngine.applyCanonicalParsedBlock(nil, nil, nil, nil); err == nil {
+	if _, err := nilEngine.applyCanonicalParsedBlock(nil, nil, nil, nil, nil); err == nil {
 		t.Fatalf("expected nil sync engine error")
 	}
 
@@ -782,7 +782,7 @@ func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 	}
 
 	engine := newEmptyEngine(t, devnetGenesisChainID)
-	if _, err := engine.applyCanonicalParsedBlock(nil, nil, nil, nil); err == nil {
+	if _, err := engine.applyCanonicalParsedBlock(nil, nil, nil, nil, nil); err == nil {
 		t.Fatalf("expected nil parsed block error")
 	}
 
@@ -1004,7 +1004,7 @@ func TestRequeueDisconnectedTransactionsUsesTipDownOrderAndContinuesAfterReject(
 	engine.requeueVerifiedDisconnectedTransactions([]verifiedStoredBlock{
 		{blockBytes: []byte("not parsed again"), parsed: highParsed},
 		{blockBytes: []byte("not parsed again"), parsed: lowParsed},
-	})
+	}, nil)
 
 	if !strings.Contains(stderr.String(), "mempool: requeue-tx:") {
 		t.Fatalf("expected duplicate requeue rejection to be logged, got %q", stderr.String())
@@ -1067,7 +1067,7 @@ func TestRequeueDisconnectedTransactionsUsesAdmissionFeeFloor(t *testing.T) {
 		txBelowFloor,
 	)
 
-	engine.requeueDisconnectedTransactions([][]byte{block})
+	engine.requeueDisconnectedTransactions([][]byte{block}, nil)
 
 	if !strings.Contains(stderr.String(), "mempool fee below rolling minimum") {
 		t.Fatalf("expected rolling-floor rejection in stderr, got %q", stderr.String())
@@ -3009,7 +3009,7 @@ func TestApplyCanonicalParsedBlockRollsBackWhenCanonicalReportFails(t *testing.T
 		Txs:         completeDASetTxsForCount(consensus.MAX_DA_BATCHES_PER_BLOCK + 1),
 	}
 
-	summary, outcome, err := engine.applyCanonicalParsedBlockTracked(overloaded, blockBytes, nil, nil)
+	summary, outcome, err := engine.applyCanonicalParsedBlockTracked(overloaded, blockBytes, nil, nil, nil)
 	if err == nil {
 		t.Fatal("over-cap canonical-applied report was accepted")
 	}
@@ -3632,7 +3632,7 @@ func TestPreparePreferredBranchRetainsCompactRowsWithoutUtxoSnapshots(t *testing
 	liveUtxos, liveUtxoHash := len(f.engine.chainState.Utxos), f.engine.chainState.UtxoSetHash()
 
 	branch := f.storedSideBranch(t, forkHash, forkHeight+1, forkGenerated, 2)
-	rows, disconnected, reorgDepth, err := f.engine.preparePreferredBranch(branch, forkHeight)
+	rows, disconnected, reorgDepth, err := f.engine.preparePreferredBranch(branch, forkHeight, nil)
 	if err != nil {
 		t.Fatalf("preparePreferredBranch: %v", err)
 	}

--- a/clients/go/node/sync_status.go
+++ b/clients/go/node/sync_status.go
@@ -53,6 +53,20 @@ func (s *SyncEngine) ReorgCount() uint64 {
 	return s.reorgCount
 }
 
+// TerminalFaulted reports whether this engine has latched the terminal storage
+// persistence fault that closes admission until the node is restarted. It is the
+// read-only projection of the EXISTING latch (the same one mutationAllowed fails
+// closed on), for operator surfaces such as GET /health.
+//
+// It exposes only the boolean: the latched cause is never returned, copied or
+// rendered, and the call neither installs, clears, replaces nor mutates a fault
+// — a latched engine stays latched and an unlatched one stays unlatched however
+// often this is called. Nil-safe like the other exported status readers: a nil
+// engine reports false, never a fabricated fault.
+func (s *SyncEngine) TerminalFaulted() bool {
+	return s.persistenceFaulted()
+}
+
 func (s *SyncEngine) BlockApplyCounts() BlockApplyCounts {
 	if s == nil {
 		return BlockApplyCounts{}

--- a/clients/go/node/sync_stderr_test.go
+++ b/clients/go/node/sync_stderr_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -73,13 +75,21 @@ func (w *lockedWriter) Write(p []byte) (int, error) {
 // stderrProducers returns every SyncEngine diagnostic producer reachable WITHOUT
 // an open canonical transition, each driven the way production drives it.
 //
+// "binding rejection" runs through the public SetMempool entry point, so it
+// exercises the BATCHED form: the record is retained and flushed after
+// mutationMu is released. The others are driven directly with a nil batch, which
+// is the direct form legal for a caller holding none of the engine's locks —
+// exactly the position these calls are in. TestSyncEngineDiagnosticWriter*
+// pin the batched isolation properties the direct form cannot show.
+//
 // One diagnostic site is deliberately absent: the standard-cleanup failure
 // report in commitPreparedBlockUnderGuard, which only fires inside an open
-// transition and would need that whole fixture here. It is exercised by
-// TestSyncPendingOutpointCleanupFailureLatchesTerminalFault, and it reads the
-// writer through the same audited helper — the repository call-site audit, not
-// this list, is what proves no SyncEngine site reads s.stderr raw. Adding a
-// transition-free diagnostic site without adding it here leaves it unproven.
+// transition and would need that whole fixture here. It is exercised, together
+// with the in-transition terminal report, by
+// TestSyncEngineTransitionDiagnosticsFlushAfterUnlock — the repository
+// call-site audit, not this list, is what proves no SyncEngine site reads
+// s.stderr raw. Adding a transition-free diagnostic site without adding it here
+// leaves it unproven.
 func stderrProducers(t *testing.T, f *pendingOutpointSyncFixture, spentBlock []byte, pvBlock []byte, pvCtx canonicalBlockApplyContext) map[string]func() {
 	t.Helper()
 	// A target the candidate's header cannot match, so the shadow's parallel
@@ -93,11 +103,11 @@ func stderrProducers(t *testing.T, f *pendingOutpointSyncFixture, spentBlock []b
 		"binding rejection": func() { f.engine.SetMempool(f.newPool(t)) },
 		// Terminal transition report: the fail-closed latch notice.
 		"terminal transition": func() {
-			f.engine.reportTerminalTransition("stderr probe", errors.New("probe cause"))
+			f.engine.reportTerminalTransition(nil, "stderr probe", errors.New("probe cause"))
 		},
 		// Requeue diagnostic: the block's inputs are already spent on chain, so
 		// readmission fails and the failure is reported.
-		"requeue": func() { f.engine.requeueDisconnectedTransactions([][]byte{spentBlock}) },
+		"requeue": func() { f.engine.requeueDisconnectedTransactions([][]byte{spentBlock}, nil) },
 		// PV shadow, sequential-error branch: the parallel run of a VALID block
 		// reports OK against the supplied sequential error, so the codes differ
 		// and the mismatch line is emitted deterministically.
@@ -274,7 +284,7 @@ func TestRequeueDisconnectedNoErrorOnCoinbaseOnly(t *testing.T) {
 	}
 
 	stderrBuf.Reset()
-	engine.requeueDisconnectedTransactions([][]byte{rawBlock})
+	engine.requeueDisconnectedTransactions([][]byte{rawBlock}, nil)
 	if stderrBuf.Len() != 0 {
 		t.Fatalf("expected no errors for coinbase-only block, got: %s", stderrBuf.String())
 	}
@@ -304,7 +314,7 @@ func TestRequeueDisconnectedSkipsUnparseableBlocks(t *testing.T) {
 	var stderrBuf bytes.Buffer
 	engine.SetStderr(&stderrBuf)
 
-	engine.requeueDisconnectedTransactions([][]byte{{0xff, 0xfe}})
+	engine.requeueDisconnectedTransactions([][]byte{{0xff, 0xfe}}, nil)
 	if stderrBuf.Len() != 0 {
 		t.Fatalf("expected no stderr for unparseable block, got: %s", stderrBuf.String())
 	}
@@ -448,10 +458,308 @@ func TestRequeueDisconnectedLogsAddTxError(t *testing.T) {
 	// Requeue the disconnected block: the tx's inputs are already spent,
 	// so AddTx fails and the error is logged to stderr.
 	stderrBuf.Reset()
-	engine.requeueDisconnectedTransactions([][]byte{rawBlock})
+	engine.requeueDisconnectedTransactions([][]byte{rawBlock}, nil)
 
 	output := stderrBuf.String()
 	if !strings.Contains(output, "mempool: requeue-tx:") {
 		t.Fatalf("expected 'mempool: requeue-tx:' in stderr, got: %q", output)
 	}
+}
+
+// newDiagnosticEngine builds the smallest engine that can produce a diagnostic
+// from a PUBLIC mutation entry point: with a mempool bound, any further
+// SetMempool call is a rejection — the cheapest batched producer there is, and
+// it needs no chain, no mined block and no key material.
+func newDiagnosticEngine(t *testing.T) (*SyncEngine, *ChainState, *BlockStore) {
+	t.Helper()
+	dir := t.TempDir()
+	chainState := NewChainState()
+	blockStore, err := CreateBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	engine, err := NewSyncEngine(chainState, blockStore, DefaultSyncConfig(nil, [32]byte{}, ChainStatePath(dir)))
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	mempool, err := NewMempool(chainState, blockStore, [32]byte{})
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	engine.SetMempool(mempool)
+	return engine, chainState, blockStore
+}
+
+func newDiagnosticRejectionCandidate(t *testing.T, chainState *ChainState, blockStore *BlockStore) *Mempool {
+	t.Helper()
+	candidate, err := NewMempool(chainState, blockStore, [32]byte{})
+	if err != nil {
+		t.Fatalf("NewMempool(candidate): %v", err)
+	}
+	return candidate
+}
+
+// diagnosticLockProbe answers the question the race detector cannot: which
+// engine locks were HELD at the moment the caller-supplied writer ran. Every
+// TryLock happens before the writer publishes `entered`, so the measurement is
+// taken before any other goroutine in the test can contend for those locks.
+type diagnosticLockProbe struct {
+	engine  *SyncEngine
+	entered chan struct{}
+	release chan struct{}
+
+	buf           bytes.Buffer
+	writes        int
+	mutationHeld  bool
+	stateHeld     bool
+	admissionHeld bool
+}
+
+func (w *diagnosticLockProbe) Write(p []byte) (int, error) {
+	w.writes++
+	if w.engine.mutationMu.TryLock() {
+		w.engine.mutationMu.Unlock()
+	} else {
+		w.mutationHeld = true
+	}
+	if w.engine.mu.TryLock() {
+		w.engine.mu.Unlock()
+	} else {
+		w.stateHeld = true
+	}
+	if w.engine.chainState.admissionMu.TryLock() {
+		w.engine.chainState.admissionMu.Unlock()
+	} else {
+		w.admissionHeld = true
+	}
+	if w.entered != nil {
+		select {
+		case w.entered <- struct{}{}:
+		default:
+		}
+		<-w.release
+	}
+	return w.buf.Write(p)
+}
+
+// TestSyncEngineDiagnosticWriterRunsAfterMutationUnlock pins the isolation
+// contract on a public mutation entry point, in two phases. Phase 1 is
+// single-goroutine, so a busy engine lock could only be this mutation's own: it
+// proves mutationMu, s.mu and the admission guard are ALL free when the
+// caller-supplied writer runs, and that the emitted bytes are unchanged. Phase 2
+// parks a writer inside Write and proves the liveness property the batch exists
+// for: a SECOND canonical mutator acquires mutationMu and reaches its own result
+// while the first call's writer is still blocked.
+func TestSyncEngineDiagnosticWriterRunsAfterMutationUnlock(t *testing.T) {
+	engine, chainState, blockStore := newDiagnosticEngine(t)
+
+	probe := &diagnosticLockProbe{engine: engine}
+	engine.SetStderr(probe)
+	engine.SetMempool(newDiagnosticRejectionCandidate(t, chainState, blockStore))
+	if probe.writes != 1 {
+		t.Fatalf("writes=%d, want exactly one flushed record", probe.writes)
+	}
+	if probe.mutationHeld || probe.stateHeld || probe.admissionHeld {
+		t.Fatalf("locks held during writer I/O: mutationMu=%v s.mu=%v admissionMu=%v",
+			probe.mutationHeld, probe.stateHeld, probe.admissionHeld)
+	}
+	const want = "sync: mempool binding rejected, engine binding unchanged: mempool replacement is not supported after the initial binding\n"
+	if got := probe.buf.String(); got != want {
+		t.Fatalf("emitted %q, want the unchanged diagnostic %q", got, want)
+	}
+
+	blocking := &diagnosticLockProbe{engine: engine, entered: make(chan struct{}, 1), release: make(chan struct{})}
+	engine.SetStderr(blocking)
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		engine.SetMempool(newDiagnosticRejectionCandidate(t, chainState, blockStore))
+	}()
+	select {
+	case <-blocking.entered:
+	case <-time.After(5 * time.Second):
+		close(blocking.release)
+		t.Fatal("timed out waiting for the diagnostic writer to be entered")
+	}
+	second := make(chan error, 1)
+	go func() { _, err := engine.DisconnectTip(); second <- err }()
+	select {
+	case <-second:
+	case <-time.After(5 * time.Second):
+		close(blocking.release)
+		t.Fatal("a second canonical mutator could not acquire mutationMu while the diagnostic writer was blocked")
+	}
+	close(blocking.release)
+	<-firstDone
+	if blocking.mutationHeld || blocking.stateHeld || blocking.admissionHeld {
+		t.Fatalf("locks held while the writer blocked: mutationMu=%v s.mu=%v admissionMu=%v",
+			blocking.mutationHeld, blocking.stateHeld, blocking.admissionHeld)
+	}
+	engine.SetStderr(io.Discard)
+}
+
+// reentrantDiagnosticWriter calls back into non-diagnostic SyncEngine mutations
+// from inside Write, which is legal precisely because the flush holds no engine
+// lock. The one-shot guard bounds the depth; this test is about deadlock, not
+// recursion.
+type reentrantDiagnosticWriter struct {
+	engine *SyncEngine
+	bound  *Mempool
+	buf    bytes.Buffer
+	writes int
+}
+
+func (w *reentrantDiagnosticWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		w.engine.SetMempool(w.bound) // same pointer: settled, no rebinding, no diagnostic
+		_, _ = w.engine.DisconnectTip()
+	}
+	return w.buf.Write(p)
+}
+
+// TestSyncEngineDiagnosticWriterReentryDoesNotDeadlock drives the case where the
+// operator's writer re-enters the engine from inside Write: the flush runs with
+// mutationMu released, so those mutations acquire it and return instead of
+// self-deadlocking against the call that is emitting.
+func TestSyncEngineDiagnosticWriterReentryDoesNotDeadlock(t *testing.T) {
+	engine, chainState, blockStore := newDiagnosticEngine(t)
+	engine.mu.RLock()
+	bound := engine.mempool
+	engine.mu.RUnlock()
+
+	writer := &reentrantDiagnosticWriter{engine: engine, bound: bound}
+	engine.SetStderr(writer)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		engine.SetMempool(newDiagnosticRejectionCandidate(t, chainState, blockStore))
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("re-entrant diagnostic writer deadlocked the emitting mutation")
+	}
+	if writer.writes == 0 {
+		t.Fatal("the re-entrant writer was never invoked")
+	}
+	if !strings.Contains(writer.buf.String(), "sync: mempool binding rejected") {
+		t.Fatalf("emitted %q, want the unchanged binding-rejection diagnostic", writer.buf.String())
+	}
+	engine.mu.RLock()
+	stillBound := engine.mempool
+	engine.mu.RUnlock()
+	if stillBound != bound {
+		t.Fatal("a re-entrant writer changed the engine's mempool binding")
+	}
+	engine.SetStderr(io.Discard)
+}
+
+// TestSyncEngineDiagnosticBatchBounded pins both caps at their exact boundary,
+// the one-over behavior, the single fixed truncation record, below-cap byte and
+// order fidelity, and flush-exactly-once.
+func TestSyncEngineDiagnosticBatchBounded(t *testing.T) {
+	var sink bytes.Buffer
+	engine := &SyncEngine{stderr: &sink}
+
+	records := &diagnosticBatch{}
+	var want strings.Builder
+	for i := 0; i < diagnosticBatchMaxRecords; i++ {
+		engine.diagnose(records, "diagnostic record %d\n", i)
+		fmt.Fprintf(&want, "diagnostic record %d\n", i)
+	}
+	if len(records.records) != diagnosticBatchMaxRecords || records.truncated {
+		t.Fatalf("at the record cap: records=%d truncated=%v", len(records.records), records.truncated)
+	}
+	engine.diagnose(records, "one over the record cap\n")
+	if !records.truncated || len(records.records) != diagnosticBatchMaxRecords {
+		t.Fatalf("one over the record cap: records=%d truncated=%v", len(records.records), records.truncated)
+	}
+	want.WriteString(diagnosticBatchTruncatedRecord)
+	engine.flushDiagnostics(records)
+	if got := sink.String(); got != want.String() {
+		t.Fatalf("flushed %q, want the below-cap records in producer order plus one truncation record %q", got, want.String())
+	}
+	sink.Reset()
+	engine.flushDiagnostics(records)
+	if sink.Len() != 0 {
+		t.Fatalf("second flush emitted %q, want nothing", sink.String())
+	}
+
+	// Byte cap: a record that exactly fills the budget is retained; the next
+	// one is dropped even though it is tiny.
+	sink.Reset()
+	full := strings.Repeat("x", diagnosticBatchMaxBytes-1) + "\n"
+	bytesBatch := &diagnosticBatch{}
+	engine.diagnose(bytesBatch, "%s", full)
+	if bytesBatch.truncated || bytesBatch.bytes != diagnosticBatchMaxBytes {
+		t.Fatalf("at the byte cap: bytes=%d truncated=%v", bytesBatch.bytes, bytesBatch.truncated)
+	}
+	engine.diagnose(bytesBatch, "one over the byte cap\n")
+	if !bytesBatch.truncated || len(bytesBatch.records) != 1 {
+		t.Fatalf("one over the byte cap: records=%d truncated=%v", len(bytesBatch.records), bytesBatch.truncated)
+	}
+	engine.flushDiagnostics(bytesBatch)
+	if got, expected := sink.String(), full+diagnosticBatchTruncatedRecord; got != expected {
+		t.Fatalf("byte-cap flush emitted %d bytes, want %d", len(got), len(expected))
+	}
+
+	// A record larger than the remaining budget is dropped whole and closes the
+	// batch, so a later small record cannot jump ahead of it in the output.
+	sink.Reset()
+	oversized := &diagnosticBatch{}
+	engine.diagnose(oversized, "first\n")
+	engine.diagnose(oversized, "%s", strings.Repeat("y", diagnosticBatchMaxBytes)+"\n")
+	engine.diagnose(oversized, "later small record\n")
+	if !oversized.truncated || len(oversized.records) != 1 || oversized.bytes != len("first\n") {
+		t.Fatalf("oversized record: records=%d bytes=%d truncated=%v", len(oversized.records), oversized.bytes, oversized.truncated)
+	}
+	engine.flushDiagnostics(oversized)
+	if got, expected := sink.String(), "first\n"+diagnosticBatchTruncatedRecord; got != expected {
+		t.Fatalf("oversized flush emitted %q, want %q", got, expected)
+	}
+}
+
+// TestSyncEngineTransitionDiagnosticsFlushAfterUnlock covers the two producers
+// that fire ONLY under an open canonical transition — the standard-cleanup
+// failure and the terminal-latch report — driven through the public ApplyBlock
+// entry point. Both records reach the writer unchanged and in producer order,
+// with mutationMu and s.mu free.
+//
+// admissionMu is deliberately asserted as STILL HELD: this scenario ends in the
+// terminal fail-closed latch, which retains the admission guard until the node
+// restarts (canonicalTransition.end). That retention is pre-existing behavior
+// this issue does not change, and it is harmless here because no mutation path
+// re-acquires that guard after the latch — every entry point fails closed
+// through mutationAllowed first. The assertion is exact so that any future
+// change to the latch shows up here rather than silently.
+func TestSyncEngineTransitionDiagnosticsFlushAfterUnlock(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	spend := f.spend(t, 700, 1)
+	if err := f.mempool.AddTx(spend); err != nil {
+		t.Fatalf("AddTx(spend): %v", err)
+	}
+	f.breakResidentClaim(t, txID(t, spend))
+
+	probe := &diagnosticLockProbe{engine: f.engine}
+	f.engine.SetStderr(probe)
+	if _, err := f.engine.ApplyBlock(f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend), nil); err == nil {
+		t.Fatal("apply committed a block whose standard cleanup failed")
+	}
+	if probe.mutationHeld || probe.stateHeld {
+		t.Fatalf("locks held during writer I/O: mutationMu=%v s.mu=%v", probe.mutationHeld, probe.stateHeld)
+	}
+	if !probe.admissionHeld {
+		t.Fatal("the terminal latch released the admission guard; the fail-closed contract changed")
+	}
+	if probe.writes != 2 {
+		t.Fatalf("writes=%d, want the cleanup record and the terminal record", probe.writes)
+	}
+	out := probe.buf.String()
+	cleanup := strings.Index(out, "sync: standard mempool cleanup failed at height ")
+	terminal := strings.Index(out, "sync: canonical transition terminal (rollback restore failed), admission stays closed until restart: ")
+	if cleanup < 0 || terminal < 0 || cleanup > terminal {
+		t.Fatalf("emitted %q, want the unchanged cleanup record before the unchanged terminal record", out)
+	}
+	f.engine.SetStderr(io.Discard)
 }

--- a/clients/go/node/sync_stderr_test.go
+++ b/clients/go/node/sync_stderr_test.go
@@ -107,7 +107,7 @@ func stderrProducers(t *testing.T, f *pendingOutpointSyncFixture, spentBlock []b
 		},
 		// Requeue diagnostic: the block's inputs are already spent on chain, so
 		// readmission fails and the failure is reported.
-		"requeue": func() { f.engine.requeueDisconnectedTransactions([][]byte{spentBlock}, nil) },
+		"requeue": func() { f.engine.requeueDisconnectedTransactions([][]byte{spentBlock}) },
 		// PV shadow, sequential-error branch: the parallel run of a VALID block
 		// reports OK against the supplied sequential error, so the codes differ
 		// and the mismatch line is emitted deterministically.
@@ -284,7 +284,7 @@ func TestRequeueDisconnectedNoErrorOnCoinbaseOnly(t *testing.T) {
 	}
 
 	stderrBuf.Reset()
-	engine.requeueDisconnectedTransactions([][]byte{rawBlock}, nil)
+	engine.requeueDisconnectedTransactions([][]byte{rawBlock})
 	if stderrBuf.Len() != 0 {
 		t.Fatalf("expected no errors for coinbase-only block, got: %s", stderrBuf.String())
 	}
@@ -314,7 +314,7 @@ func TestRequeueDisconnectedSkipsUnparseableBlocks(t *testing.T) {
 	var stderrBuf bytes.Buffer
 	engine.SetStderr(&stderrBuf)
 
-	engine.requeueDisconnectedTransactions([][]byte{{0xff, 0xfe}}, nil)
+	engine.requeueDisconnectedTransactions([][]byte{{0xff, 0xfe}})
 	if stderrBuf.Len() != 0 {
 		t.Fatalf("expected no stderr for unparseable block, got: %s", stderrBuf.String())
 	}
@@ -458,7 +458,7 @@ func TestRequeueDisconnectedLogsAddTxError(t *testing.T) {
 	// Requeue the disconnected block: the tx's inputs are already spent,
 	// so AddTx fails and the error is logged to stderr.
 	stderrBuf.Reset()
-	engine.requeueDisconnectedTransactions([][]byte{rawBlock}, nil)
+	engine.requeueDisconnectedTransactions([][]byte{rawBlock})
 
 	output := stderrBuf.String()
 	if !strings.Contains(output, "mempool: requeue-tx:") {

--- a/clients/go/node/sync_stderr_test.go
+++ b/clients/go/node/sync_stderr_test.go
@@ -500,38 +500,67 @@ func newDiagnosticRejectionCandidate(t *testing.T, chainState *ChainState, block
 }
 
 // diagnosticLockProbe answers the question the race detector cannot: which
-// engine locks were HELD at the moment the caller-supplied writer ran. Every
-// TryLock happens before the writer publishes `entered`, so the measurement is
-// taken before any other goroutine in the test can contend for those locks.
+// engine locks were HELD at the moment the caller-supplied writer ran. It probes
+// all six lock families named in the issue invariant — mutationMu, SyncEngine.mu,
+// the ChainState admission guard, ChainState.mu, Mempool.mu and the
+// PendingOutpointOwner mutex.
+//
+// It is itself safe for concurrent use, as SetStderr requires of any writer:
+// flushes run outside mutationMu, so two mutations' flushes may overlap.
 type diagnosticLockProbe struct {
 	engine  *SyncEngine
+	mempool *Mempool
+	owner   *PendingOutpointOwner
 	entered chan struct{}
 	release chan struct{}
 
+	mu            sync.Mutex
 	buf           bytes.Buffer
 	writes        int
 	mutationHeld  bool
 	stateHeld     bool
 	admissionHeld bool
+	chainHeld     bool
+	mempoolHeld   bool
+	ownerHeld     bool
+}
+
+// tryLock reports whether l was FREE, taking and releasing it when it was.
+func tryLockFree(l interface {
+	TryLock() bool
+	Unlock()
+},
+) bool {
+	if !l.TryLock() {
+		return false
+	}
+	l.Unlock()
+	return true
 }
 
 func (w *diagnosticLockProbe) Write(p []byte) (int, error) {
+	// Measured BEFORE `entered` is published, so in the blocking phases the
+	// sample is taken before any other goroutine can contend for these locks.
+	mutationFree := tryLockFree(&w.engine.mutationMu)
+	stateFree := tryLockFree(&w.engine.mu)
+	admissionFree := tryLockFree(&w.engine.chainState.admissionMu)
+	chainFree := tryLockFree(&w.engine.chainState.mu)
+	mempoolFree, ownerFree := true, true
+	if w.mempool != nil {
+		mempoolFree = tryLockFree(&w.mempool.mu)
+	}
+	if w.owner != nil {
+		ownerFree = tryLockFree(&w.owner.mu)
+	}
+	w.mu.Lock()
 	w.writes++
-	if w.engine.mutationMu.TryLock() {
-		w.engine.mutationMu.Unlock()
-	} else {
-		w.mutationHeld = true
-	}
-	if w.engine.mu.TryLock() {
-		w.engine.mu.Unlock()
-	} else {
-		w.stateHeld = true
-	}
-	if w.engine.chainState.admissionMu.TryLock() {
-		w.engine.chainState.admissionMu.Unlock()
-	} else {
-		w.admissionHeld = true
-	}
+	w.mutationHeld = w.mutationHeld || !mutationFree
+	w.stateHeld = w.stateHeld || !stateFree
+	w.admissionHeld = w.admissionHeld || !admissionFree
+	w.chainHeld = w.chainHeld || !chainFree
+	w.mempoolHeld = w.mempoolHeld || !mempoolFree
+	w.ownerHeld = w.ownerHeld || !ownerFree
+	w.mu.Unlock()
 	if w.entered != nil {
 		select {
 		case w.entered <- struct{}{}:
@@ -539,36 +568,69 @@ func (w *diagnosticLockProbe) Write(p []byte) (int, error) {
 		}
 		<-w.release
 	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.buf.Write(p)
 }
 
+// held reports the six flags plus the write count under the probe's own mutex.
+func (w *diagnosticLockProbe) held() (writes int, anyEngineLock bool, admission bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes, w.mutationHeld || w.stateHeld || w.chainHeld || w.mempoolHeld || w.ownerHeld, w.admissionHeld
+}
+
+func (w *diagnosticLockProbe) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return fmt.Sprintf("mutationMu=%v s.mu=%v admissionMu=%v ChainState.mu=%v Mempool.mu=%v owner.mu=%v",
+		w.mutationHeld, w.stateHeld, w.admissionHeld, w.chainHeld, w.mempoolHeld, w.ownerHeld)
+}
+
+func (w *diagnosticLockProbe) output() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
 // TestSyncEngineDiagnosticWriterRunsAfterMutationUnlock pins the isolation
-// contract on a public mutation entry point, in two phases. Phase 1 is
-// single-goroutine, so a busy engine lock could only be this mutation's own: it
-// proves mutationMu, s.mu and the admission guard are ALL free when the
-// caller-supplied writer runs, and that the emitted bytes are unchanged. Phase 2
-// parks a writer inside Write and proves the liveness property the batch exists
-// for: a SECOND canonical mutator acquires mutationMu and reaches its own result
-// while the first call's writer is still blocked.
+// contract on a public mutation entry point, in two phases.
+//
+// Phase 1 is single-goroutine, so a busy engine lock could only be this
+// mutation's own: it proves every lock family the invariant names is free when
+// the caller-supplied writer runs, and that the emitted bytes are unchanged. Its
+// admission-guard claim is narrow — this path releases that guard inside
+// bindMempoolUnderMutation before the flush, so the probe only catches a
+// regression moving the flush back into that span; the load-bearing admission
+// evidence is TestSyncEngineTransitionDiagnosticsFlushAfterUnlock, which drives
+// the path that actually holds it.
+//
+// Phase 2 parks a writer inside Write and proves the liveness property the batch
+// exists for: a SECOND canonical mutator acquires mutationMu and reaches its own
+// result while the first call's writer is still blocked.
 func TestSyncEngineDiagnosticWriterRunsAfterMutationUnlock(t *testing.T) {
 	engine, chainState, blockStore := newDiagnosticEngine(t)
+	bound, owner := boundPoolOf(engine)
 
-	probe := &diagnosticLockProbe{engine: engine}
+	probe := &diagnosticLockProbe{engine: engine, mempool: bound, owner: owner}
 	engine.SetStderr(probe)
 	engine.SetMempool(newDiagnosticRejectionCandidate(t, chainState, blockStore))
-	if probe.writes != 1 {
-		t.Fatalf("writes=%d, want exactly one flushed record", probe.writes)
+	writes, engineLockHeld, admissionHeld := probe.held()
+	if writes != 1 {
+		t.Fatalf("writes=%d, want exactly one flushed record", writes)
 	}
-	if probe.mutationHeld || probe.stateHeld || probe.admissionHeld {
-		t.Fatalf("locks held during writer I/O: mutationMu=%v s.mu=%v admissionMu=%v",
-			probe.mutationHeld, probe.stateHeld, probe.admissionHeld)
+	if engineLockHeld || admissionHeld {
+		t.Fatalf("locks held during writer I/O: %s", probe)
 	}
 	const want = "sync: mempool binding rejected, engine binding unchanged: mempool replacement is not supported after the initial binding\n"
-	if got := probe.buf.String(); got != want {
+	if got := probe.output(); got != want {
 		t.Fatalf("emitted %q, want the unchanged diagnostic %q", got, want)
 	}
 
-	blocking := &diagnosticLockProbe{engine: engine, entered: make(chan struct{}, 1), release: make(chan struct{})}
+	blocking := &diagnosticLockProbe{
+		engine: engine, mempool: bound, owner: owner,
+		entered: make(chan struct{}, 1), release: make(chan struct{}),
+	}
 	engine.SetStderr(blocking)
 	firstDone := make(chan struct{})
 	go func() {
@@ -591,11 +653,28 @@ func TestSyncEngineDiagnosticWriterRunsAfterMutationUnlock(t *testing.T) {
 	}
 	close(blocking.release)
 	<-firstDone
-	if blocking.mutationHeld || blocking.stateHeld || blocking.admissionHeld {
-		t.Fatalf("locks held while the writer blocked: mutationMu=%v s.mu=%v admissionMu=%v",
-			blocking.mutationHeld, blocking.stateHeld, blocking.admissionHeld)
+	writes, engineLockHeld, admissionHeld = blocking.held()
+	if engineLockHeld || admissionHeld {
+		t.Fatalf("locks held while the writer blocked: %s", blocking)
+	}
+	// Make the phase-2 dependency explicit instead of implicit: the second
+	// mutator is a tipless DisconnectTip, which produces NO diagnostic, so it
+	// could not have blocked inside this same parked writer. If it ever starts
+	// emitting, this fails rather than silently turning the liveness proof into
+	// a second observation of the same blocked flush.
+	if writes != 1 {
+		t.Fatalf("writes=%d, want exactly the parked binding-rejection record; the second mutator must not emit", writes)
 	}
 	engine.SetStderr(io.Discard)
+}
+
+// boundPoolOf reads the engine's bound mempool and its owner the way production
+// readers do, so a probe can name their locks.
+func boundPoolOf(engine *SyncEngine) (*Mempool, *PendingOutpointOwner) {
+	engine.mu.RLock()
+	bound := engine.mempool
+	engine.mu.RUnlock()
+	return bound, bound.PendingOutpointOwner()
 }
 
 // reentrantDiagnosticWriter calls back into non-diagnostic SyncEngine mutations
@@ -718,6 +797,98 @@ func TestSyncEngineDiagnosticBatchBounded(t *testing.T) {
 	if got, expected := sink.String(), "first\n"+diagnosticBatchTruncatedRecord; got != expected {
 		t.Fatalf("oversized flush emitted %q, want %q", got, expected)
 	}
+
+	// The terminal-latch record is NEVER evicted. This is the >=64-row reorg
+	// with systematic PV-shadow mismatch: the batch is closed on both caps long
+	// before the transition latches, and the one record an operator needs must
+	// still arrive — after the truncation marker that accounts for the dropped
+	// shadow noise.
+	sink.Reset()
+	latched := &diagnosticBatch{}
+	for i := 0; i <= diagnosticBatchMaxRecords; i++ {
+		engine.diagnose(latched, "pv_shadow: mismatch height=%d post_state_digest\n", i)
+	}
+	engine.diagnose(latched, "%s", strings.Repeat("z", diagnosticBatchMaxBytes)+"\n")
+	engine.reportTerminalTransition(latched, "rollback restore failed", errors.New("probe cause"))
+	if !latched.truncated || len(latched.records) != diagnosticBatchMaxRecords {
+		t.Fatalf("closed batch: records=%d truncated=%v", len(latched.records), latched.truncated)
+	}
+	engine.flushDiagnostics(latched)
+	const terminalRecord = "sync: canonical transition terminal (rollback restore failed), admission stays closed until restart: probe cause\n"
+	out := sink.String()
+	if !strings.HasSuffix(out, terminalRecord) {
+		t.Fatalf("the closed batch dropped or reordered the terminal-latch record; flushed %d bytes ending %q", len(out), out[max(0, len(out)-120):])
+	}
+	if truncation := strings.Index(out, diagnosticBatchTruncatedRecord); truncation < 0 || truncation > strings.Index(out, terminalRecord) {
+		t.Fatalf("want the truncation marker present and before the terminal record, got %q", out[max(0, len(out)-200):])
+	}
+}
+
+// overlapWriter parks every Write until the test releases it, so the number of
+// flushes simultaneously inside the writer is observable rather than inferred.
+// It is safe for concurrent use, which is what SetStderr requires of a writer.
+type overlapWriter struct {
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	arrived chan struct{}
+	release chan struct{}
+}
+
+func (w *overlapWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	n, err := w.buf.Write(p)
+	w.mu.Unlock()
+	w.arrived <- struct{}{}
+	<-w.release
+	return n, err
+}
+
+func (w *overlapWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// TestSyncEngineDiagnosticFlushesMayOverlapSafely pins the concurrency contract
+// SetStderr states: because flushes run OUTSIDE mutationMu, several mutations'
+// flush windows overlap by design. The test proves the overlap deterministically
+// — it waits until every mutation's flush is parked inside the writer at the
+// same time, which can only happen if each released mutationMu before flushing —
+// and proves nothing is lost or garbled when they do. Under -race it is also the
+// proof that the batches share no state.
+func TestSyncEngineDiagnosticFlushesMayOverlapSafely(t *testing.T) {
+	const mutations = 3
+	engine, chainState, blockStore := newDiagnosticEngine(t)
+	candidates := make([]*Mempool, 0, mutations)
+	for i := 0; i < mutations; i++ {
+		candidates = append(candidates, newDiagnosticRejectionCandidate(t, chainState, blockStore))
+	}
+	writer := &overlapWriter{arrived: make(chan struct{}, mutations), release: make(chan struct{})}
+	engine.SetStderr(writer)
+
+	var wg sync.WaitGroup
+	for _, candidate := range candidates {
+		wg.Add(1)
+		go func(candidate *Mempool) {
+			defer wg.Done()
+			engine.SetMempool(candidate)
+		}(candidate)
+	}
+	for parked := 0; parked < mutations; parked++ {
+		select {
+		case <-writer.arrived:
+		case <-time.After(10 * time.Second):
+			close(writer.release)
+			wg.Wait()
+			t.Fatalf("only %d of %d flushes were inside the writer at once; flushes are being serialized behind a lock", parked, mutations)
+		}
+	}
+	close(writer.release)
+	wg.Wait()
+	if got := strings.Count(writer.String(), "sync: mempool binding rejected, engine binding unchanged: "); got != mutations {
+		t.Fatalf("overlapping flushes delivered %d records, want %d intact", got, mutations)
+	}
+	engine.SetStderr(io.Discard)
 }
 
 // TestSyncEngineTransitionDiagnosticsFlushAfterUnlock covers the two producers
@@ -741,25 +912,165 @@ func TestSyncEngineTransitionDiagnosticsFlushAfterUnlock(t *testing.T) {
 	}
 	f.breakResidentClaim(t, txID(t, spend))
 
-	probe := &diagnosticLockProbe{engine: f.engine}
+	probe := &diagnosticLockProbe{engine: f.engine, mempool: f.mempool, owner: f.owner}
 	f.engine.SetStderr(probe)
 	if _, err := f.engine.ApplyBlock(f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend), nil); err == nil {
 		t.Fatal("apply committed a block whose standard cleanup failed")
 	}
-	if probe.mutationHeld || probe.stateHeld {
-		t.Fatalf("locks held during writer I/O: mutationMu=%v s.mu=%v", probe.mutationHeld, probe.stateHeld)
+	writes, engineLockHeld, admissionHeld := probe.held()
+	if engineLockHeld {
+		t.Fatalf("locks held during writer I/O: %s", probe)
 	}
-	if !probe.admissionHeld {
+	if !admissionHeld {
 		t.Fatal("the terminal latch released the admission guard; the fail-closed contract changed")
 	}
-	if probe.writes != 2 {
-		t.Fatalf("writes=%d, want the cleanup record and the terminal record", probe.writes)
+	if writes != 2 {
+		t.Fatalf("writes=%d, want the cleanup record and the terminal record", writes)
 	}
-	out := probe.buf.String()
+	out := probe.output()
 	cleanup := strings.Index(out, "sync: standard mempool cleanup failed at height ")
 	terminal := strings.Index(out, "sync: canonical transition terminal (rollback restore failed), admission stays closed until restart: ")
 	if cleanup < 0 || terminal < 0 || cleanup > terminal {
 		t.Fatalf("emitted %q, want the unchanged cleanup record before the unchanged terminal record", out)
+	}
+	f.engine.SetStderr(io.Discard)
+}
+
+// flakySpendRotationProvider serves the real ML-DSA-87 spend suite for its first
+// `full` queries and an empty set afterwards. A rotation provider that answers
+// differently for the same height is exactly the divergence class PV shadow
+// exists to catch, and it is reachable through public SyncConfig — no production
+// seam is added to force it.
+type flakySpendRotationProvider struct {
+	mu    sync.Mutex
+	calls int
+	full  int
+}
+
+func (p *flakySpendRotationProvider) NativeCreateSuites(uint64) *consensus.NativeSuiteSet {
+	return consensus.NewNativeSuiteSet(consensus.SUITE_ID_ML_DSA_87)
+}
+
+func (p *flakySpendRotationProvider) NativeSpendSuites(uint64) *consensus.NativeSuiteSet {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.calls <= p.full {
+		return consensus.NewNativeSuiteSet(consensus.SUITE_ID_ML_DSA_87)
+	}
+	return consensus.NewNativeSuiteSet()
+}
+
+func (p *flakySpendRotationProvider) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// TestSyncEnginePVShadowDiagnosticIsBatchedThroughApplyBlock drives a REAL PV
+// shadow mismatch through the public ApplyBlock entry point, proving the PV
+// producers' batch wiring (the diag literal they read as ctx.diag) end to end:
+// dropping it fails this test, because the record would then be written from
+// under mutationMu.
+//
+// The divergence is honest — the sequential connect consumes exactly one
+// NativeSpendSuites answer (measured), the shadow asks a second time, and a
+// provider answering differently for one height is the class PV shadow reports.
+// RotationProvider is public SyncConfig, so no production seam is added.
+func TestSyncEnginePVShadowDiagnosticIsBatchedThroughApplyBlock(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	f.engine.pvMode = pvModeShadow
+	flaky := &flakySpendRotationProvider{full: 1}
+	f.engine.cfg.RotationProvider = flaky
+	spend := f.spend(t, 700, 1)
+	block := f.blockIncluding(t, f.tipHash, f.tipHeight+1, f.alreadyGenerated, 202, spend)
+
+	probe := &diagnosticLockProbe{engine: f.engine, mempool: f.mempool, owner: f.owner}
+	f.engine.SetStderr(probe)
+	if _, err := f.engine.ApplyBlock(block, nil); err != nil {
+		t.Fatalf("ApplyBlock: %v, want the sequential connect to succeed", err)
+	}
+	if got := flaky.count(); got < 2 {
+		t.Fatalf("NativeSpendSuites calls=%d, want the shadow's second query; the shadow never ran", got)
+	}
+	writes, engineLockHeld, admissionHeld := probe.held()
+	if engineLockHeld || admissionHeld {
+		t.Fatalf("locks held during writer I/O: %s", probe)
+	}
+	if writes != 1 {
+		t.Fatalf("writes=%d, want exactly the flushed PV mismatch record", writes)
+	}
+	want := fmt.Sprintf("pv_shadow: mismatch height=%d seq_ok par_err=", f.tipHeight+1)
+	if got := probe.output(); !strings.HasPrefix(got, want) {
+		t.Fatalf("emitted %q, want the unchanged PV shadow record %q", got, want)
+	}
+	f.engine.SetStderr(io.Discard)
+}
+
+// TestSyncEngineRequeueDiagnosticIsBatchedThroughReorg drives a REAL requeue
+// failure through the public ApplyBlockWithReorg entry point: the winning branch
+// double-spends the outpoint of the block it displaces, so the displaced
+// transaction cannot be readmitted. It is the end-to-end proof for the requeue
+// producer's batch wiring — the diag literal applyPreferredBranch passes after
+// the transition ends but while mutationMu is still held; dropping it fails this
+// test.
+func TestSyncEngineRequeueDiagnosticIsBatchedThroughReorg(t *testing.T) {
+	f := newPendingOutpointSyncFixture(t)
+	forkHash, forkHeight, forkGenerated := f.tipHash, f.tipHeight+1, f.alreadyGenerated
+
+	// Both spends are signed BEFORE either branch is applied: they consume the
+	// same live outpoint, so the second could not be built once the first is on
+	// chain — which is exactly why the requeue of the displaced one fails.
+	displaced := f.spend(t, 700, 1)
+	conflicting := f.spend(t, 600, 2)
+
+	// Canonical branch A: one block spending the fixture's mature coinbase.
+	if _, err := f.engine.ApplyBlock(f.blockIncluding(t, forkHash, forkHeight, forkGenerated, 202, displaced), nil); err != nil {
+		t.Fatalf("ApplyBlock(A): %v", err)
+	}
+
+	// Competing branch B at the same height, spending the SAME outpoint with a
+	// different amount, then one more block so B outweighs A.
+	//
+	// The probe is installed BEFORE B1: at equal height and work, fork choice
+	// breaks the tie on the lexicographically lower tip hash, and the fixture's
+	// block hashes come from freshly generated key material, so the switch lands
+	// on B1 or on B2 depending on the run. Both orders disconnect A and requeue
+	// its displaced transaction, so the assertions below hold either way — but
+	// only if the writer is watching the whole sequence.
+	probe := &diagnosticLockProbe{engine: f.engine, mempool: f.mempool, owner: f.owner}
+	f.engine.SetStderr(probe)
+
+	blockB1 := f.blockIncluding(t, forkHash, forkHeight, forkGenerated, 303, conflicting)
+	if _, err := f.engine.ApplyBlockWithReorg(blockB1, nil); err != nil {
+		t.Fatalf("ApplyBlockWithReorg(B1): %v", err)
+	}
+	hashB1, err := consensus.BlockHash(blockHeaderBytes(t, blockB1))
+	if err != nil {
+		t.Fatalf("BlockHash(B1): %v", err)
+	}
+	generatedB2 := forkGenerated + consensus.BlockSubsidy(forkHeight, forkGenerated)
+	blockB2 := buildSingleTxBlock(t, hashB1, f.target, 304,
+		reorgTestCoinbaseForAddress(t, forkHeight+1, consensus.BlockSubsidy(forkHeight+1, generatedB2), f.destAddress))
+	hashB2, err := consensus.BlockHash(blockHeaderBytes(t, blockB2))
+	if err != nil {
+		t.Fatalf("BlockHash(B2): %v", err)
+	}
+	if _, err := f.engine.ApplyBlockWithReorg(blockB2, nil); err != nil {
+		t.Fatalf("ApplyBlockWithReorg(B2): %v", err)
+	}
+	if got := f.engine.chainState.TipHash; got != hashB2 {
+		t.Fatalf("tip=%x, want branch B's tip %x: nothing was disconnected or requeued", got, hashB2)
+	}
+	writes, engineLockHeld, admissionHeld := probe.held()
+	if engineLockHeld || admissionHeld {
+		t.Fatalf("locks held during writer I/O: %s", probe)
+	}
+	if writes == 0 {
+		t.Fatal("the reorg produced no requeue diagnostic; the double spend was readmitted?")
+	}
+	if got := probe.output(); !strings.Contains(got, "mempool: requeue-tx: ") {
+		t.Fatalf("emitted %q, want the unchanged requeue record", got)
 	}
 	f.engine.SetStderr(io.Discard)
 }


### PR DESCRIPTION
## Issue
- Linear: RUB-1133
- GitHub Issue mirror (non-authoritative): #2848

Refs: Q-GO-SYNC-DIAGNOSTIC-ISOLATION-01

## Summary
Operator diagnostics become observational-only in the Go SyncEngine. Every public mutation entry point (ApplyBlock, ApplyBlockWithReorg, DisconnectTip, SetMempool, BootstrapCanonicalGenesisIfEmpty) owns one bounded per-mutation diagnostic batch; all seven producers (binding rejection, PV shadow mismatch x3, standard-cleanup failure, terminal transition report, requeue failure) append records instead of invoking the configured writer, and the batch flushes exactly once after the entry point has captured its results and released mutationMu and every releasable inner lock — so a blocked or re-entrant caller-supplied writer can no longer stall another canonical mutator. Retention is bounded to 64 records / 64 KiB per mutation with one fixed truncation record, except the terminal-latch record, which is never dropped (a closed batch still flushes it — the one record the cap exists to protect). Below the caps, diagnostic bytes and producer order are byte-for-byte unchanged. Flush windows of concurrent mutations may overlap by design; SetStderr's contract now requires a concurrent-use-safe writer (os.Stderr qualifies) and keeps nil mapping to io.Discard. The single deliberate exception is the terminal fail-closed path: its flush runs with the latch-retained admission guard held (the RUB-1113 design retains it until restart), with mutationMu and every releasable lock free. A terminally latched engine is now operator-visible: a nil-safe read-only TerminalFaulted() boolean backs GET /health, which reports terminal_fault:true, restart_required:true, ready:false with HTTP 503 and the usual bounded snapshot; healthy ready and healthy not-yet-ready nodes keep HTTP 200, and the RPC state binds the reporter to the real engine (wiring proven by identity in tests). No goroutines, queues, timeouts, or retries are added; no consensus, error-precedence, rollback, persistence, readiness-machine, or Rust change.

## Invariant
Operator diagnostics are observational only: no caller-supplied writer is invoked while SyncEngine.mutationMu, SyncEngine.mu, the canonical admission guard, ChainState locks, Mempool locks, or PendingOutpointOwner locks are held; a blocked or re-entrant writer cannot prevent another canonical mutator from acquiring mutationMu. A terminally latched SyncEngine remains fail-closed and GET /health reports that exact latch as HTTP 503 with bounded explicit restart-required state.

## Scope
- Changed files: 12
- Surfaces: clients/go
- Non-scope: no consensus decision, block/transaction bytes, error precedence, canonical state transition, persistence format, rollback result, mempool/owner invariant, readiness state machine, P2P, Rust, conformance, formal, or spec change; the terminal latch's admission-guard retention is unchanged (its flush necessarily runs under that one latch-retained guard, per the contract's carve); /ready deliberately stays terminal-fault-unaware (byte-pinned against the Rust client; recorded as a contract decision); SetStderr body unchanged (nil→io.Discard pre-existed).
- Consensus rules unchanged: YES — diagnostic transport and health projection only; every accept/reject outcome, error kind and ordering is untouched
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at d7560066 (base implementation): `go build ./... && go vet ./...` — PASS; mandated node families focused `-count=1` and `-race` — PASS; /health family — PASS; `go test -count=1 ./node` — PASS; `go test -race -count=1 ./node ./cmd/rubin-node` — PASS; `go test -count=1 ./...` — PASS
- Dynamic checks at a1b1cd82 (review repair round: never-dropped terminal record, concurrent-flush contract + overlap test, batched PV/requeue entry-point tests, six-family lock probe): changed families `-count=1` and `-race` — PASS; `go test -count=1 ./node` — PASS; `go test -race -count=1 ./node` — PASS; `go test -count=1 ./cmd/rubin-node` and `-race` — PASS; reorg batching test `-count=5` — PASS
- Dynamic checks at final head 44b0fc81 (lint round: noctx, CCN split, dead parameter removal): `go vet ./node ./cmd/rubin-node` — PASS; flush-tail and requeue families focused `-count=1` — PASS; `gofumpt -l` — PASS; `git diff --check` — PASS
- Deterministic static tooling (TOOLING_STAGE=static, new-only) — PASS at 44b0fc81

## Follow-ups / Waivers
- RUB-1128
