### PR TITLE
RUB-876: validate featurebits-deployments before storage mutation

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -422,7 +422,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// filesystem with no service started. The parsed rows are reused by
 	// the telemetry print below — the file is read exactly once per run.
 	// An empty value skips validation and telemetry alike (the flag's
-	// pre-existing contract).
+	// pre-existing contract). On the --legacy-exposure-scan path and on a
+	// store with no tip this ADDS a new rejection: exit 2 where the
+	// pre-diff code returned 0 with an invalid file silently ignored (the
+	// scan returns before the telemetry branch, which is also tipOK-gated)
+	// — a contracted operator-visible change.
 	var featureBitDeployments []featureBitDeploymentJSON
 	if *featurebitsDeploymentsPath != "" {
 		ds, err := loadFeatureBitDeployments(*featurebitsDeploymentsPath)

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -414,6 +414,24 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "--create-store cannot be combined with --dry-run or --legacy-exposure-scan")
 		return 2
 	}
+	// --featurebits-deployments is untrusted operator input: parse and
+	// validate it with the same loader the telemetry print consumes BEFORE
+	// the legacy-exposure-scan chainstate read, the storage lifecycle
+	// (createOrOpenBlockStore below), chainstate load/reconcile/save, and
+	// service startup, so an invalid file exits 2 on an untouched
+	// filesystem with no service started. The parsed rows are reused by
+	// the telemetry print below — the file is read exactly once per run.
+	// An empty value skips validation and telemetry alike (the flag's
+	// pre-existing contract).
+	var featureBitDeployments []featureBitDeploymentJSON
+	if *featurebitsDeploymentsPath != "" {
+		ds, err := loadFeatureBitDeployments(*featurebitsDeploymentsPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "invalid featurebits deployments: %v\n", err)
+			return 2
+		}
+		featureBitDeployments = ds
+	}
 	chainStatePath := node.ChainStatePath(cfg.DataDir)
 	if *legacyExposureScan {
 		chainState, err := loadLegacyExposureScanChainState(chainStatePath)
@@ -580,7 +598,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	if *featurebitsDeploymentsPath != "" && tipOK {
 		nextHeight := tipHeight + 1
-		if err := printFeatureBitsTelemetry(stdout, blockStore, nextHeight, *featurebitsDeploymentsPath); err != nil {
+		if err := printFeatureBitsTelemetryRows(stdout, blockStore, nextHeight, featureBitDeployments); err != nil {
 			_, _ = fmt.Fprintf(stderr, "featurebits telemetry failed: %v\n", err)
 			return 2
 		}
@@ -762,17 +780,52 @@ type headerStore interface {
 	GetHeaderByHash(hash [32]byte) ([]byte, error)
 }
 
-func printFeatureBitsTelemetry(w io.Writer, bs headerStore, height uint64, deploymentsPath string) error {
-	// Operator config read, bounded pre-allocation (RUB-1062 rider A; see
-	// node.ReadConfigFile for the ceiling derivation).
+// loadFeatureBitDeployments reads, parses, and validates a
+// --featurebits-deployments file without touching the blockstore: the
+// bounded config read (RUB-1062 rider A; see node.ReadConfigFile for the
+// ceiling derivation), the JSON decode, and the per-row consensus
+// validation that FeatureBitStateAtHeightFromWindowCounts would otherwise
+// report only at telemetry time. It is the validation-only half of the
+// telemetry path, hoisted so run() can reject an invalid file before any
+// filesystem or service side effect (RUB-876).
+func loadFeatureBitDeployments(deploymentsPath string) ([]featureBitDeploymentJSON, error) {
 	raw, err := node.ReadConfigFile(filepath.Clean(deploymentsPath))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var ds []featureBitDeploymentJSON
 	if err := json.Unmarshal(raw, &ds); err != nil {
+		return nil, err
+	}
+	for _, dj := range ds {
+		d := consensus.FeatureBitDeployment{
+			Name:          dj.Name,
+			Bit:           dj.Bit,
+			StartHeight:   dj.StartHeight,
+			TimeoutHeight: dj.TimeoutHeight,
+		}
+		if err := d.Validate(); err != nil {
+			return nil, err
+		}
+	}
+	return ds, nil
+}
+
+// printFeatureBitsTelemetry loads deploymentsPath and prints its telemetry:
+// the pre-RUB-876 single-call shape, kept for callers holding only a path
+// (currently tests in this package). run() does not use it: startup
+// validates early via loadFeatureBitDeployments — before any filesystem or
+// service side effect — and later prints via printFeatureBitsTelemetryRows,
+// so the file is read exactly once per run.
+func printFeatureBitsTelemetry(w io.Writer, bs headerStore, height uint64, deploymentsPath string) error {
+	ds, err := loadFeatureBitDeployments(deploymentsPath)
+	if err != nil {
 		return err
 	}
+	return printFeatureBitsTelemetryRows(w, bs, height, ds)
+}
+
+func printFeatureBitsTelemetryRows(w io.Writer, bs headerStore, height uint64, ds []featureBitDeploymentJSON) error {
 	for _, dj := range ds {
 		d := consensus.FeatureBitDeployment{
 			Name:          dj.Name,

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -481,6 +481,127 @@ func runFeatureBitsDeploymentsUsesLexicallyNormalizedPath(t *testing.T) {
 	}
 }
 
+// TestRunRejectsInvalidFeatureBitsDeploymentsBeforeStorage proves the
+// RUB-876 guard fires BEFORE any filesystem or service side effect:
+// datadir creation, chainstate load/save, blockstore open/create,
+// reconcile, and service construction. Pre-hoist, the file was parsed
+// only inside the telemetry print AFTER blockstore open + reconcile +
+// Save (and silently ignored whenever the store had no tip, as on a
+// fresh --create-store run), so the clean-datadir, snapshot, stdout,
+// and exit-code assertions all turn red without the hoisted guard.
+func TestRunRejectsInvalidFeatureBitsDeploymentsBeforeStorage(t *testing.T) {
+	const wantGuardStderr = "invalid featurebits deployments: "
+	forbiddenStderr := []string{
+		"datadir create failed",
+		"chainstate load failed",
+		"chainstate reconcile failed",
+		"chainstate save failed",
+		"blockstore open failed",
+		"blockstore create failed",
+		"featurebits telemetry failed",
+	}
+	const invalidRow = `[{"name":"x","bit":1,"start_height":10,"timeout_height":9}]`
+
+	writeDeployments := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "deployments.json")
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write deployments: %v", err)
+		}
+		return path
+	}
+
+	runInvalid := func(t *testing.T, args []string) string {
+		t.Helper()
+		var out, errOut bytes.Buffer
+		if code := run(args, &out, &errOut); code != 2 {
+			t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+		}
+		if !strings.Contains(errOut.String(), wantGuardStderr) {
+			t.Fatalf("stderr missing featurebits guard error: %q", errOut.String())
+		}
+		for _, marker := range forbiddenStderr {
+			if strings.Contains(errOut.String(), marker) {
+				t.Fatalf("storage path reached despite invalid featurebits deployments (%q): %q", marker, errOut.String())
+			}
+		}
+		if out.String() != "" {
+			t.Fatalf("expected empty stdout, got %q", out.String())
+		}
+		return errOut.String()
+	}
+
+	t.Run("hostile_inputs_clean_datadir_create_store", func(t *testing.T) {
+		for _, tc := range []struct {
+			name, content, wantErr string
+			missing                bool
+		}{
+			{name: "missing_file", missing: true},
+			{name: "malformed_json", content: "{"},
+			{name: "wrong_shape_object", content: `{"name":"x"}`},
+			{name: "bit_out_of_range", content: `[{"name":"x","bit":32,"start_height":0,"timeout_height":10}]`, wantErr: "bit out of range"},
+			{name: "empty_name", content: `[{"name":"","bit":1,"start_height":0,"timeout_height":10}]`, wantErr: "name required"},
+			{name: "timeout_before_start", content: invalidRow, wantErr: "timeout_height < start_height"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "missing.json")
+				if !tc.missing {
+					path = writeDeployments(t, tc.content)
+				}
+				datadir := filepath.Join(t.TempDir(), "data")
+				stderr := runInvalid(t, []string{
+					"--datadir", datadir, "--create-store", "--mine-blocks", "1", "--mine-exit",
+					"--featurebits-deployments", path,
+				})
+				if tc.wantErr != "" && !strings.Contains(stderr, tc.wantErr) {
+					t.Fatalf("stderr missing %q: %q", tc.wantErr, stderr)
+				}
+				if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+					t.Fatalf("datadir must not be created on invalid featurebits deployments: stat err=%v", err)
+				}
+			})
+		}
+	})
+
+	for _, leg := range []struct {
+		name   string
+		dryRun bool
+	}{
+		{name: "normal_preexisting_datadir"},
+		{name: "dry_run_preexisting_datadir", dryRun: true},
+	} {
+		t.Run(leg.name, func(t *testing.T) {
+			datadir := preparedDatadir(t)
+			before := datadirSnapshot(t, datadir)
+			args := []string{"--datadir", datadir, "--featurebits-deployments", writeDeployments(t, invalidRow)}
+			if leg.dryRun {
+				args = append(args, "--dry-run")
+			}
+			runInvalid(t, args)
+			assertNoFilesystemWrite(t, before, datadirSnapshot(t, datadir))
+		})
+	}
+}
+
+// TestRunEmptyFeatureBitsDeploymentsFlagSkipsValidation pins the flag's
+// pre-existing contract that an explicitly empty --featurebits-deployments
+// behaves exactly like an unset flag: no file read, no validation, no
+// telemetry line.
+func TestRunEmptyFeatureBitsDeploymentsFlagSkipsValidation(t *testing.T) {
+	datadir := filepath.Join(t.TempDir(), "data")
+	seedBlockStore(t, datadir)
+	var out, errOut bytes.Buffer
+	if code := run([]string{"--dry-run", "--datadir", datadir, "--featurebits-deployments", ""}, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("empty flag must not write to stderr: %q", errOut.String())
+	}
+	if strings.Contains(out.String(), "featurebits:") {
+		t.Fatalf("empty flag must not emit telemetry: %q", out.String())
+	}
+}
+
 func TestRunCreatesPrivatePersistencePaths(t *testing.T) {
 	datadir := filepath.Join(t.TempDir(), "data")
 

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -564,19 +564,19 @@ func TestRunRejectsInvalidFeatureBitsDeploymentsBeforeStorage(t *testing.T) {
 	})
 
 	for _, leg := range []struct {
-		name   string
-		dryRun bool
+		name      string
+		extraArgs []string
 	}{
 		{name: "normal_preexisting_datadir"},
-		{name: "dry_run_preexisting_datadir", dryRun: true},
+		{name: "dry_run_preexisting_datadir", extraArgs: []string{"--dry-run"}},
+		// Pre-hoist the scan returned 0 without ever reading the
+		// deployments file; this rejection is a disclosed RUB-876 change.
+		{name: "legacy_exposure_scan_preexisting_datadir", extraArgs: []string{"--legacy-exposure-scan", "--legacy-suite-id", "1"}},
 	} {
 		t.Run(leg.name, func(t *testing.T) {
 			datadir := preparedDatadir(t)
 			before := datadirSnapshot(t, datadir)
-			args := []string{"--datadir", datadir, "--featurebits-deployments", writeDeployments(t, invalidRow)}
-			if leg.dryRun {
-				args = append(args, "--dry-run")
-			}
+			args := append([]string{"--datadir", datadir, "--featurebits-deployments", writeDeployments(t, invalidRow)}, leg.extraArgs...)
 			runInvalid(t, args)
 			assertNoFilesystemWrite(t, before, datadirSnapshot(t, datadir))
 		})
@@ -586,10 +586,11 @@ func TestRunRejectsInvalidFeatureBitsDeploymentsBeforeStorage(t *testing.T) {
 // TestRunEmptyFeatureBitsDeploymentsFlagSkipsValidation pins the flag's
 // pre-existing contract that an explicitly empty --featurebits-deployments
 // behaves exactly like an unset flag: no file read, no validation, no
-// telemetry line.
+// telemetry line. preparedDatadir has a mined tip, so a non-empty valid
+// file WOULD print a "featurebits:" line here — the absence assertion
+// discriminates on the flag, not on the missing tip.
 func TestRunEmptyFeatureBitsDeploymentsFlagSkipsValidation(t *testing.T) {
-	datadir := filepath.Join(t.TempDir(), "data")
-	seedBlockStore(t, datadir)
+	datadir := preparedDatadir(t)
 	var out, errOut bytes.Buffer
 	if code := run([]string{"--dry-run", "--datadir", datadir, "--featurebits-deployments", ""}, &out, &errOut); code != 0 {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())


### PR DESCRIPTION
## Issue
- Linear: RUB-876
- GitHub Issue mirror (non-authoritative): #2514

Refs: Q-GO-FEATUREBITS-VALIDATE-BEFORE-STORAGE-01

## Summary
The --featurebits-deployments input is parsed and validated at startup BEFORE the first filesystem or service side effect: one validation-only wrapper (loadFeatureBitDeployments) over the existing loader (node.ReadConfigFile + json.Unmarshal + the same per-row consensus Validate() the telemetry path already enforced) runs immediately after flag/config validation and before the legacy-exposure-scan chainstate read, datadir creation, blockstore open/create, chainstate load, reconcile, save, and every service constructor. An invalid file now exits 2 with `invalid featurebits deployments: ...` on an untouched filesystem in both dry-run and ordinary startup; pre-fix, the file was parsed only inside the tipOK-gated telemetry branch after blockstore open + reconcile + save — and on a fresh --create-store run an invalid file was silently ignored (exit 0). The telemetry print site is unchanged in location, tipOK gating, and output bytes; it consumes the already-parsed rows, so the file is read exactly once per run. An empty or unset flag skips validation and telemetry alike (pre-existing contract). The old path-taking printFeatureBitsTelemetry survives as a load-then-print shim whose only callers are existing tests; run() does not use it. Validation domain is unchanged: the early loader calls the same FeatureBitDeployment.Validate() that FeatureBitStateAtHeightFromWindowCounts already applied per row, so every previously-valid file remains valid.

## Invariant
Go parses and validates the --featurebits-deployments input before datadir creation, chainstate load/save, blockstore open, reconcile, or service startup; every invalid input exits before the first filesystem or service side effect, and valid inputs preserve current behavior byte-for-byte.

## Scope
- Changed files: 2
- Surfaces: clients/go (cmd/rubin-node only)
- Non-scope: no featurebits semantic or schema change; no telemetry output change beyond validation ordering; no Rust (flag is inventoried go-only), consensus, storage schema/recovery, or unrelated CLI validation change. Operator-visible ordering deltas are the contracted rejected-class fix: a doubly-invalid invocation (featurebits + genesis) now reports the featurebits error first, and invalid featurebits with --create-store or --legacy-exposure-scan now exits 2 where it was previously ignored or reported late.
- Consensus rules unchanged: YES — startup validation ordering only; the single consensus call is the pre-existing Validate() reused unchanged
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at 1898145e (base implementation): `go build ./... && go vet ./...` — PASS; `gofumpt -l cmd/rubin-node` — PASS (empty); `go test -count=1 ./cmd/rubin-node` — PASS; `go test -race -count=1 ./cmd/rubin-node` — PASS; `git diff --check` — PASS; mutation receipt — hoist reverted makes every new ordering test fail (exit 0 + datadir created on the pre-fix tree)
- Dynamic checks at final head 917ca8af (review repair: scan-path disclosure + scan test leg + discriminating telemetry-skip assertion on a tipped datadir): same gate set — PASS; scan-leg mutation receipt — hoist reverted makes the leg fail with exit 0 (pre-fix the scan never read the file); telemetry-skip receipt — a valid non-empty file on the same tipped datadir prints a featurebits: line, the empty flag prints none
- Deterministic static tooling (TOOLING_STAGE=static, new-only) — PASS at 1898145e and at 917ca8af

## Follow-ups / Waivers
- None
