### PR TITLE
RUB-1137: mirror Go devnet genesis-identity guard and canonical-genesis mining bootstrap in Rust

### DIFF
--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -12,7 +12,7 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
-use crate::genesis::validate_incoming_chain_id;
+use crate::genesis::validate_genesis_identity;
 use crate::io_utils::{
     atomic_write_error_before, parse_hex32, reclaim_atomic_write_parent,
     reclaim_atomic_write_scratch, write_file_atomic_typed, AtomicWriteError, AtomicWriteOperation,
@@ -171,7 +171,7 @@ impl ChainState {
         registry: Option<&SuiteRegistry>,
     ) -> Result<ChainStateConnectSummary, String> {
         let (block_height, expected_prev_hash) = self.next_block_context()?;
-        validate_incoming_chain_id(block_height, chain_id)?;
+        validate_genesis_identity(block_height, chain_id, block_bytes)?;
         let mut work_state = InMemoryChainState {
             utxos: copy_utxo_set(&self.utxos),
             already_generated: u128::from(self.already_generated),

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -383,6 +383,39 @@ pub fn validate_incoming_chain_id(block_height: u64, chain_id: [u8; 32]) -> Resu
     Ok(())
 }
 
+/// Height-0 genesis identity guard, mirroring the Go reference
+/// `SyncEngine.validateGenesisIdentity` (`clients/go/node/sync_pv.go`).
+///
+/// The two verdicts are ordered exactly as Go orders them: the chain_id verdict
+/// (`validate_incoming_chain_id`) first, then the hash verdict. Under a devnet
+/// ChainID a height-0 block whose hash differs from the published devnet genesis
+/// hash is rejected with `"genesis_hash mismatch"`. The all-zero ChainID skips
+/// both verdicts, preserving the synthetic height-0 fixtures unit tests build.
+///
+/// A block too short to carry a header, or one whose header does not hash, is
+/// passed through untouched: Go parses before it guards, so a malformed block
+/// must surface the parser's error, not a genesis verdict.
+pub fn validate_genesis_identity(
+    block_height: u64,
+    chain_id: [u8; 32],
+    block_bytes: &[u8],
+) -> Result<(), String> {
+    validate_incoming_chain_id(block_height, chain_id)?;
+    if block_height != 0 || chain_id != devnet_genesis_chain_id() {
+        return Ok(());
+    }
+    let Some(header) = block_bytes.get(..BLOCK_HEADER_BYTES) else {
+        return Ok(());
+    };
+    let Ok(hash) = block_hash(header) else {
+        return Ok(());
+    };
+    if hash != devnet_genesis_hash() {
+        return Err("genesis_hash mismatch".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 fn derive_devnet_genesis_chain_id() -> [u8; 32] {
     use sha3::{Digest, Sha3_256};
@@ -434,8 +467,9 @@ mod tests {
     use super::{
         build_suite_context_from_descriptor_with_production_lookup, derive_devnet_genesis_chain_id,
         devnet_genesis_block_bytes, devnet_genesis_chain_id, load_chain_id_from_genesis_file,
-        load_genesis_config, validate_incoming_chain_id, CryptoRotationDescriptor,
-        GenesisRotationDescriptor, GenesisSuiteParams, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
+        load_genesis_config, validate_genesis_identity, validate_incoming_chain_id,
+        CryptoRotationDescriptor, GenesisRotationDescriptor, GenesisSuiteParams,
+        BLOCK_HEADER_BYTES, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
     };
     use std::collections::BTreeMap;
 
@@ -1515,6 +1549,71 @@ mod tests {
     fn validate_incoming_chain_id_rejects_wrong_non_zero_genesis_chain_id() {
         let err = validate_incoming_chain_id(0, [0x11; 32]).unwrap_err();
         assert_eq!(err, "genesis chain_id mismatch");
+    }
+
+    /// Mirror of the Go reference fixture `mutatedDevnetGenesisBlock`
+    /// (clients/go/node/sync_genesis_identity_test.go): the published genesis
+    /// with its nonce's first byte flipped — parses identically, hashes
+    /// differently. The offset is derived from `BLOCK_HEADER_BYTES` so the
+    /// fixture survives a header layout that grows trailing fields.
+    fn mutated_devnet_genesis_block() -> Vec<u8> {
+        let mut wrong = devnet_genesis_block_bytes();
+        wrong[BLOCK_HEADER_BYTES - 8] ^= 0xFF;
+        wrong
+    }
+
+    #[test]
+    fn validate_genesis_identity_accepts_published_devnet_genesis_at_height_zero() {
+        validate_genesis_identity(0, devnet_genesis_chain_id(), &devnet_genesis_block_bytes())
+            .expect("published devnet genesis must pass the height-0 guard");
+    }
+
+    #[test]
+    fn validate_genesis_identity_rejects_wrong_devnet_genesis_at_height_zero() {
+        let err = validate_genesis_identity(
+            0,
+            devnet_genesis_chain_id(),
+            &mutated_devnet_genesis_block(),
+        )
+        .unwrap_err();
+        assert_eq!(err, "genesis_hash mismatch");
+    }
+
+    #[test]
+    fn validate_genesis_identity_skips_hash_verdict_when_chain_id_zero() {
+        validate_genesis_identity(0, [0u8; 32], &mutated_devnet_genesis_block())
+            .expect("zero chain_id must skip both height-0 verdicts");
+    }
+
+    /// Ordering row mirroring Go's `validateGenesisIdentity`: the chain_id
+    /// verdict is decided BEFORE the hash verdict, so a block that violates
+    /// both reports the chain_id message.
+    #[test]
+    fn validate_genesis_identity_reports_chain_id_verdict_before_hash_verdict() {
+        let err =
+            validate_genesis_identity(0, [0x11; 32], &mutated_devnet_genesis_block()).unwrap_err();
+        assert_eq!(err, "genesis chain_id mismatch");
+    }
+
+    #[test]
+    fn validate_genesis_identity_is_inert_above_height_zero() {
+        validate_genesis_identity(
+            1,
+            devnet_genesis_chain_id(),
+            &mutated_devnet_genesis_block(),
+        )
+        .expect("the guard applies to height 0 only");
+        validate_genesis_identity(1, [0x11; 32], &mutated_devnet_genesis_block())
+            .expect("the guard applies to height 0 only");
+    }
+
+    /// A block too short to carry a header yields no genesis verdict: Go parses
+    /// before it guards, so the parser owns that error class in both clients.
+    #[test]
+    fn validate_genesis_identity_leaves_headerless_block_to_the_parser() {
+        let short = vec![0u8; BLOCK_HEADER_BYTES - 1];
+        validate_genesis_identity(0, devnet_genesis_chain_id(), &short)
+            .expect("a headerless block must surface the parser's error, not a genesis verdict");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -3808,8 +3808,29 @@ mod tests {
         assert_eq!(code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
         let out = String::from_utf8(stdout).expect("utf8");
         assert!(out.contains("\"mine_blocks\": 2"), "stdout={out}");
-        assert!(out.contains("mined: height=0"), "stdout={out}");
+        // RUB-1137 migration (bootstrap-first): height 0 is the published
+        // devnet genesis the miner adopts, so the two mined blocks are heights
+        // 1 and 2. Original property — `--mine-blocks N` mines exactly N
+        // consecutive blocks and exits 0 — unchanged.
         assert!(out.contains("mined: height=1"), "stdout={out}");
+        assert!(out.contains("mined: height=2"), "stdout={out}");
+        assert!(!out.contains("mined: height=0"), "stdout={out}");
+
+        // Cross-client row-0 evidence: the freshly mined devnet datadir's
+        // canonical index row 0 is the published devnet genesis hash — the same
+        // literal the Go reference pins as `genesisBlockHashHex`
+        // (clients/go/node/chainstate.go).
+        let store = rubin_node::BlockStore::open(rubin_node::block_store_path(&dir))
+            .expect("open mined store");
+        let row0 = store
+            .canonical_hash(0)
+            .expect("read canonical row 0")
+            .expect("canonical row 0 present");
+        let row0_hex: String = row0.iter().map(|byte| format!("{byte:02x}")).collect();
+        assert_eq!(
+            row0_hex, "8d48b863805b96e5fcb79ee9652cd6257ae352b2f52088af921212039f9e8aff",
+            "mined devnet datadir row 0 must be the published genesis hash"
+        );
 
         fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -1477,6 +1477,59 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    /// Mirror of Go `TestMinerMineOne_PropagatesBootstrapError`
+    /// (clients/go/node/sync_genesis_identity_test.go): when the bootstrap
+    /// fails, `mine_one` surfaces that error instead of continuing into
+    /// candidate construction on an engine that cannot persist. Go triggers the
+    /// failure by nilling the engine's `chainState`; the Rust engine owns its
+    /// chainstate by value, so the equivalent construction is a latched
+    /// persistence fault — the only failure `bootstrap_canonical_genesis_if_empty`
+    /// can report before it applies anything.
+    ///
+    /// Asserting the returned message alone would be vacuous: a swallowed
+    /// bootstrap error is rediscovered with the SAME message when the candidate
+    /// reaches `apply_block`. The counting timestamp source isolates it — it is
+    /// consulted only during candidate construction.
+    #[test]
+    fn mine_one_propagates_bootstrap_error() {
+        use crate::io_utils::{atomic_write_error_after, AtomicWriteOperation};
+        let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-bootstrap-err");
+        let _ = sync.handle_persistence_error(
+            atomic_write_error_after(&dir, AtomicWriteOperation::Overwrite, "postcommit"),
+            false,
+            false,
+        );
+        let cfg = MinerConfig {
+            timestamp_source: bootstrap_error_timestamp_source,
+            ..MinerConfig::default()
+        };
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
+
+        assert_eq!(
+            miner
+                .mine_one(&[])
+                .expect_err("a halted engine must not mine"),
+            "storage persistence fault; restart required"
+        );
+        assert_eq!(
+            BOOTSTRAP_ERROR_TIMESTAMP_CALLS.load(Ordering::Relaxed),
+            0,
+            "mine_one must return at the bootstrap call, before building a candidate"
+        );
+        assert!(
+            !miner.sync.chain_state.has_tip,
+            "the failed bootstrap must not leave a tip behind"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Owned by `mine_one_propagates_bootstrap_error`; no other test installs it.
+    static BOOTSTRAP_ERROR_TIMESTAMP_CALLS: AtomicU64 = AtomicU64::new(0);
+    fn bootstrap_error_timestamp_source() -> u64 {
+        BOOTSTRAP_ERROR_TIMESTAMP_CALLS.fetch_add(1, Ordering::Relaxed);
+        1
+    }
+
     /// RUB-1137 accepted row: a fresh empty devnet datadir mined N times ends
     /// with the published devnet genesis at canonical index row 0 — the same
     /// row 0 the Go reference produces — mined heights 1..=N, and a restart

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -155,6 +155,15 @@ impl<'a> Miner<'a> {
     }
 
     pub fn mine_one(&mut self, txs: &[Vec<u8>]) -> Result<MinedBlock, String> {
+        // Ensure the chain is bootstrapped at the canonical published genesis
+        // before any candidate is built, mirroring the Go reference's
+        // `bootstrapGenesisIfNeeded` call position in `Miner.MineOne`
+        // (`clients/go/node/miner.go`). The height-0 genesis-identity guard
+        // rejects miner-synthesized height-0 blocks under a devnet ChainID, so
+        // empty-chain mining must start from the published bytes. The call is
+        // idempotent: a no-op once the chain has a tip and a no-op for ChainIDs
+        // without a published canonical genesis.
+        self.sync.bootstrap_canonical_genesis_if_empty()?;
         let next_height = if self.sync.chain_state.has_tip {
             self.sync
                 .chain_state
@@ -1455,12 +1464,52 @@ mod tests {
         };
         let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
 
+        // RUB-1137 migration (bootstrap-first): `mine_one` now adopts the
+        // published devnet genesis at height 0 before building a candidate, so
+        // the first mined block is height 1. Original property — mining from an
+        // empty state publishes a tip equal to the mined block — unchanged.
         let mined = miner.mine_one(&[]).expect("mine one");
-        assert_eq!(mined.height, 0);
+        assert_eq!(mined.height, 1);
         assert_eq!(mined.tx_count, 1);
         let tip = miner.sync.tip().expect("tip").expect("some tip");
-        assert_eq!(tip.0, 0);
+        assert_eq!(tip.0, 1);
         assert_eq!(tip.1, mined.hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// RUB-1137 accepted row: a fresh empty devnet datadir mined N times ends
+    /// with the published devnet genesis at canonical index row 0 — the same
+    /// row 0 the Go reference produces — mined heights 1..=N, and a restart
+    /// that reconciles cleanly onto the mined tip.
+    #[test]
+    fn mine_n_from_empty_devnet_chain_bootstraps_published_genesis_at_row_zero() {
+        let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-bootstrap-row0");
+        let cfg = MinerConfig {
+            timestamp_source: || 1,
+            ..MinerConfig::default()
+        };
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
+
+        let mined = miner.mine_n(2, &[]).expect("mine n");
+        assert_eq!(mined[0].height, 1);
+        assert_eq!(mined[1].height, 2);
+
+        let mut store =
+            BlockStore::open(crate::blockstore::block_store_path(&dir)).expect("reopen store");
+        assert_eq!(
+            store.canonical_hash(0).expect("row 0"),
+            Some(crate::genesis::devnet_genesis_hash()),
+            "row 0 must be the published devnet genesis, not a miner-synthesized block"
+        );
+        assert_eq!(store.tip().expect("tip"), Some((2, mined[1].hash)));
+
+        // Restart leg: the datadir reconciles cleanly onto the mined tip.
+        let cfg = miner.sync.cfg.clone();
+        let mut state = ChainState::new();
+        crate::reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile mined datadir");
+        assert_eq!(state.height, 2);
+        assert_eq!(state.tip_hash, mined[1].hash);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -1474,13 +1523,22 @@ mod tests {
         let mut pool = TxPool::new();
         let mut miner = Miner::new(&mut sync, Some(&mut pool), cfg).expect("miner");
 
+        // RUB-1137 migration (bootstrap-first): heights shift by one because
+        // height 0 is now the published devnet genesis. Original property —
+        // consecutive heights with non-decreasing timestamps — unchanged.
         let mined = miner.mine_n(3, &[]).expect("mine n");
         assert_eq!(mined.len(), 3);
-        assert_eq!(mined[0].height, 0);
-        assert_eq!(mined[1].height, 1);
-        assert_eq!(mined[2].height, 2);
-        assert!(mined[1].timestamp > mined[0].timestamp);
+        assert_eq!(mined[0].height, 1);
+        assert_eq!(mined[1].height, 2);
+        assert_eq!(mined[2].height, 3);
+        // Timestamps stay non-decreasing and advance across the run. The
+        // pre-migration strict `>` between the first two blocks was an artifact
+        // of the height-0 candidate taking the raw clock: every post-genesis
+        // height clamps to MTP+1, and the even-window MTP median repeats one
+        // value, so heights 1 and 2 may legitimately share a timestamp.
+        assert!(mined[1].timestamp >= mined[0].timestamp);
         assert!(mined[2].timestamp >= mined[1].timestamp);
+        assert!(mined[2].timestamp > mined[0].timestamp);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -1749,8 +1807,11 @@ mod tests {
         };
         let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
 
+        // RUB-1137 migration (bootstrap-first): height shifts 0 -> 1. Original
+        // property — the explicit transaction is included alongside the
+        // coinbase and a tip is published — unchanged.
         let mined = miner.mine_one(&[raw]).expect("mine one");
-        assert_eq!(mined.height, 0);
+        assert_eq!(mined.height, 1);
         assert_eq!(mined.tx_count, 2);
         assert!(miner.sync.chain_state.has_tip);
         let _ = fs::remove_dir_all(&dir);

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -969,6 +969,45 @@ impl SyncEngine {
         }
     }
 
+    /// Applies the published canonical genesis block to an empty chainstate when
+    /// the configured network has one, so the chain always starts from the
+    /// published bytes rather than from a miner-synthesized height-0 block.
+    /// Mirrors the Go reference `SyncEngine.BootstrapCanonicalGenesisIfEmpty`
+    /// (`clients/go/node/sync.go`).
+    ///
+    /// The height-0 genesis-identity guard rejects any block at height 0 whose
+    /// hash differs from the published devnet genesis under a devnet ChainID;
+    /// without this bootstrap the miner-driven empty-chain path would always
+    /// build a non-canonical height-0 block and fail under that guard.
+    ///
+    /// Idempotent. No-op when:
+    ///   - the chainstate already has a tip, or
+    ///   - `SyncConfig.chain_id` does not identify a network with a published
+    ///     canonical genesis (currently only `devnet_genesis_chain_id()`; the
+    ///     all-zero ChainID used by ephemeral unit tests is skipped on purpose
+    ///     to preserve those tests' synthetic genesis fixtures, mirroring the
+    ///     chain_id guard's zero-ChainID skip clause).
+    ///
+    /// A halted engine reports its persistence fault before the no-op checks,
+    /// exactly as the Go reference orders `mutationAllowed` first. On success
+    /// the tip is the published devnet genesis at height 0 and its bytes are
+    /// persisted through the NORMAL `apply_block` path, so persistence, index
+    /// row 0 and recovery semantics are the stock ones.
+    ///
+    /// Go's `raceTolerantBootstrapResult` recheck has no mirror here: it exists
+    /// because a Go `SyncEngine` shares its `*ChainState` with other holders
+    /// that can install a tip concurrently. The Rust engine owns `chain_state`
+    /// behind `&mut self`, so no concurrent tip can appear across this call and
+    /// an apply failure is always a real failure.
+    pub fn bootstrap_canonical_genesis_if_empty(&mut self) -> Result<(), String> {
+        self.mutation_allowed()?;
+        if self.chain_state.has_tip || self.cfg.chain_id != devnet_genesis_chain_id() {
+            return Ok(());
+        }
+        self.apply_block(&crate::genesis::devnet_genesis_block_bytes(), None)?;
+        Ok(())
+    }
+
     pub fn apply_block(
         &mut self,
         block_bytes: &[u8],
@@ -1693,7 +1732,9 @@ mod tests {
     use crate::blockstore::{block_store_path, BlockStore};
     use crate::chainstate::{chain_state_path, load_chain_state, ChainState};
     use crate::coinbase::{build_coinbase_tx, default_mine_address};
-    use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
+    use crate::genesis::{
+        devnet_genesis_block_bytes, devnet_genesis_chain_id, devnet_genesis_hash,
+    };
     use crate::io_utils::{
         atomic_write_error_after, unique_temp_path, AtomicWriteOperation, AtomicWriteStage,
         AtomicWriteTestOp, AtomicWriteTestScope,
@@ -2033,6 +2074,220 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    // ---------------------------------------------------------------------
+    // RUB-1137: height-0 genesis identity guard + canonical-genesis bootstrap.
+    // Mirrors clients/go/node/sync_genesis_identity_test.go.
+    // ---------------------------------------------------------------------
+
+    /// Engine on a real datadir, mirroring Go's `newGenesisIdentityTestEngine`:
+    /// a block store and a chainstate file so persistence is observable.
+    fn genesis_identity_engine(prefix: &str, chain_id: [u8; 32]) -> (SyncEngine, PathBuf) {
+        let dir = unique_temp_path(prefix);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("create store");
+        let cfg = default_sync_config(None, chain_id, Some(chain_state_path(&dir)));
+        let engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("engine");
+        (engine, dir)
+    }
+
+    /// Mirror of Go's `mutatedDevnetGenesisBlock`: the published genesis with
+    /// its nonce's first byte flipped. Still parses, hashes differently.
+    fn mutated_devnet_genesis_block() -> Vec<u8> {
+        let mut wrong = devnet_genesis_block_bytes();
+        wrong[BLOCK_HEADER_BYTES - 8] ^= 0xFF;
+        wrong
+    }
+
+    /// Every regular file under `dir` with its bytes, sorted by path — a
+    /// deterministic fingerprint for proving a reject path wrote nothing.
+    fn dir_fingerprint(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(current) = stack.pop() {
+            for entry in std::fs::read_dir(&current).expect("read_dir") {
+                let entry = entry.expect("dir entry");
+                let path = entry.path();
+                if entry.file_type().expect("file type").is_dir() {
+                    stack.push(path);
+                } else {
+                    out.push((path.clone(), std::fs::read(&path).expect("read file")));
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn apply_block_accepts_published_devnet_genesis_at_height_zero() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-genesis-ok", devnet_genesis_chain_id());
+        engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .expect("published devnet genesis must still apply");
+        assert_eq!(engine.chain_state.tip_hash, devnet_genesis_hash());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Rejected row + hostile row: the wrong height-0 block under a devnet
+    /// ChainID fails with the mirrored message AND mutates nothing — neither
+    /// the in-memory chainstate nor a single byte on disk.
+    #[test]
+    fn apply_block_rejects_wrong_devnet_genesis_at_height_zero_without_persistence() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-genesis-wrong", devnet_genesis_chain_id());
+        let before = dir_fingerprint(&dir);
+
+        let err = engine
+            .apply_block(&mutated_devnet_genesis_block(), None)
+            .unwrap_err();
+        assert_eq!(err, "genesis_hash mismatch");
+
+        assert!(
+            !engine.chain_state.has_tip,
+            "rejected genesis must not install a tip"
+        );
+        assert_eq!(engine.tip().expect("tip read"), None);
+        assert_eq!(
+            dir_fingerprint(&dir),
+            before,
+            "the reject path must not write to the datadir"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Re-proves the already-shipped chain_id half at the same call site.
+    #[test]
+    fn apply_block_rejects_height_zero_under_non_devnet_chain_id() {
+        let (mut engine, dir) = genesis_identity_engine("rubin-rust-genesis-chainid", [0x11; 32]);
+        let err = engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .unwrap_err();
+        assert_eq!(err, "genesis chain_id mismatch");
+        assert!(!engine.chain_state.has_tip);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Zero-ChainID skip, asserted by the negative shape exactly as Go does:
+    /// the mutated block may still fail further down in consensus connect, but
+    /// it must NOT fail with the genesis-hash verdict.
+    #[test]
+    fn apply_block_genesis_hash_guard_skips_when_chain_id_zero() {
+        let (mut engine, dir) = genesis_identity_engine("rubin-rust-genesis-zero", [0u8; 32]);
+        if let Err(err) = engine.apply_block(&mutated_devnet_genesis_block(), None) {
+            assert_ne!(
+                err, "genesis_hash mismatch",
+                "the hash guard must skip in zero-ChainID test mode"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bootstrap_canonical_genesis_if_empty_devnet_imports_published_genesis() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-bootstrap-devnet", devnet_genesis_chain_id());
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("bootstrap canonical genesis");
+
+        assert!(engine.chain_state.has_tip);
+        assert_eq!(engine.chain_state.height, 0);
+        assert_eq!(engine.chain_state.tip_hash, devnet_genesis_hash());
+        let store = engine.block_store_snapshot().expect("blockstore");
+        assert_eq!(
+            store.canonical_hash(0).expect("row 0"),
+            Some(devnet_genesis_hash())
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bootstrap_canonical_genesis_if_empty_is_noop_with_zero_chain_id() {
+        let (mut engine, dir) = genesis_identity_engine("rubin-rust-bootstrap-zero", [0u8; 32]);
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("zero-ChainID bootstrap must be a no-op");
+        assert!(
+            !engine.chain_state.has_tip,
+            "zero-ChainID bootstrap must leave the chain empty for synthetic-genesis fixtures"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bootstrap_canonical_genesis_if_empty_is_idempotent_after_tip() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-bootstrap-idem", devnet_genesis_chain_id());
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("first bootstrap");
+        let tip_before = engine.chain_state.tip_hash;
+        let height_before = engine.chain_state.height;
+
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("second bootstrap must be a no-op");
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("third bootstrap must be a no-op");
+
+        assert_eq!(engine.chain_state.tip_hash, tip_before);
+        assert_eq!(engine.chain_state.height, height_before);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Hostile row: a crash between the bootstrap-applied genesis and the first
+    /// mined block. The store holds the committed genesis while the in-memory
+    /// snapshot is lost; the stock recovery machinery reconciles forward onto
+    /// the published genesis. No new crash class is introduced.
+    #[test]
+    fn bootstrap_then_crash_before_first_mined_block_reconciles_cleanly() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-bootstrap-crash", devnet_genesis_chain_id());
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("bootstrap canonical genesis");
+        let mut store = engine.block_store_snapshot().expect("blockstore");
+        let cfg = engine.cfg.clone();
+        drop(engine);
+
+        // Worst-case crash: the chainstate snapshot never reached disk.
+        let mut state = ChainState::new();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile after crash");
+        assert!(changed, "reconcile must replay the committed genesis");
+        assert!(state.has_tip);
+        assert_eq!(state.height, 0);
+        assert_eq!(state.tip_hash, devnet_genesis_hash());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Hostile row, documenting observed behavior only: a pre-fix datadir whose
+    /// row 0 is a self-mined height-0 block. The bootstrap does NOT repair,
+    /// migrate or overwrite it — it is a no-op on any tipped chain. Repairing
+    /// such datadirs is explicitly out of this issue's scope; under RUB-1134's
+    /// genesis anchor they are the foreign-datadir class and operators reset.
+    #[test]
+    fn bootstrap_does_not_repair_a_pre_fix_self_mined_row_zero() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-bootstrap-prefix", devnet_genesis_chain_id());
+        engine.chain_state.has_tip = true;
+        engine.chain_state.height = 0;
+        engine.chain_state.tip_hash = [0x11; 32];
+
+        engine
+            .bootstrap_canonical_genesis_if_empty()
+            .expect("bootstrap must be a no-op on a tipped chain");
+
+        assert_eq!(engine.chain_state.height, 0);
+        assert_eq!(
+            engine.chain_state.tip_hash, [0x11; 32],
+            "a foreign row 0 is left untouched, not silently replaced"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -1746,6 +1746,7 @@ mod tests {
         target_context_for_candidate, CanonicalApplyTarget, SuiteContext, SyncEngine,
         MAX_PV_SHADOW_MAX_SAMPLES, PARENT_BLOCK_NOT_FOUND_ERR, UNBOUND_DEVNET_TARGET_ERR,
     };
+    use crate::test_helpers::coinbase_only_block_with_gen;
     use crate::undo::{build_block_undo, marshal_undo_envelope};
 
     /// Test-only rotation provider that counts how many times the
@@ -2158,6 +2159,27 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Mirror of Go `TestSyncEngineApplyBlockWithReorg_RejectsWrongDevnetGenesisAtHeight0`
+    /// (clients/go/node/sync_genesis_identity_test.go). `apply_block_with_reorg`
+    /// is the entry point the inbound P2P block path uses, so it needs its own
+    /// row: a relayed wrong genesis must not become local genesis there either.
+    /// Pins the routing, not a second guard — the empty-chain fast path reaches
+    /// the guard through `apply_block`.
+    #[test]
+    fn apply_block_with_reorg_rejects_wrong_devnet_genesis_at_height_zero() {
+        let (mut engine, dir) =
+            genesis_identity_engine("rubin-rust-genesis-reorg", devnet_genesis_chain_id());
+        let err = engine
+            .apply_block_with_reorg(&mutated_devnet_genesis_block(), None)
+            .unwrap_err();
+        assert_eq!(err, "genesis_hash mismatch");
+        assert!(
+            !engine.chain_state.has_tip,
+            "the reorg entry point must not install a foreign genesis either"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// Re-proves the already-shipped chain_id half at the same call site.
     #[test]
     fn apply_block_rejects_height_zero_under_non_devnet_chain_id() {
@@ -2265,27 +2287,90 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Hostile row, documenting observed behavior only: a pre-fix datadir whose
-    /// row 0 is a self-mined height-0 block. The bootstrap does NOT repair,
-    /// migrate or overwrite it — it is a no-op on any tipped chain. Repairing
-    /// such datadirs is explicitly out of this issue's scope; under RUB-1134's
-    /// genesis anchor they are the foreign-datadir class and operators reset.
+    /// Ordering pin for the bootstrap's documented `mutation_allowed()`-first
+    /// contract, mirroring Go's `BootstrapCanonicalGenesisIfEmpty`: a halted
+    /// engine reports its persistence fault even when the tip no-op would
+    /// otherwise return `Ok(())`. Reversed, `has_tip` would swallow the fault.
     #[test]
-    fn bootstrap_does_not_repair_a_pre_fix_self_mined_row_zero() {
+    fn bootstrap_canonical_genesis_if_empty_reports_persistence_fault_before_tip_noop() {
         let (mut engine, dir) =
-            genesis_identity_engine("rubin-rust-bootstrap-prefix", devnet_genesis_chain_id());
+            genesis_identity_engine("rubin-rust-bootstrap-halted", devnet_genesis_chain_id());
+        let _ = engine.handle_persistence_error(
+            atomic_write_error_after(&dir, AtomicWriteOperation::Overwrite, "postcommit"),
+            false,
+            false,
+        );
         engine.chain_state.has_tip = true;
-        engine.chain_state.height = 0;
-        engine.chain_state.tip_hash = [0x11; 32];
 
-        engine
-            .bootstrap_canonical_genesis_if_empty()
-            .expect("bootstrap must be a no-op on a tipped chain");
-
-        assert_eq!(engine.chain_state.height, 0);
         assert_eq!(
-            engine.chain_state.tip_hash, [0x11; 32],
-            "a foreign row 0 is left untouched, not silently replaced"
+            engine
+                .bootstrap_canonical_genesis_if_empty()
+                .expect_err("a halted engine must not report Ok from the tip no-op"),
+            "storage persistence fault; restart required"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Hostile row, documenting observed behavior only: a PRE-FIX Rust datadir
+    /// — canonical row 0 a self-mined, non-canonical height-0 block — restarted
+    /// by a post-fix devnet node. Repairing or migrating such datadirs is
+    /// explicitly OUT of this issue's scope: under RUB-1134's genesis anchor
+    /// they are the foreign-datadir class and operators reset.
+    ///
+    /// The fixture is written by a zero-ChainID engine — what a pre-fix devnet
+    /// engine effectively was here, no height-0 hash guard — so a miner-shaped
+    /// height-0 block commits through the stock apply path into canonical row 0
+    /// with a matching chainstate snapshot on disk. Both restart modes:
+    ///   (a) snapshot survived and still matches the store tip:
+    ///       `reconcile_chain_state_with_block_store` early-returns before any
+    ///       replay, the restart SUCCEEDS and the node keeps running on the
+    ///       foreign row 0 — this fix does not retroactively repair it;
+    ///   (b) snapshot lost or no longer matching: replay restarts at height 0,
+    ///       reaches the genesis-identity guard, and the restart fails with
+    ///       `"genesis_hash mismatch"` (fatal at startup).
+    #[test]
+    fn pre_fix_self_mined_datadir_restart_modes() {
+        let dir = unique_temp_path("rubin-rust-prefix-datadir");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let store = BlockStore::create(block_store_path(&dir)).expect("create store");
+        let pre_fix_cfg =
+            default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_path(&dir)));
+        let mut pre_fix =
+            SyncEngine::new(ChainState::new(), Some(store), pre_fix_cfg).expect("engine");
+        pre_fix
+            .apply_block(&coinbase_only_block_with_gen(0, 0, [0u8; 32], 1), None)
+            .expect("a pre-fix engine committed its own height-0 block");
+        let foreign_hash = pre_fix.chain_state.tip_hash;
+        assert_ne!(foreign_hash, devnet_genesis_hash());
+        let mut store = pre_fix.block_store_snapshot().expect("blockstore");
+        drop(pre_fix);
+
+        // Post-fix restart under the real devnet config.
+        let cfg = default_sync_config(
+            None,
+            devnet_genesis_chain_id(),
+            Some(chain_state_path(&dir)),
+        );
+
+        // (a) Intact snapshot -> early return, restart succeeds on foreign row 0.
+        let mut intact = load_chain_state(chain_state_path(&dir)).expect("pre-fix snapshot");
+        let changed = reconcile_chain_state_with_block_store(&mut intact, &mut store, &cfg)
+            .expect("a snapshot matching the store tip must reconcile without replay");
+        assert!(!changed, "a matching snapshot must not trigger replay");
+        assert_eq!(
+            intact.tip_hash, foreign_hash,
+            "the foreign row 0 keeps running: startup neither repairs nor rejects it"
+        );
+
+        // (b) Lost snapshot -> replay from 0 hits the guard, restart is fatal.
+        let mut lost = ChainState::new();
+        let err = reconcile_chain_state_with_block_store(&mut lost, &mut store, &cfg)
+            .expect_err("replay from height 0 must hit the genesis-identity guard");
+        assert_eq!(err, "genesis_hash mismatch");
+        assert_eq!(
+            store.canonical_hash(0).expect("row 0"),
+            Some(foreign_hash),
+            "neither restart mode rewrites the foreign datadir"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1137
- GitHub Issue mirror (non-authoritative): #2855

Refs: Q-XCLIENT-RUST-DEVNET-GENESIS-BOOTSTRAP-PARITY-01

## Summary
Rust mirrors the merged Go devnet genesis-identity subsystem: the apply-path height-0 guard gains its missing hash half (validate_genesis_identity — chain_id verdict first, then "genesis_hash mismatch", zero-ChainID skip preserved), SyncEngine gains bootstrap_canonical_genesis_if_empty (idempotent; no-op on a tipped chain or without a published canonical genesis; applies the published devnet genesis through the normal apply path), and mine_one performs that bootstrap before building any candidate. A fresh empty devnet datadir mined by Rust now carries the published devnet genesis at canonical index row 0 — the same literal hash Go produces — and mines heights 1..N; a miner-synthesized height-0 block is rejected identically by both clients. Pre-fix self-mined datadirs are documented in a test (restart modes) and their repair is explicitly out of scope. Test migrations shift pinned mined heights by one; zero-ChainID synthetic fixtures are untouched.

## Invariant
Under a devnet ChainID the Rust node accepts at height 0 only the published canonical devnet genesis block and, when mining from an empty chain, first adopts that published genesis through the normal apply path and mines on top of it — mirroring the merged Go reference including the zero-ChainID synthetic-fixture skip — so a freshly mined devnet datadir's canonical index row 0 equals the published devnet genesis hash in both clients and a miner-synthesized height-0 block is rejected identically by both.

## Scope
- Changed files: 5
- Surfaces: clients/rust (rubin-node crate only)
- Non-scope: mainnet pack identity (RUB-713/RUB-714); RUB-1134 store envelope and genesis anchor (separate branch, rebases on this); migration or repair of pre-fix self-mined datadirs; no Go change; no consensus-crate change; no script, dependency, or CLI change.
- Consensus rules unchanged: YES — node-level startup/mining bootstrap and an apply-path identity guard mirroring already-merged Go behavior; consensus crates untouched
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head fa9ab444 (history re-signed from 563d7d6b; tree byte-identical, verified 848cfa7e): scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace --locked' — PASS (892 passed, 0 failed); scripts/dev-env.sh -- bash scripts/test_node_storage_lock_parity.sh datadir — PASS; scripts/dev-env.sh -- bash scripts/test_node_storage_lock_parity.sh atomic-parent — PASS; scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./... && go vet ./...' — PASS (Go untouched); cargo fmt --check — PASS; cargo clippy --workspace --all-targets --locked -- -D warnings — PASS; deterministic static tooling (TOOLING_STAGE=static) — PASS
- New/migrated tests additionally run one-by-one via cargo test -p rubin-node --lib <fully-qualified> -- --exact — PASS (guard rows in genesis.rs, apply/bootstrap/restart-modes rows in sync.rs, miner bootstrap/propagation rows, bin mine-exit row)
- Mutation receipts on record: bootstrap call removed -> 8 lib tests + bin test red; guard hash half disabled -> wrong height-0 genesis accepted (unit and reorg-entry rows red); mutation_allowed reordered -> halted-engine row red; propagation ? dropped -> miner row red

## Follow-ups / Waivers
- RUB-1134 rebases onto this merge (queue dependency recorded in both contracts): https://linear.app/rubinp/issue/RUB-1134
- None otherwise

### Parity exemption justification
Rust-only mirror of the already-merged Go reference (sync_pv.go validateGenesisIdentity, sync.go BootstrapCanonicalGenesisIfEmpty, miner.go bootstrap call position; landed via PRs #1296/#1300 and unchanged here). Parity is discharged by mirrored unit tests pinning the exact Go message bytes ("genesis chain_id mismatch", "genesis_hash mismatch") and the literal Go genesis hash 8d48b863805b96e5fcb79ee9652cd6257ae352b2f52088af921212039f9e8aff as canonical row 0; contract RUB-1137 scopes this as a single-client parity-remediation slice with the cross-client property proven against the merged Go behavior.
