### PR TITLE
RUB-1134: envelope chainstate and canonical index files and anchor the index to genesis

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -550,6 +550,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// blockstore is reported, not fixed. Ordinary startup is unaffected:
 	// same two calls, same order, same errors, same exit codes.
 	if !*dryRun {
+		// RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
+		// not the configured genesis hash is a foreign datadir. Checked BEFORE
+		// the reconcile so no replay, truncate, or reconcile adoption ever
+		// consumes a foreign index; an empty index skips the anchor. --dry-run
+		// adopts nothing and stays a read-only report, so the anchor is
+		// enforced only on this mutating path. Rust mirror in
+		// clients/rust/crates/rubin-node/src/main.rs uses the same stderr
+		// frame and exit code.
+		if err := blockStore.VerifyGenesisAnchor(genesisHashFromGenesis); err != nil {
+			_, _ = fmt.Fprintf(stderr, "canonical index genesis anchor failed: %v\n", err)
+			return 2
+		}
 		if _, err := node.ReconcileChainStateWithBlockStore(chainState, blockStore, syncCfg); err != nil {
 			_, _ = fmt.Fprintf(stderr, "chainstate reconcile failed: %v\n", err)
 			return 2

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -552,12 +552,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if !*dryRun {
 		// RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
 		// not the configured genesis hash is a foreign datadir. Checked BEFORE
-		// the reconcile so no replay, truncate, or reconcile adoption ever
-		// consumes a foreign index; an empty index skips the anchor. --dry-run
-		// adopts nothing and stays a read-only report, so the anchor is
-		// enforced only on this mutating path. Rust mirror in
-		// clients/rust/crates/rubin-node/src/main.rs uses the same stderr
-		// frame and exit code.
+		// the reconcile so no replay, truncate or adoption consumes a foreign
+		// index; an empty index skips it. --dry-run adopts nothing, so the
+		// anchor is enforced only on this mutating path, as in the Rust mirror.
 		if err := blockStore.VerifyGenesisAnchor(genesisHashFromGenesis); err != nil {
 			_, _ = fmt.Fprintf(stderr, "canonical index genesis anchor failed: %v\n", err)
 			return 2

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1914,6 +1914,75 @@ func TestRunStartupFailsWhenChainstateReconcileFails(t *testing.T) {
 	}
 }
 
+// TestRunGenesisAnchorRefusesForeignDatadir drives the RUB-1134 genesis anchor
+// through run(): the node-package anchor test calls the BlockStore method
+// directly, so deleting this call site would leave every other suite green.
+// Row 0 here is a foreign chain's genesis, so a mutating startup must exit 2 on
+// the anchor message BEFORE the reconcile adopts anything and without touching
+// the datadir; --dry-run adopts nothing and therefore still exits 0.
+func TestRunGenesisAnchorRefusesForeignDatadir(t *testing.T) {
+	dir := t.TempDir()
+	store, err := node.CreateBlockStore(node.BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+	// A COHERENT foreign row 0: header, block bytes and index row agree, so the
+	// stored-identity checks all pass and only the anchor can refuse it.
+	block := append([]byte(nil), node.DevnetGenesisBlockBytes()...)
+	block[consensus.BLOCK_HEADER_BYTES-1] ^= 0x01 // another chain's genesis
+	header := block[:consensus.BLOCK_HEADER_BYTES]
+	foreign, err := consensus.BlockHash(header)
+	if err != nil {
+		t.Fatalf("BlockHash(foreign genesis): %v", err)
+	}
+	if foreign == node.DevnetGenesisBlockHash() {
+		t.Fatalf("fixture is not foreign")
+	}
+	if err := store.CommitCanonicalBlock(0, foreign, header, block, &node.BlockUndo{}); err != nil {
+		t.Fatalf("CommitCanonicalBlock: %v", err)
+	}
+	// Scoped to the blockstore subtree, where all canonical state lives: a
+	// mutating startup legitimately creates its datadir-root lock files
+	// (.rubin.lock, .rubin-atomic-write.lock) before the anchor runs, and those
+	// are infrastructure, not state. The marker bytes cover the CONTENT axis
+	// the snapshot does not.
+	storeRoot := node.BlockStorePath(dir)
+	marker := filepath.Join(storeRoot, "index.json")
+	before := datadirSnapshot(t, storeRoot)
+	markerBefore, err := os.ReadFile(marker) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+
+	// --mine-blocks/--mine-exit only bound the run: the anchor rejects long
+	// before the miner starts. Measured with the anchor call site deleted, a
+	// plain `--datadir` startup ACCEPTS this datadir and serves forever (the
+	// contract's "a coherent foreign datadir boots silently today"), so the
+	// bounded form keeps the regression signal fast and loud.
+	var out, errOut bytes.Buffer
+	if code := run([]string{"--datadir", dir, "--mine-blocks", "1", "--mine-exit"}, &out, &errOut); code != 2 {
+		t.Fatalf("run code=%d, want 2 (stderr=%q)", code, errOut.String())
+	}
+	const want = "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch."
+	if !strings.Contains(errOut.String(), want) {
+		t.Fatalf("stderr=%q, want %q", errOut.String(), want)
+	}
+	assertNoFilesystemWrite(t, before, datadirSnapshot(t, storeRoot))
+	if markerAfter, err := os.ReadFile(marker); err != nil || !bytes.Equal(markerAfter, markerBefore) {
+		t.Fatalf("the refused startup rewrote the canonical index: %q (%v)", markerAfter, err)
+	}
+	if _, err := os.Lstat(node.ChainStatePath(dir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the refused startup wrote a chainstate: %v", err)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := run([]string{"--dry-run", "--datadir", dir}, &out, &errOut); code != 0 {
+		t.Fatalf("dry-run code=%d, want 0 (stderr=%q)", code, errOut.String())
+	}
+	assertNoFilesystemWrite(t, before, datadirSnapshot(t, storeRoot))
+}
+
 // A datadir the reconcile cannot replay is exactly when an operator reaches
 // for --dry-run. It must not inherit the startup rejection above: --dry-run
 // never runs the reconcile, so it reports the store as found and exits 0.

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1963,7 +1963,7 @@ func TestRunGenesisAnchorRefusesForeignDatadir(t *testing.T) {
 	if code := run([]string{"--datadir", dir, "--mine-blocks", "1", "--mine-exit"}, &out, &errOut); code != 2 {
 		t.Fatalf("run code=%d, want 2 (stderr=%q)", code, errOut.String())
 	}
-	const want = "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch."
+	const want = "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch"
 	if !strings.Contains(errOut.String(), want) {
 		t.Fatalf("stderr=%q, want %q", errOut.String(), want)
 	}

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -565,13 +565,21 @@ func (bs *BlockStore) GetUndo(blockHash [32]byte) (*BlockUndo, error) {
 }
 
 // loadBlockStoreIndex reads the sole initialization marker. A missing marker is
-// an error, never an implicit empty index.
+// an error, never an implicit empty index (the RUB-1052/1053 strict-open
+// rejection, unchanged by the envelope). Every present marker must clear the
+// strict store_envelope_v1 (layout, canonical base64, domain-tagged checksum)
+// BEFORE the inner index decode runs; envelope failures carry the
+// ErrStoreIntegrity identity unwrapped so the pinned messages reach callers.
 func loadBlockStoreIndex(path string) (blockStoreIndexDisk, error) {
 	raw, err := readFileByPath(path)
 	if err != nil {
 		return blockStoreIndexDisk{}, err
 	}
-	index, err := decodeBlockStoreIndex(raw)
+	payload, err := openStoreEnvelope(storeEnvelopeBlockIndex, raw)
+	if err != nil {
+		return blockStoreIndexDisk{}, err
+	}
+	index, err := decodeBlockStoreIndex(payload)
 	if err != nil {
 		return blockStoreIndexDisk{}, fmt.Errorf("decode blockstore index: %w", err)
 	}
@@ -673,12 +681,46 @@ func validCanonicalHashHex(value string) bool {
 }
 
 func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {
-	raw, err := json.MarshalIndent(index, "", "  ")
+	payload, err := json.MarshalIndent(index, "", "  ")
 	if err != nil {
 		return err
 	}
-	raw = append(raw, '\n')
+	payload = append(payload, '\n')
+	// The pre-envelope on-disk bytes become the exact envelope payload: the
+	// inner index encoding is unchanged, only the frame is new. The existing
+	// atomic write path (temp, sync, rename, parent-sync) is unchanged.
+	raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, payload)
+	if err != nil {
+		return err
+	}
 	return writeFileAtomicFn(path, raw, 0o600)
+}
+
+// VerifyGenesisAnchor enforces the RUB-1134 genesis anchor: whenever the
+// loaded canonical index is non-empty, row 0 must equal the configured
+// genesis hash for the active network. An empty canonical index skips the
+// anchor (a fresh store has no rows to anchor). Failure is the distinct
+// fail-closed foreign-datadir class, not an envelope-integrity failure, and
+// satisfies errors.Is(err, ErrStoreIntegrity).
+//
+// Startup wiring (cmd/rubin-node/main.go) calls this BEFORE
+// ReconcileChainStateWithBlockStore, so no replay, truncate, or reconcile
+// adoption ever consumes an index whose row 0 names a foreign chain.
+func (bs *BlockStore) VerifyGenesisAnchor(genesisHash [32]byte) error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	row0, ok, err := bs.CanonicalHash(0)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if row0 != genesisHash {
+		return errStoreGenesisAnchor
+	}
+	return nil
 }
 
 func validateBlockHeaderHash(headerBytes []byte, blockHash [32]byte) error {

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -567,9 +567,9 @@ func (bs *BlockStore) GetUndo(blockHash [32]byte) (*BlockUndo, error) {
 // loadBlockStoreIndex reads the sole initialization marker. A missing marker is
 // an error, never an implicit empty index (the RUB-1052/1053 strict-open
 // rejection, unchanged by the envelope). Every present marker must clear the
-// strict store_envelope_v1 (layout, canonical base64, domain-tagged checksum)
-// BEFORE the inner index decode runs; envelope failures carry the
-// ErrStoreIntegrity identity unwrapped so the pinned messages reach callers.
+// strict store_envelope_v1 BEFORE the inner index decode runs; envelope
+// failures carry the ErrStoreIntegrity identity unwrapped, so the pinned
+// messages reach callers.
 func loadBlockStoreIndex(path string) (blockStoreIndexDisk, error) {
 	raw, err := readFileByPath(path)
 	if err != nil {
@@ -686,9 +686,8 @@ func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {
 		return err
 	}
 	payload = append(payload, '\n')
-	// The pre-envelope on-disk bytes become the exact envelope payload: the
-	// inner index encoding is unchanged, only the frame is new. The existing
-	// atomic write path (temp, sync, rename, parent-sync) is unchanged.
+	// The pre-envelope on-disk bytes become the exact envelope payload; the
+	// inner encoding and the atomic write path are unchanged.
 	raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, payload)
 	if err != nil {
 		return err
@@ -696,16 +695,13 @@ func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {
 	return writeFileAtomicFn(path, raw, 0o600)
 }
 
-// VerifyGenesisAnchor enforces the RUB-1134 genesis anchor: whenever the
-// loaded canonical index is non-empty, row 0 must equal the configured
-// genesis hash for the active network. An empty canonical index skips the
-// anchor (a fresh store has no rows to anchor). Failure is the distinct
-// fail-closed foreign-datadir class, not an envelope-integrity failure, and
-// satisfies errors.Is(err, ErrStoreIntegrity).
-//
-// Startup wiring (cmd/rubin-node/main.go) calls this BEFORE
-// ReconcileChainStateWithBlockStore, so no replay, truncate, or reconcile
-// adoption ever consumes an index whose row 0 names a foreign chain.
+// VerifyGenesisAnchor enforces the RUB-1134 genesis anchor: a non-empty
+// canonical index must carry the configured genesis hash at row 0, while an
+// empty index skips the anchor. Failure is the distinct fail-closed
+// foreign-datadir class, not an envelope-integrity failure, and satisfies
+// errors.Is(err, ErrStoreIntegrity). Startup wiring (cmd/rubin-node/main.go)
+// calls this BEFORE ReconcileChainStateWithBlockStore, so no replay, truncate
+// or reconcile adoption ever consumes a foreign index.
 func (bs *BlockStore) VerifyGenesisAnchor(genesisHash [32]byte) error {
 	if bs == nil {
 		return errors.New("nil blockstore")

--- a/clients/go/node/blockstore_additional_test.go
+++ b/clients/go/node/blockstore_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -34,42 +35,40 @@ func TestLoadBlockStoreIndex_Errors(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid_json", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "index.json")
-		if err := os.WriteFile(path, []byte("{\n"), 0o600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
+	mustMarshal := func(index blockStoreIndexDisk) []byte {
+		raw, err := json.Marshal(index)
+		if err != nil {
+			t.Fatalf("marshal index: %v", err)
 		}
-		if _, err := loadBlockStoreIndex(path); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
-
-	t.Run("version_mismatch", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "index.json")
-		raw, _ := json.Marshal(blockStoreIndexDisk{Version: blockStoreIndexVersion + 1, Canonical: []string{}})
-		raw = append(raw, '\n')
-		if err := os.WriteFile(path, raw, 0o600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
-		}
-		if _, err := loadBlockStoreIndex(path); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
-
-	t.Run("invalid_canonical_hash", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "index.json")
-		raw, _ := json.Marshal(blockStoreIndexDisk{Version: blockStoreIndexVersion, Canonical: []string{"zz"}})
-		raw = append(raw, '\n')
-		if err := os.WriteFile(path, raw, 0o600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
-		}
-		if _, err := loadBlockStoreIndex(path); err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+		return append(raw, '\n')
+	}
+	// RUB-1134: each payload is planted INSIDE a valid frame, so the row still
+	// reaches the INNER decode class it names rather than the legacy verdict
+	// (owned by TestBlockstoreIndexRejectsIntegrityFailures).
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+	}{
+		{"invalid_json", []byte("{\n")},
+		{"version_mismatch", mustMarshal(blockStoreIndexDisk{Version: blockStoreIndexVersion + 1, Canonical: []string{}})},
+		{"invalid_canonical_hash", mustMarshal(blockStoreIndexDisk{Version: blockStoreIndexVersion, Canonical: []string{"zz"}})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "index.json")
+			raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, tc.payload)
+			if err != nil {
+				t.Fatalf("wrap index: %v", err)
+			}
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := loadBlockStoreIndex(path); err == nil {
+				t.Fatalf("expected error")
+			} else if errors.Is(err, ErrStoreIntegrity) {
+				t.Fatalf("row must fail on the inner decode class, got %v", err)
+			}
+		})
+	}
 }
 
 func TestBlockStorePutBlock_RejectsInvalidHeaderLen(t *testing.T) {

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -645,12 +645,10 @@ func TestCreateBlockStoreCommitsExactEmptyMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read marker: %v", err)
 	}
-	// RUB-1134: the marker is the store_envelope_v1 frame over the UNCHANGED
-	// inner payload "{\n  \"canonical\": [],\n  \"version\": 1\n}\n". The
+	// RUB-1134: the marker is the frame over the UNCHANGED inner payload; the
 	// literal below is the cross-client vector
-	// `blockstore_index_empty_marker_payload` (store_envelope_test.go, Rust
-	// twin `store_envelope_v1_cross_client_vectors`), so this row doubles as
-	// the on-disk pin of those exact bytes.
+	// `blockstore_index_empty_marker_payload`, so this row doubles as its
+	// on-disk pin.
 	want := `{"version":1,"payload_b64":"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=",` +
 		`"checksum":"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15"}` + "\n"
 	if string(raw) != want {
@@ -776,10 +774,8 @@ func TestOpenBlockStoreRejectsMalformedMarker(t *testing.T) {
 	root := BlockStorePath(freshDataDir(t))
 	mustCreateBlockStore(t, root)
 	marker := filepath.Join(root, "index.json")
-	// RUB-1134: every row is planted INSIDE a valid store_envelope_v1 frame
-	// with a correct checksum, so this table keeps testing the inner marker
-	// schema exactly as before. Frame-level rejection (legacy, checksum,
-	// duplicate/unknown envelope fields) is pinned by
+	// RUB-1134: every row is planted INSIDE a valid frame, so this table keeps
+	// testing the inner marker schema; frame-level rejection is pinned by
 	// TestBlockstoreIndexRejectsIntegrityFailures.
 	writeEnvelopedMarker := func(t *testing.T, body string) {
 		t.Helper()

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -645,8 +645,23 @@ func TestCreateBlockStoreCommitsExactEmptyMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read marker: %v", err)
 	}
-	if want := "{\n  \"canonical\": [],\n  \"version\": 1\n}\n"; string(raw) != want {
+	// RUB-1134: the marker is the store_envelope_v1 frame over the UNCHANGED
+	// inner payload "{\n  \"canonical\": [],\n  \"version\": 1\n}\n". The
+	// literal below is the cross-client vector
+	// `blockstore_index_empty_marker_payload` (store_envelope_test.go, Rust
+	// twin `store_envelope_v1_cross_client_vectors`), so this row doubles as
+	// the on-disk pin of those exact bytes.
+	want := `{"version":1,"payload_b64":"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=",` +
+		`"checksum":"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15"}` + "\n"
+	if string(raw) != want {
 		t.Fatalf("marker = %q, want %q", raw, want)
+	}
+	payload, err := openStoreEnvelope(storeEnvelopeBlockIndex, raw)
+	if err != nil {
+		t.Fatalf("open marker envelope: %v", err)
+	}
+	if wantPayload := "{\n  \"canonical\": [],\n  \"version\": 1\n}\n"; string(payload) != wantPayload {
+		t.Fatalf("marker payload = %q, want %q", payload, wantPayload)
 	}
 	mustOpenBlockStore(t, root)
 }
@@ -761,10 +776,23 @@ func TestOpenBlockStoreRejectsMalformedMarker(t *testing.T) {
 	root := BlockStorePath(freshDataDir(t))
 	mustCreateBlockStore(t, root)
 	marker := filepath.Join(root, "index.json")
-	for _, tc := range rejected {
-		if err := os.WriteFile(marker, []byte(tc.body), 0o600); err != nil {
-			t.Fatalf("%s: write marker: %v", tc.name, err)
+	// RUB-1134: every row is planted INSIDE a valid store_envelope_v1 frame
+	// with a correct checksum, so this table keeps testing the inner marker
+	// schema exactly as before. Frame-level rejection (legacy, checksum,
+	// duplicate/unknown envelope fields) is pinned by
+	// TestBlockstoreIndexRejectsIntegrityFailures.
+	writeEnvelopedMarker := func(t *testing.T, body string) {
+		t.Helper()
+		raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, []byte(body))
+		if err != nil {
+			t.Fatalf("wrap marker: %v", err)
 		}
+		if err := os.WriteFile(marker, raw, 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+	}
+	for _, tc := range rejected {
+		writeEnvelopedMarker(t, tc.body)
 		if _, err := OpenBlockStore(root); err == nil {
 			t.Fatalf("marker row %s must be rejected", tc.name)
 		}
@@ -778,9 +806,7 @@ func TestOpenBlockStoreRejectsMalformedMarker(t *testing.T) {
 		{`{"version":1,"canonical":[]}`, 0},
 		{`{"canonical":["` + hash + `"],"version":1}`, 1},
 	} {
-		if err := os.WriteFile(marker, []byte(tc.body), 0o600); err != nil {
-			t.Fatalf("write marker: %v", err)
-		}
+		writeEnvelopedMarker(t, tc.body)
 		store, err := OpenBlockStore(root)
 		if err != nil {
 			t.Fatalf("%s must be accepted: %v", tc.body, err)

--- a/clients/go/node/chainstate_additional_test.go
+++ b/clients/go/node/chainstate_additional_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,12 +24,20 @@ func TestLoadChainState_InvalidFileName(t *testing.T) {
 func TestLoadChainState_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "chainstate.json")
-	if err := os.WriteFile(path, []byte("{\n"), 0o600); err != nil {
+	// RUB-1134: planted INSIDE a valid frame so the row still reaches the INNER
+	// chainStateDisk decode rather than the legacy verdict (owned by
+	// TestLoadChainStateRejectsIntegrityFailures).
+	raw, err := marshalStoreEnvelope(storeEnvelopeChainState, []byte("{\n"))
+	if err != nil {
+		t.Fatalf("wrap chainstate: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	_, err := LoadChainState(path)
-	if err == nil {
+	if _, err := LoadChainState(path); err == nil {
 		t.Fatalf("expected error")
+	} else if errors.Is(err, ErrStoreIntegrity) {
+		t.Fatalf("row must fail on the inner decode class, got %v", err)
 	}
 }
 

--- a/clients/go/node/chainstate_io.go
+++ b/clients/go/node/chainstate_io.go
@@ -100,6 +100,12 @@ func ChainStatePath(dataDir string) string {
 	return filepath.Join(dataDir, chainStateFileName)
 }
 
+// LoadChainState reads the store_envelope_v1-wrapped snapshot. An ABSENT file
+// keeps the NewChainState-plus-full-replay repair path; every present file
+// must clear the strict envelope (layout, canonical base64, domain-tagged
+// checksum) BEFORE the inner chainStateDisk decode runs. Envelope failures
+// carry the ErrStoreIntegrity identity and never satisfy fs.ErrNotExist, so
+// a corrupt file can never ride the absent-file fallback.
 func LoadChainState(path string) (*ChainState, error) {
 	raw, err := readFileByPath(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -108,8 +114,12 @@ func LoadChainState(path string) (*ChainState, error) {
 	if err != nil {
 		return nil, err
 	}
+	payload, err := openStoreEnvelope(storeEnvelopeChainState, raw)
+	if err != nil {
+		return nil, err
+	}
 	var disk chainStateDisk
-	if err := json.Unmarshal(raw, &disk); err != nil {
+	if err := json.Unmarshal(payload, &disk); err != nil {
 		return nil, fmt.Errorf("decode chainstate: %w", err)
 	}
 	return chainStateFromDisk(disk)
@@ -123,11 +133,17 @@ func (s *ChainState) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	raw, err := json.MarshalIndent(disk, "", "  ")
+	payload, err := json.MarshalIndent(disk, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode chainstate: %w", err)
 	}
-	raw = append(raw, '\n')
+	payload = append(payload, '\n')
+	// The pre-envelope on-disk bytes become the exact envelope payload: the
+	// inner chainStateDisk encoding is unchanged, only the frame is new.
+	raw, err := marshalStoreEnvelope(storeEnvelopeChainState, payload)
+	if err != nil {
+		return err
+	}
 	if err := validateAtomicWriteDestination(path, atomicWriteOverwrite); err != nil {
 		return err
 	}

--- a/clients/go/node/chainstate_io.go
+++ b/clients/go/node/chainstate_io.go
@@ -101,11 +101,10 @@ func ChainStatePath(dataDir string) string {
 }
 
 // LoadChainState reads the store_envelope_v1-wrapped snapshot. An ABSENT file
-// keeps the NewChainState-plus-full-replay repair path; every present file
-// must clear the strict envelope (layout, canonical base64, domain-tagged
-// checksum) BEFORE the inner chainStateDisk decode runs. Envelope failures
-// carry the ErrStoreIntegrity identity and never satisfy fs.ErrNotExist, so
-// a corrupt file can never ride the absent-file fallback.
+// keeps the NewChainState-plus-full-replay repair path; every present file must
+// clear the strict envelope BEFORE the inner chainStateDisk decode runs.
+// Envelope failures carry the ErrStoreIntegrity identity and never satisfy
+// fs.ErrNotExist, so a corrupt file can never ride the absent-file fallback.
 func LoadChainState(path string) (*ChainState, error) {
 	raw, err := readFileByPath(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -138,8 +137,7 @@ func (s *ChainState) Save(path string) error {
 		return fmt.Errorf("encode chainstate: %w", err)
 	}
 	payload = append(payload, '\n')
-	// The pre-envelope on-disk bytes become the exact envelope payload: the
-	// inner chainStateDisk encoding is unchanged, only the frame is new.
+	// The pre-envelope on-disk bytes become the exact envelope payload.
 	raw, err := marshalStoreEnvelope(storeEnvelopeChainState, payload)
 	if err != nil {
 		return err

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -64,9 +64,8 @@ func TestChainStateSaveLoadRoundTripDeterministic(t *testing.T) {
 		t.Fatalf("chainstate encoding is not deterministic")
 	}
 
-	// RUB-1134: the saved file is the store_envelope_v1 frame; the INNER
-	// chainStateDisk encoding this test pins is unchanged, so the payload is
-	// opened first and everything below still asserts the inner bytes.
+	// RUB-1134: the saved file is the frame; the INNER chainStateDisk encoding
+	// this test pins is unchanged, so the payload is opened first.
 	firstPayload, err := openStoreEnvelope(storeEnvelopeChainState, firstBytes)
 	if err != nil {
 		t.Fatalf("open chainstate envelope: %v", err)

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -64,8 +64,15 @@ func TestChainStateSaveLoadRoundTripDeterministic(t *testing.T) {
 		t.Fatalf("chainstate encoding is not deterministic")
 	}
 
+	// RUB-1134: the saved file is the store_envelope_v1 frame; the INNER
+	// chainStateDisk encoding this test pins is unchanged, so the payload is
+	// opened first and everything below still asserts the inner bytes.
+	firstPayload, err := openStoreEnvelope(storeEnvelopeChainState, firstBytes)
+	if err != nil {
+		t.Fatalf("open chainstate envelope: %v", err)
+	}
 	var disk chainStateDisk
-	if err := json.Unmarshal(firstBytes, &disk); err != nil {
+	if err := json.Unmarshal(firstPayload, &disk); err != nil {
 		t.Fatalf("decode disk chainstate: %v", err)
 	}
 	if len(disk.Utxos) != 2 {

--- a/clients/go/node/store_envelope.go
+++ b/clients/go/node/store_envelope.go
@@ -1,0 +1,247 @@
+package node
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// store_envelope_v1 (RUB-1134)
+//
+// The persisted chainstate snapshot (chainstate.json) and the canonical
+// blockstore index (index.json) are each stored as one compact JSON object
+// binding the exact inner payload bytes to a domain-tagged checksum:
+//
+//	{"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n
+//
+// checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload).
+// The length term makes the preimage injective, so no two payloads share a
+// digest by concatenation. The trailing LF is NOT in the preimage. Domain
+// tags: "RUBIN_CHAINSTATE_V1" for chainstate.json and
+// "RUBIN_BLOCKSTORE_INDEX_V1" for index.json. Both files are per-datadir
+// singletons, so the domain tag is the identity; chain identity is enforced
+// by the separate genesis anchor (BlockStore.VerifyGenesisAnchor), never by
+// an envelope field.
+//
+// These helpers are 3-field siblings of the merged undo_envelope_v1 frame
+// (undo.go, RUB-1132), which embeds block_hash in its prefix and preimage and
+// therefore cannot be reused as-is. Its structure is mirrored deliberately:
+// strict field order, compact JSON, one trailing LF outside the preimage,
+// constant-time checksum compare, layout validation by index arithmetic with
+// JSON parsed only on the reject path.
+//
+// Deliberately UNBOUNDED: both payloads grow with accumulated state (UTXO-set
+// size, chain length), so per the RUB-1057 standing decision no read or save
+// size bound exists here and none may be added.
+//
+// Rust twin: crates/rubin-node/src/store_envelope.rs. Both clients must emit
+// byte-identical envelopes for the same payload bytes; the mirrored
+// cross-client vectors pin those bytes in both test suites.
+//
+// Claim boundary: this detects accidental, torn, tool-mediated and parse-valid
+// local corruption before either file is adopted. It is NOT authentication — a
+// local actor able to rewrite payload and checksum together defeats it.
+// ---------------------------------------------------------------------------
+
+// ErrStoreIntegrity is the stable identity behind every envelope, version,
+// base64, checksum and genesis-anchor rejection class in the RUB-1134
+// error_contract: errors.Is(err, ErrStoreIntegrity) holds for all of them, and
+// the pinned messages are the exact cross-client strings Rust returns verbatim.
+// None of these is, wraps, or satisfies fs.ErrNotExist: absent-file fallbacks
+// must never trigger on a corrupt file. The inner payload-decode class is
+// deliberately OUTSIDE this identity: a file that clears the checksum is intact
+// on disk, so a failure past it is a schema fault, not an integrity fault.
+var ErrStoreIntegrity = errors.New("STORE_INTEGRITY")
+
+var (
+	// Pinned cross-client messages. Rust returns these same strings.
+	// Deliberately no repair command: this build ships no --reindex.
+	errStoreLegacyChainState = fmt.Errorf("%w: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay.", ErrStoreIntegrity)
+	errStoreLegacyBlockIndex = fmt.Errorf("%w: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required.", ErrStoreIntegrity)
+	errStoreChecksumMismatch = fmt.Errorf("%w: checksum mismatch.", ErrStoreIntegrity)
+	errStoreGenesisAnchor    = fmt.Errorf("%w: canonical index genesis mismatch.", ErrStoreIntegrity)
+)
+
+// The canonical envelope's byte layout is fully determined by these fixed
+// segments plus the 64-character checksum, so the reader validates the layout
+// by index arithmetic instead of decoding JSON: no value is materialized on
+// the accept path and payload_b64 is a SLICE of the caller's buffer. Rust
+// twin: STORE_ENVELOPE_PREFIX and friends in store_envelope.rs.
+const (
+	storeEnvelopePrefix      = `{"version":1,"payload_b64":"`
+	storeEnvelopeChecksumSep = `","checksum":"`
+	storeEnvelopeSuffix      = "\"}\n"
+	storeEnvelopeVersion     = 1
+	storeChecksumHexLen      = 64
+	storeEnvelopeFrameBytes  = len(storeEnvelopePrefix) + len(storeEnvelopeChecksumSep) +
+		storeChecksumHexLen + len(storeEnvelopeSuffix)
+	storeChainStateDomain = "RUBIN_CHAINSTATE_V1"
+	storeBlockIndexDomain = "RUBIN_BLOCKSTORE_INDEX_V1"
+)
+
+// storeEnvelopeKind carries the per-file parameters of the shared frame: the
+// checksum domain tag, the noun used in shape errors, and the pinned legacy
+// message for a pre-envelope file of that class.
+type storeEnvelopeKind struct {
+	domain    string
+	noun      string
+	legacyErr error
+}
+
+var (
+	storeEnvelopeChainState = storeEnvelopeKind{
+		domain:    storeChainStateDomain,
+		noun:      "chainstate",
+		legacyErr: errStoreLegacyChainState,
+	}
+	storeEnvelopeBlockIndex = storeEnvelopeKind{
+		domain:    storeBlockIndexDomain,
+		noun:      "blockstore index",
+		legacyErr: errStoreLegacyBlockIndex,
+	}
+)
+
+// storeEnvelopeDisk is the writer's shape; the reader never decodes into it.
+// Field ORDER is part of the format: encoding/json emits struct fields in
+// declaration order and serde does the same, which is what makes the two
+// clients' envelope bytes identical for identical payload bytes.
+type storeEnvelopeDisk struct {
+	Version    uint32 `json:"version"`
+	PayloadB64 string `json:"payload_b64"`
+	Checksum   string `json:"checksum"`
+}
+
+// storeEnvelopeChecksum streams the preimage into the hash rather than
+// materializing it; the payload can be large (unbounded class) and the whole
+// point of this path is one decision before any inner decode. hash.Hash.Write
+// never returns an error. Rust twin: store_envelope_checksum.
+func storeEnvelopeChecksum(domain string, payload []byte) [32]byte {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(payload)))
+	hasher := sha3.New256()
+	_, _ = hasher.Write([]byte(domain))
+	_, _ = hasher.Write(length[:])
+	_, _ = hasher.Write(payload)
+	var out [32]byte
+	hasher.Sum(out[:0])
+	return out
+}
+
+// marshalStoreEnvelope wraps the exact payload bytes in the v1 frame. New
+// writes emit v1 only; there is deliberately no size bound on either side
+// (RUB-1057 standing decision for both protected files).
+func marshalStoreEnvelope(kind storeEnvelopeKind, payload []byte) ([]byte, error) {
+	checksum := storeEnvelopeChecksum(kind.domain, payload)
+	raw, err := json.Marshal(storeEnvelopeDisk{
+		Version:    storeEnvelopeVersion,
+		PayloadB64: base64.StdEncoding.EncodeToString(payload),
+		Checksum:   hex.EncodeToString(checksum[:]),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode %s envelope: %w", kind.noun, err)
+	}
+	return append(raw, '\n'), nil
+}
+
+// openStoreEnvelope runs the validation order on one protected file: strict
+// canonical layout (which subsumes shape, version-literal, duplicate,
+// unknown, missing, null, wrong-type, ordering, whitespace and trailing-token
+// rejection, with unversioned legacy classified before the exact-field-set
+// verdict), canonical padded base64, then the constant-time checksum compare.
+// Only after checksum success does the caller decode the inner schema.
+func openStoreEnvelope(kind storeEnvelopeKind, raw []byte) ([]byte, error) {
+	payloadB64, checksumHex, err := splitStoreEnvelope(kind, raw)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := decodeCanonicalStoreBase64(payloadB64)
+	if err != nil {
+		return nil, err
+	}
+	// splitStoreEnvelope already proved this is 64 lowercase hex characters.
+	stored, err := hex.DecodeString(string(checksumHex))
+	if err != nil {
+		return nil, fmt.Errorf("%w: checksum is not hexadecimal", ErrStoreIntegrity)
+	}
+	computed := storeEnvelopeChecksum(kind.domain, payload)
+	if subtle.ConstantTimeCompare(stored, computed[:]) != 1 {
+		return nil, errStoreChecksumMismatch
+	}
+	return payload, nil
+}
+
+// splitStoreEnvelope validates the canonical layout and returns sub-slices of
+// raw. The body length is DERIVED (len(raw) - frame) rather than searched for,
+// so any inserted, removed, reordered, duplicated or renamed field shifts the
+// trailing segments and fails. On failure it hands off to
+// classifyStoreEnvelopeFailure, the only path that parses JSON at all.
+func splitStoreEnvelope(kind storeEnvelopeKind, raw []byte) (payloadB64, checksumHex []byte, err error) {
+	body := len(raw) - storeEnvelopeFrameBytes
+	if body < 0 {
+		return nil, nil, classifyStoreEnvelopeFailure(kind, raw)
+	}
+	payloadAt := len(storeEnvelopePrefix)
+	checksumSepAt := payloadAt + body
+	checksumAt := checksumSepAt + len(storeEnvelopeChecksumSep)
+	suffixAt := checksumAt + storeChecksumHexLen
+	if string(raw[:payloadAt]) != storeEnvelopePrefix ||
+		string(raw[checksumSepAt:checksumAt]) != storeEnvelopeChecksumSep ||
+		string(raw[suffixAt:]) != storeEnvelopeSuffix {
+		return nil, nil, classifyStoreEnvelopeFailure(kind, raw)
+	}
+	checksumHex = raw[checksumAt:suffixAt]
+	if !validCanonicalHashHex(string(checksumHex)) {
+		return nil, nil, fmt.Errorf("%w: checksum must be 64 lowercase hex characters", ErrStoreIntegrity)
+	}
+	return raw[payloadAt:checksumSepAt], checksumHex, nil
+}
+
+// classifyStoreEnvelopeFailure names WHY a file that failed the layout check
+// failed it; it runs only on files already being rejected, so its JSON scan is
+// never paid on the accept path. It decodes ONE value and ignores anything
+// after it, and duplicate keys last-win (both mirrored by the Rust twin), so a
+// legacy file with trailing garbage still reports the actionable legacy
+// message. A pre-envelope legacy file carries NEITHER payload_b64 NOR checksum
+// — both legacy inner schemas carry their own top-level "version": 1, which is
+// why legacy detection keys on the envelope fields and precedes the version
+// verdicts.
+func classifyStoreEnvelopeFailure(kind storeEnvelopeKind, raw []byte) error {
+	var probe map[string]json.RawMessage
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&probe); err != nil || probe == nil {
+		return fmt.Errorf("%w: %s is not a single JSON object", ErrStoreIntegrity, kind.noun)
+	}
+	_, hasPayload := probe["payload_b64"]
+	_, hasChecksum := probe["checksum"]
+	if !hasPayload && !hasChecksum {
+		return kind.legacyErr
+	}
+	// A POINTER target: JSON null decodes into it as nil WITHOUT an error, so
+	// `"version":null` is classified as a non-canonical frame rather than as
+	// "unsupported version 0". Any non-integer spelling errors instead. Rust
+	// twin classifies the same three cases identically.
+	var version *uint64
+	if err := json.Unmarshal(probe["version"], &version); err == nil && version != nil && *version != storeEnvelopeVersion {
+		return fmt.Errorf("%w: unsupported store envelope version %d", ErrStoreIntegrity, *version)
+	}
+	return fmt.Errorf("%w: envelope is not the canonical encoding", ErrStoreIntegrity)
+}
+
+// decodeCanonicalStoreBase64 accepts only the one padded RFC 4648 spelling of
+// the payload. Sibling of the undo-class decoder with the store identity:
+// Strict() covers non-zero padding bits, the EncodedLen equality covers the
+// rest, notably the \r and \n Go's decoder silently skips.
+func decodeCanonicalStoreBase64(value []byte) ([]byte, error) {
+	payload := make([]byte, base64.StdEncoding.DecodedLen(len(value)))
+	n, err := base64.StdEncoding.Strict().Decode(payload, value)
+	if err != nil || base64.StdEncoding.EncodedLen(n) != len(value) {
+		return nil, fmt.Errorf("%w: payload_b64 is not canonical padded base64", ErrStoreIntegrity)
+	}
+	return payload[:n], nil
+}

--- a/clients/go/node/store_envelope.go
+++ b/clients/go/node/store_envelope.go
@@ -13,37 +13,30 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// store_envelope_v1 (RUB-1134)
-//
-// The persisted chainstate snapshot (chainstate.json) and the canonical
-// blockstore index (index.json) are each stored as one compact JSON object
-// binding the exact inner payload bytes to a domain-tagged checksum:
+// store_envelope_v1 (RUB-1134) — authoritative description of the format the
+// Rust twin (crates/rubin-node/src/store_envelope.rs) mirrors byte for byte.
+// chainstate.json and the canonical blockstore index.json are each stored as one
+// compact JSON object binding the exact inner payload bytes to a domain-tagged
+// checksum:
 //
 //	{"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n
 //
 // checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload).
 // The length term makes the preimage injective, so no two payloads share a
-// digest by concatenation. The trailing LF is NOT in the preimage. Domain
-// tags: "RUBIN_CHAINSTATE_V1" for chainstate.json and
-// "RUBIN_BLOCKSTORE_INDEX_V1" for index.json. Both files are per-datadir
-// singletons, so the domain tag is the identity; chain identity is enforced
-// by the separate genesis anchor (BlockStore.VerifyGenesisAnchor), never by
-// an envelope field.
+// digest by concatenation. The trailing LF is NOT in the preimage. Domain tags
+// are "RUBIN_CHAINSTATE_V1" and "RUBIN_BLOCKSTORE_INDEX_V1": both files are
+// per-datadir singletons, so the domain tag is the identity, and chain identity
+// is enforced by the separate genesis anchor (BlockStore.VerifyGenesisAnchor),
+// never by an envelope field. Both payloads grow with accumulated state and are
+// deliberately UNBOUNDED per the RUB-1057 standing decision: no size bound may
+// be added.
 //
 // These helpers are 3-field siblings of the merged undo_envelope_v1 frame
-// (undo.go, RUB-1132), which embeds block_hash in its prefix and preimage and
-// therefore cannot be reused as-is. Its structure is mirrored deliberately:
-// strict field order, compact JSON, one trailing LF outside the preimage,
-// constant-time checksum compare, layout validation by index arithmetic with
-// JSON parsed only on the reject path.
-//
-// Deliberately UNBOUNDED: both payloads grow with accumulated state (UTXO-set
-// size, chain length), so per the RUB-1057 standing decision no read or save
-// size bound exists here and none may be added.
-//
-// Rust twin: crates/rubin-node/src/store_envelope.rs. Both clients must emit
-// byte-identical envelopes for the same payload bytes; the mirrored
-// cross-client vectors pin those bytes in both test suites.
+// (undo.go, RUB-1132), which embeds block_hash in its prefix and preimage and so
+// cannot be reused as-is; its structure is mirrored deliberately (strict field
+// order, compact JSON, trailing LF outside the preimage, constant-time compare,
+// layout validation by index arithmetic with JSON parsed only on the reject
+// path).
 //
 // Claim boundary: this detects accidental, torn, tool-mediated and parse-valid
 // local corruption before either file is adopted. It is NOT authentication — a
@@ -57,7 +50,7 @@ import (
 // None of these is, wraps, or satisfies fs.ErrNotExist: absent-file fallbacks
 // must never trigger on a corrupt file. The inner payload-decode class is
 // deliberately OUTSIDE this identity: a file that clears the checksum is intact
-// on disk, so a failure past it is a schema fault, not an integrity fault.
+// on disk, so a failure past it is a schema fault.
 var ErrStoreIntegrity = errors.New("STORE_INTEGRITY")
 
 var (
@@ -69,11 +62,9 @@ var (
 	errStoreGenesisAnchor    = fmt.Errorf("%w: canonical index genesis mismatch.", ErrStoreIntegrity)
 )
 
-// The canonical envelope's byte layout is fully determined by these fixed
-// segments plus the 64-character checksum, so the reader validates the layout
-// by index arithmetic instead of decoding JSON: no value is materialized on
-// the accept path and payload_b64 is a SLICE of the caller's buffer. Rust
-// twin: STORE_ENVELOPE_PREFIX and friends in store_envelope.rs.
+// The canonical byte layout is fully determined by these fixed segments plus the
+// 64-character checksum, so the reader validates it by index arithmetic instead
+// of decoding JSON: nothing is materialized on the accept path.
 const (
 	storeEnvelopePrefix      = `{"version":1,"payload_b64":"`
 	storeEnvelopeChecksumSep = `","checksum":"`
@@ -86,9 +77,7 @@ const (
 	storeBlockIndexDomain = "RUBIN_BLOCKSTORE_INDEX_V1"
 )
 
-// storeEnvelopeKind carries the per-file parameters of the shared frame: the
-// checksum domain tag, the noun used in shape errors, and the pinned legacy
-// message for a pre-envelope file of that class.
+// storeEnvelopeKind carries the per-file frame parameters.
 type storeEnvelopeKind struct {
 	domain    string
 	noun      string
@@ -109,19 +98,16 @@ var (
 )
 
 // storeEnvelopeDisk is the writer's shape; the reader never decodes into it.
-// Field ORDER is part of the format: encoding/json emits struct fields in
-// declaration order and serde does the same, which is what makes the two
-// clients' envelope bytes identical for identical payload bytes.
+// Field ORDER is part of the format: encoding/json and serde both emit
+// declaration order, which is what makes the two clients' bytes identical.
 type storeEnvelopeDisk struct {
 	Version    uint32 `json:"version"`
 	PayloadB64 string `json:"payload_b64"`
 	Checksum   string `json:"checksum"`
 }
 
-// storeEnvelopeChecksum streams the preimage into the hash rather than
-// materializing it; the payload can be large (unbounded class) and the whole
-// point of this path is one decision before any inner decode. hash.Hash.Write
-// never returns an error. Rust twin: store_envelope_checksum.
+// storeEnvelopeChecksum streams the preimage rather than materializing it
+// (unbounded payload class); hash.Hash.Write never returns an error.
 func storeEnvelopeChecksum(domain string, payload []byte) [32]byte {
 	var length [8]byte
 	binary.BigEndian.PutUint64(length[:], uint64(len(payload)))
@@ -135,8 +121,7 @@ func storeEnvelopeChecksum(domain string, payload []byte) [32]byte {
 }
 
 // marshalStoreEnvelope wraps the exact payload bytes in the v1 frame. New
-// writes emit v1 only; there is deliberately no size bound on either side
-// (RUB-1057 standing decision for both protected files).
+// writes emit v1 only, and deliberately without a size bound (RUB-1057).
 func marshalStoreEnvelope(kind storeEnvelopeKind, payload []byte) ([]byte, error) {
 	checksum := storeEnvelopeChecksum(kind.domain, payload)
 	raw, err := json.Marshal(storeEnvelopeDisk{
@@ -151,11 +136,11 @@ func marshalStoreEnvelope(kind storeEnvelopeKind, payload []byte) ([]byte, error
 }
 
 // openStoreEnvelope runs the validation order on one protected file: strict
-// canonical layout (which subsumes shape, version-literal, duplicate,
-// unknown, missing, null, wrong-type, ordering, whitespace and trailing-token
-// rejection, with unversioned legacy classified before the exact-field-set
-// verdict), canonical padded base64, then the constant-time checksum compare.
-// Only after checksum success does the caller decode the inner schema.
+// canonical layout (which subsumes shape, version, duplicate, unknown, missing,
+// null, wrong-type, ordering, whitespace and trailing-token rejection, with
+// unversioned legacy classified first), canonical padded base64, then the
+// constant-time checksum compare. Only after checksum success does the caller
+// decode the inner schema.
 func openStoreEnvelope(kind storeEnvelopeKind, raw []byte) ([]byte, error) {
 	payloadB64, checksumHex, err := splitStoreEnvelope(kind, raw)
 	if err != nil {
@@ -178,10 +163,9 @@ func openStoreEnvelope(kind storeEnvelopeKind, raw []byte) ([]byte, error) {
 }
 
 // splitStoreEnvelope validates the canonical layout and returns sub-slices of
-// raw. The body length is DERIVED (len(raw) - frame) rather than searched for,
-// so any inserted, removed, reordered, duplicated or renamed field shifts the
-// trailing segments and fails. On failure it hands off to
-// classifyStoreEnvelopeFailure, the only path that parses JSON at all.
+// raw. The body length is DERIVED (len(raw) - frame), never searched for, so
+// any inserted, removed, reordered, duplicated or renamed field shifts the
+// trailing segments and fails.
 func splitStoreEnvelope(kind storeEnvelopeKind, raw []byte) (payloadB64, checksumHex []byte, err error) {
 	body := len(raw) - storeEnvelopeFrameBytes
 	if body < 0 {
@@ -203,15 +187,12 @@ func splitStoreEnvelope(kind storeEnvelopeKind, raw []byte) (payloadB64, checksu
 	return raw[payloadAt:checksumSepAt], checksumHex, nil
 }
 
-// classifyStoreEnvelopeFailure names WHY a file that failed the layout check
-// failed it; it runs only on files already being rejected, so its JSON scan is
-// never paid on the accept path. It decodes ONE value and ignores anything
-// after it, and duplicate keys last-win (both mirrored by the Rust twin), so a
-// legacy file with trailing garbage still reports the actionable legacy
-// message. A pre-envelope legacy file carries NEITHER payload_b64 NOR checksum
-// — both legacy inner schemas carry their own top-level "version": 1, which is
-// why legacy detection keys on the envelope fields and precedes the version
-// verdicts.
+// classifyStoreEnvelopeFailure names WHY a file failed the layout check; it runs
+// only on already-rejected files. It decodes ONE value, ignores anything after
+// it, and duplicate keys last-win (as in Rust), so a legacy file with trailing
+// garbage still reports the actionable legacy message. Legacy detection keys on
+// the ENVELOPE fields and precedes the version verdicts: both legacy inner
+// schemas carry a top-level "version": 1.
 func classifyStoreEnvelopeFailure(kind storeEnvelopeKind, raw []byte) error {
 	var probe map[string]json.RawMessage
 	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&probe); err != nil || probe == nil {
@@ -223,9 +204,8 @@ func classifyStoreEnvelopeFailure(kind storeEnvelopeKind, raw []byte) error {
 		return kind.legacyErr
 	}
 	// A POINTER target: JSON null decodes into it as nil WITHOUT an error, so
-	// `"version":null` is classified as a non-canonical frame rather than as
-	// "unsupported version 0". Any non-integer spelling errors instead. Rust
-	// twin classifies the same three cases identically.
+	// `"version":null` is a non-canonical frame, not "unsupported version 0".
+	// Any non-integer spelling errors instead; Rust classifies all three the same.
 	var version *uint64
 	if err := json.Unmarshal(probe["version"], &version); err == nil && version != nil && *version != storeEnvelopeVersion {
 		return fmt.Errorf("%w: unsupported store envelope version %d", ErrStoreIntegrity, *version)
@@ -233,9 +213,8 @@ func classifyStoreEnvelopeFailure(kind storeEnvelopeKind, raw []byte) error {
 	return fmt.Errorf("%w: envelope is not the canonical encoding", ErrStoreIntegrity)
 }
 
-// decodeCanonicalStoreBase64 accepts only the one padded RFC 4648 spelling of
-// the payload. Sibling of the undo-class decoder with the store identity:
-// Strict() covers non-zero padding bits, the EncodedLen equality covers the
+// decodeCanonicalStoreBase64 accepts only the one padded RFC 4648 spelling:
+// Strict() covers non-zero padding bits and the EncodedLen equality covers the
 // rest, notably the \r and \n Go's decoder silently skips.
 func decodeCanonicalStoreBase64(value []byte) ([]byte, error) {
 	payload := make([]byte, base64.StdEncoding.DecodedLen(len(value)))

--- a/clients/go/node/store_envelope.go
+++ b/clients/go/node/store_envelope.go
@@ -56,10 +56,10 @@ var ErrStoreIntegrity = errors.New("STORE_INTEGRITY")
 var (
 	// Pinned cross-client messages. Rust returns these same strings.
 	// Deliberately no repair command: this build ships no --reindex.
-	errStoreLegacyChainState = fmt.Errorf("%w: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay.", ErrStoreIntegrity)
-	errStoreLegacyBlockIndex = fmt.Errorf("%w: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required.", ErrStoreIntegrity)
-	errStoreChecksumMismatch = fmt.Errorf("%w: checksum mismatch.", ErrStoreIntegrity)
-	errStoreGenesisAnchor    = fmt.Errorf("%w: canonical index genesis mismatch.", ErrStoreIntegrity)
+	errStoreLegacyChainState = fmt.Errorf("%w: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay", ErrStoreIntegrity)
+	errStoreLegacyBlockIndex = fmt.Errorf("%w: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required", ErrStoreIntegrity)
+	errStoreChecksumMismatch = fmt.Errorf("%w: checksum mismatch", ErrStoreIntegrity)
+	errStoreGenesisAnchor    = fmt.Errorf("%w: canonical index genesis mismatch", ErrStoreIntegrity)
 )
 
 // The canonical byte layout is fully determined by these fixed segments plus the

--- a/clients/go/node/store_envelope.go
+++ b/clients/go/node/store_envelope.go
@@ -22,8 +22,10 @@ import (
 //	{"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n
 //
 // checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload).
-// The length term makes the preimage injective, so no two payloads share a
-// digest by concatenation. The trailing LF is NOT in the preimage. Domain tags
+// The length prefix makes the preimage encoding unambiguous: no two distinct
+// (domain, payload) pairs serialize to the same preimage bytes, so
+// concatenation cannot alias one frame into another. The trailing LF is NOT
+// in the preimage. Domain tags
 // are "RUBIN_CHAINSTATE_V1" and "RUBIN_BLOCKSTORE_INDEX_V1": both files are
 // per-datadir singletons, so the domain tag is the identity, and chain identity
 // is enforced by the separate genesis anchor (BlockStore.VerifyGenesisAnchor),

--- a/clients/go/node/store_envelope_test.go
+++ b/clients/go/node/store_envelope_test.go
@@ -18,55 +18,23 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-// storeEnvelopeVectors are the RUB-1134 cross-client vectors. Both clients
-// embed these SAME literals: given identical payload bytes, the preimage,
-// checksum and complete envelope bytes must be byte-identical in Go and Rust.
-// Rust twin: `store_envelope_v1_cross_client_vectors`. The two empty-payload
-// rows differ only by domain tag, so they pin domain separation; the two
-// non-empty rows pin the length term and the base64 body. Row 4's payload is
-// the exact Go empty canonical-index payload, so its envelope is also the
-// on-disk marker pinned by TestCreateBlockStoreCommitsExactEmptyMarker.
+// storeEnvelopeVectors are the RUB-1134 cross-client vectors; Rust embeds these
+// SAME literals. Rows 1/3 differ only by domain tag (domain separation); rows
+// 2/4 pin the length term and the base64 body, and row 4 is also the on-disk
+// marker pinned by TestCreateBlockStoreCommitsExactEmptyMarker.
 var storeEnvelopeVectors = []struct {
-	name         string
-	kind         storeEnvelopeKind
-	payload      string
-	wantChecksum string
-	wantEnvelope string
+	name, payload, wantChecksum, wantEnvelope string
+	kind                                      storeEnvelopeKind
 }{
-	{
-		name:         "chainstate_empty_payload",
-		kind:         storeEnvelopeChainState,
-		payload:      "",
-		wantChecksum: "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
-		wantEnvelope: `{"version":1,"payload_b64":"","checksum":"51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe"}` + "\n",
-	},
-	{
-		name:         "chainstate_small_payload",
-		kind:         storeEnvelopeChainState,
-		payload:      "{\"version\":1}\n",
-		wantChecksum: "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0",
-		wantEnvelope: `{"version":1,"payload_b64":"eyJ2ZXJzaW9uIjoxfQo=","checksum":"6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0"}` + "\n",
-	},
-	{
-		name:         "blockstore_index_empty_payload",
-		kind:         storeEnvelopeBlockIndex,
-		payload:      "",
-		wantChecksum: "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a",
-		wantEnvelope: `{"version":1,"payload_b64":"","checksum":"bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a"}` + "\n",
-	},
-	{
-		name:         "blockstore_index_empty_marker_payload",
-		kind:         storeEnvelopeBlockIndex,
-		payload:      "{\n  \"canonical\": [],\n  \"version\": 1\n}\n",
-		wantChecksum: "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15",
-		wantEnvelope: `{"version":1,"payload_b64":"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=","checksum":"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15"}` + "\n",
-	},
+	{"chainstate_empty_payload", "", "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe", `{"version":1,"payload_b64":"","checksum":"51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe"}` + "\n", storeEnvelopeChainState},
+	{"chainstate_small_payload", "{\"version\":1}\n", "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0", `{"version":1,"payload_b64":"eyJ2ZXJzaW9uIjoxfQo=","checksum":"6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0"}` + "\n", storeEnvelopeChainState},
+	{"blockstore_index_empty_payload", "", "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a", `{"version":1,"payload_b64":"","checksum":"bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a"}` + "\n", storeEnvelopeBlockIndex},
+	{"blockstore_index_empty_marker_payload", "{\n  \"canonical\": [],\n  \"version\": 1\n}\n", "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15", `{"version":1,"payload_b64":"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=","checksum":"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15"}` + "\n", storeEnvelopeBlockIndex},
 }
 
 // TestStoreEnvelopeV1CrossClientVectors pins the frame, the preimage and the
-// checksum. The expected checksum is ALSO recomputed here from the contract's
-// stated preimage (ASCII(domain) || uint64_be(len) || payload), so the pin
-// cannot drift with the production helper.
+// checksum, recomputing the checksum from the contract's stated preimage so the
+// pin cannot drift with the production helper.
 func TestStoreEnvelopeV1CrossClientVectors(t *testing.T) {
 	for _, tc := range storeEnvelopeVectors {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,8 +71,7 @@ func TestStoreEnvelopeV1CrossClientVectors(t *testing.T) {
 		})
 	}
 
-	// Domain separation: the same payload under the other domain tag must not
-	// verify, and the two pinned empty-payload checksums differ.
+	// Domain separation: the same payload under the other tag must not verify.
 	if storeEnvelopeVectors[0].wantChecksum == storeEnvelopeVectors[2].wantChecksum {
 		t.Fatalf("domain tags must produce distinct checksums for the same payload")
 	}
@@ -118,9 +85,8 @@ func TestStoreEnvelopeV1CrossClientVectors(t *testing.T) {
 	}
 }
 
-// storeIntegrityRow is one hostile/malformed on-disk body. `body` receives the
-// VALID envelope bytes and the valid inner payload bytes for that file and
-// returns the bytes to plant.
+// storeIntegrityRow is one malformed on-disk body: body(valid envelope, valid
+// payload) returns the bytes to plant.
 type storeIntegrityRow struct {
 	name    string
 	body    func(t *testing.T, valid, payload []byte) []byte
@@ -132,8 +98,7 @@ type storeIntegrityRow struct {
 }
 
 // storeEnvelopeSharedRejectRows are the frame-level rows both protected files
-// must reject identically. Per-file rows (legacy message, payload edits) are
-// added by each caller.
+// must reject identically; per-file rows are added by each caller.
 func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 	replaceOnce := func(old, new string) func(*testing.T, []byte, []byte) []byte {
 		return func(t *testing.T, valid, _ []byte) []byte {
@@ -145,7 +110,6 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 			return []byte(out)
 		}
 	}
-	// replaceChecksum rewrites the checksum field through `next`.
 	replaceChecksum := func(next func(string) string) func(*testing.T, []byte, []byte) []byte {
 		return func(t *testing.T, valid, payload []byte) []byte {
 			t.Helper()
@@ -153,7 +117,7 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 		}
 	}
 	// duplicateChecksum appends a SECOND checksum field carrying `next` of the
-	// real one, so both the identical and the conflicting spelling are reachable.
+	// real one, reaching both the identical and the conflicting spelling.
 	duplicateChecksum := func(next func(string) string) func(*testing.T, []byte, []byte) []byte {
 		return func(t *testing.T, valid, payload []byte) []byte {
 			t.Helper()
@@ -184,10 +148,8 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 	sub := func(name string, body func(*testing.T, []byte, []byte) []byte, want string) storeIntegrityRow {
 		return storeIntegrityRow{name: name, body: body, wantSub: want}
 	}
-	// A duplicated field lands INSIDE the derived body slice (the body length
-	// is len(raw) - frame, not a searched delimiter), so the canonical-base64
-	// check is what refuses it. Both clients derive the same slice and
-	// therefore return that same message; those rows pin the agreement.
+	// A duplicated field lands INSIDE the derived body slice, so the
+	// canonical-base64 check refuses it; both clients agree, which those rows pin.
 	return []storeIntegrityRow{
 		sub("empty_file", static(""), notObject),
 		sub("not_an_object", static("[]\n"), notObject),
@@ -233,9 +195,7 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 			wantMsg: errStoreChecksumMismatch.Error(),
 		},
 		{
-			// Shared with the undo-class rows (blockstore_test.go): one interior
-			// symbol changes, so the file stays canonical base64 and only the
-			// checksum can catch it.
+			// Stays canonical base64, so only the checksum can catch it.
 			name: "payload_base64_bitflip",
 			body: func(t *testing.T, valid, payload []byte) []byte {
 				t.Helper()
@@ -255,9 +215,7 @@ func decodeValidEnvelope(t *testing.T, valid []byte) storeEnvelopeDisk {
 	return probe
 }
 
-func hexChecksumOf(t *testing.T, valid []byte) string {
-	return decodeValidEnvelope(t, valid).Checksum
-}
+func hexChecksumOf(t *testing.T, valid []byte) string { return decodeValidEnvelope(t, valid).Checksum }
 
 func payloadB64Of(t *testing.T, valid []byte) string {
 	return decodeValidEnvelope(t, valid).PayloadB64
@@ -265,7 +223,7 @@ func payloadB64Of(t *testing.T, valid []byte) string {
 
 // runStoreIntegrityRows plants each row at `path`, calls `load`, and pins the
 // message, the ErrStoreIntegrity identity, the fs.ErrNotExist exclusion, and
-// that the refusal never rewrote the file. Rust twin: run_store_integrity_rows.
+// that the refusal never rewrote the file.
 func runStoreIntegrityRows(t *testing.T, path string, valid, payload []byte, load func() error, rows []storeIntegrityRow) {
 	t.Helper()
 	for _, row := range rows {
@@ -302,9 +260,8 @@ func runStoreIntegrityRows(t *testing.T, path string, valid, payload []byte, loa
 }
 
 // TestLoadChainStateRejectsIntegrityFailures: every malformed, legacy,
-// checksum-mismatched or parse-valid-but-edited chainstate.json fails BEFORE
-// the inner decode, with the pinned identity, and never rides the absent-file
-// fallback. Rust twin: `load_chainstate_rejects_integrity_failures`.
+// checksum-mismatched or parse-valid-but-edited chainstate.json fails BEFORE the
+// inner decode with the pinned identity and never rides the absent-file fallback.
 func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 	dir := t.TempDir()
 	path := ChainStatePath(dir)
@@ -327,8 +284,6 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 
 	rows := append(storeEnvelopeSharedRejectRows(),
 		storeIntegrityRow{
-			// The whole pre-envelope file, byte for byte: what a first
-			// post-upgrade startup finds on disk.
 			name:    "legacy_unversioned_chainstate",
 			body:    func(_ *testing.T, _, payload []byte) []byte { return payload },
 			wantMsg: errStoreLegacyChainState.Error(),
@@ -342,8 +297,8 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 		},
 		storeIntegrityRow{
 			// already_generated is a SCALAR outside the UTXO set and the tip is
-			// preserved, so the payload stays parse-valid and every downstream
-			// chainstate check passes: only the stale checksum catches it.
+			// preserved, so every downstream check passes and only the stale
+			// checksum catches it.
 			name: "already_generated_edited_stale_checksum",
 			body: func(t *testing.T, valid, payload []byte) []byte {
 				t.Helper()
@@ -357,9 +312,8 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 			wantMsg: errStoreChecksumMismatch.Error(),
 		},
 		storeIntegrityRow{
-			// A checksum-VALID envelope over a malformed inner payload: the
-			// bytes on disk are intact, so this is a schema fault and stays
-			// OUTSIDE the STORE_INTEGRITY identity.
+			// Checksum-VALID envelope, malformed inner payload: the bytes are
+			// intact, so this is a schema fault OUTSIDE STORE_INTEGRITY.
 			name: "inner_payload_malformed",
 			body: func(t *testing.T, _, _ []byte) []byte {
 				t.Helper()
@@ -378,7 +332,6 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 		return err
 	}, rows)
 
-	// Positive control on the same path: the valid envelope still round-trips.
 	if err := os.WriteFile(path, valid, 0o600); err != nil {
 		t.Fatalf("restore valid envelope: %v", err)
 	}
@@ -392,8 +345,7 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 }
 
 // TestBlockstoreIndexRejectsIntegrityFailures: the same frame rows plus the
-// canonical-row swap, through the real OpenBlockStore path. Rust twin:
-// `blockstore_index_rejects_integrity_failures`.
+// canonical-row swap, through the real OpenBlockStore path.
 func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 	dir := t.TempDir()
 	root := BlockStorePath(dir)
@@ -442,9 +394,9 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 			wantMsg: errStoreLegacyBlockIndex.Error(),
 		},
 		storeIntegrityRow{
-			// The swapped row names a same-height sibling whose header, block
-			// and undo artifacts ALL exist, so the stored-identity and undo
-			// bindings both pass: only the envelope catches the file edit.
+			// The sibling's header/block/undo artifacts ALL exist, so the
+			// stored-identity and undo bindings pass: only the envelope catches
+			// the file edit.
 			name: "canonical_row_swapped_to_existing_sibling",
 			body: func(t *testing.T, valid, payload []byte) []byte {
 				return swapRow(t, valid, payload, false)
@@ -471,8 +423,7 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 	}, rows)
 
 	// The envelope is the ONLY guard on that swap: with the checksum
-	// recomputed over the swapped payload the store opens, which is exactly
-	// why the checksum may never be waived.
+	// recomputed the store opens, which is why it may never be waived.
 	if err := os.WriteFile(marker, swapRow(t, valid, payload, true), 0o600); err != nil {
 		t.Fatalf("plant recomputed swap: %v", err)
 	}
@@ -488,9 +439,9 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 	}
 }
 
-// storeSameHeightSibling writes a complete header/block/undo artifact set for a
-// non-canonical block at the canonical tip's height, so a swapped index row can
-// point at a block every downstream identity check accepts.
+// storeSameHeightSibling writes a complete header/block/undo set for a
+// non-canonical block at the tip's height, so a swapped row points at a block
+// every downstream identity check accepts.
 func storeSameHeightSibling(t *testing.T, store *BlockStore) [32]byte {
 	t.Helper()
 	parsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
@@ -517,12 +468,9 @@ func storeSameHeightSibling(t *testing.T, store *BlockStore) [32]byte {
 }
 
 // TestStartupGenesisAnchorMismatchFails pins the RUB-1134 genesis anchor: a
-// non-empty canonical index whose row 0 is not the configured genesis hash is
-// a foreign datadir and is refused BEFORE reconcile adopts the index; an EMPTY
-// canonical index skips the anchor. Startup wiring lives in
-// cmd/rubin-node/main.go, which calls this method before
-// ReconcileChainStateWithBlockStore. Rust twin:
-// `startup_genesis_anchor_mismatch_fails`.
+// non-empty index whose row 0 is not the configured genesis hash is refused
+// BEFORE reconcile adopts it; an EMPTY index skips the anchor. Startup wiring
+// (cmd/rubin-node/main.go) calls it before ReconcileChainStateWithBlockStore.
 func TestStartupGenesisAnchorMismatchFails(t *testing.T) {
 	empty := mustCreateBlockStore(t, BlockStorePath(t.TempDir()))
 	if err := empty.VerifyGenesisAnchor([32]byte{0xff}); err != nil {
@@ -535,8 +483,7 @@ func TestStartupGenesisAnchorMismatchFails(t *testing.T) {
 		t.Fatalf("a legitimate datadir must pass the anchor: %v", err)
 	}
 
-	// A coherent FOREIGN datadir: both envelopes verify and the tips agree, so
-	// only the anchor refuses it.
+	// A coherent FOREIGN datadir: only the anchor refuses it.
 	foreign := [32]byte{0xab}
 	err := store.VerifyGenesisAnchor(foreign)
 	if err == nil {
@@ -552,8 +499,7 @@ func TestStartupGenesisAnchorMismatchFails(t *testing.T) {
 		t.Fatalf("anchor failure must never satisfy fs.ErrNotExist: %v", err)
 	}
 
-	// The anchor precedes adoption: the refused store is untouched, and the
-	// reconcile that would have adopted it is never reached on the wired path.
+	// The anchor precedes adoption: the refused store is untouched.
 	snapshot, err := store.CanonicalIndexSnapshot()
 	if err != nil || len(snapshot) != 1 || snapshot[0] != hex.EncodeToString(devnetGenesisBlockHash[:]) {
 		t.Fatalf("anchor refusal mutated the canonical index: %v (%v)", snapshot, err)
@@ -564,9 +510,8 @@ func TestStartupGenesisAnchorMismatchFails(t *testing.T) {
 }
 
 // TestAbsentChainstateRebuildsByReplay: an ABSENT chainstate.json keeps the
-// NewChainState-plus-full-validated-replay repair path over an enveloped
-// index, and a corrupt one does NOT. Rust twin:
-// `absent_chainstate_rebuilds_by_replay`.
+// full-validated-replay repair path over an enveloped index; a corrupt one does
+// NOT.
 func TestAbsentChainstateRebuildsByReplay(t *testing.T) {
 	dir := t.TempDir()
 	store, live, cfg := storeAtGenesis(t, dir)
@@ -593,7 +538,6 @@ func TestAbsentChainstateRebuildsByReplay(t *testing.T) {
 		t.Fatalf("replay did not rebuild the tip: changed=%v state=%+v", changed, rebuilt)
 	}
 
-	// The absent-file fallback must NOT extend to a corrupt file.
 	if err := os.WriteFile(path, []byte("{\"version\":1}\n"), 0o600); err != nil {
 		t.Fatalf("plant legacy chainstate: %v", err)
 	}
@@ -602,11 +546,48 @@ func TestAbsentChainstateRebuildsByReplay(t *testing.T) {
 	}
 }
 
+// TestBothLegacyFilesFailClosedAtFirstStartup is the hostile "both together"
+// row: a first post-upgrade startup finds BOTH files pre-envelope. Startup opens
+// the blockstore before it loads the chainstate, so the index verdict is the one
+// an operator sees; each file is refused on its own class and neither is
+// rewritten.
+func TestBothLegacyFilesFailClosedAtFirstStartup(t *testing.T) {
+	dir := t.TempDir()
+	root := BlockStorePath(dir)
+	mustCreateBlockStore(t, root)
+	indexPath, chainStatePath := filepath.Join(root, "index.json"), ChainStatePath(dir)
+	// Exactly the pre-envelope encodings the two writers now wrap as payloads.
+	legacy := map[string][]byte{
+		indexPath:      []byte("{\n  \"canonical\": [],\n  \"version\": 1\n}\n"),
+		chainStatePath: []byte("{\n  \"version\": 1,\n  \"utxos\": []\n}\n"),
+	}
+	for _, path := range []string{indexPath, chainStatePath} {
+		if err := os.WriteFile(path, legacy[path], 0o600); err != nil {
+			t.Fatalf("plant legacy %s: %v", path, err)
+		}
+	}
+
+	if _, err := OpenBlockStore(root); err == nil || err.Error() != errStoreLegacyBlockIndex.Error() {
+		t.Fatalf("legacy index = %v, want %v", err, errStoreLegacyBlockIndex)
+	}
+	if _, err := LoadChainState(chainStatePath); err == nil || err.Error() != errStoreLegacyChainState.Error() {
+		t.Fatalf("legacy chainstate = %v, want %v", err, errStoreLegacyChainState)
+	}
+	for _, path := range []string{indexPath, chainStatePath} {
+		raw, err := os.ReadFile(path) // #nosec G304 -- test-owned temp path
+		if err != nil {
+			t.Fatalf("re-read %s: %v", path, err)
+		}
+		if !bytes.Equal(raw, legacy[path]) {
+			t.Fatalf("%s was rewritten by a refused load", path)
+		}
+	}
+}
+
 // TestReconcileCrashRecoveryOverEnvelopedFiles re-proves every baseline
 // crash-recovery reconcile scenario over enveloped files: a crash at each
-// atomic-write boundary (scratch open/write, rename, parent sync) for each of
-// the two files, in BOTH write orders, then reopen from disk and reconcile.
-// Rust twin: `reconcile_crash_recovery_over_enveloped_files`.
+// atomic-write boundary (scratch open/write, rename, parent sync) for each file,
+// in BOTH write orders, then reopen from disk and reconcile.
 func TestReconcileCrashRecoveryOverEnvelopedFiles(t *testing.T) {
 	for _, boundary := range []string{"scratch_open", "scratch_write", "rename", "parent_sync"} {
 		for _, order := range []string{"index_first", "chainstate_first"} {
@@ -621,8 +602,7 @@ func TestReconcileCrashRecoveryOverEnvelopedFiles(t *testing.T) {
 
 				crashed := crashAtBoundary(t, boundary, order, store, live, chainStatePath)
 
-				// Whatever the crash left on disk, the reopened datadir must be
-				// envelope-clean and reconcile back to the canonical tip.
+				// The reopened datadir must reconcile back to the canonical tip.
 				reopened := mustOpenBlockStore(t, BlockStorePath(dir))
 				state, err := LoadChainState(chainStatePath)
 				if err != nil {
@@ -667,9 +647,8 @@ func appendCanonicalBlock(t *testing.T, store *BlockStore, live *ChainState, cfg
 	return summary.BlockHash
 }
 
-// crashAtBoundary injects one failure at one atomic-write boundary while the
-// two files are written in the given order, scoped to the file the row names,
-// and reports whether the injected write actually failed.
+// crashAtBoundary injects one failure at one atomic-write boundary while the two
+// files are written in the given order, and reports whether it actually failed.
 func crashAtBoundary(t *testing.T, boundary, order string, store *BlockStore, live *ChainState, chainStatePath string) bool {
 	t.Helper()
 	victim := store.indexPath

--- a/clients/go/node/store_envelope_test.go
+++ b/clients/go/node/store_envelope_test.go
@@ -125,12 +125,14 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 		}
 	}
 	// reframe rebuilds the whole envelope from an alternative SPELLING of the
-	// base64 body, keeping a correct checksum over the real payload.
+	// base64 body, keeping a correct checksum over the real payload. The body
+	// is emitted RAW (%s, not %q), so a row can plant the exact control bytes
+	// a permissive base64 decoder would skip.
 	reframe := func(spell func(string) string) func(*testing.T, []byte, []byte) []byte {
 		return func(t *testing.T, _, payload []byte) []byte {
 			t.Helper()
 			checksum := storeEnvelopeChecksum(storeEnvelopeChainState.domain, payload)
-			return fmt.Appendf(nil, "{\"version\":1,\"payload_b64\":%q,\"checksum\":%q}\n",
+			return fmt.Appendf(nil, "{\"version\":1,\"payload_b64\":\"%s\",\"checksum\":\"%s\"}\n",
 				spell(base64.StdEncoding.EncodeToString(payload)), hex.EncodeToString(checksum[:]))
 		}
 	}
@@ -165,7 +167,10 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 			return fmt.Appendf(nil, "{\"payload_b64\":%q,\"version\":1,\"checksum\":%q}\n",
 				base64.StdEncoding.EncodeToString(payload), hex.EncodeToString(checksum[:]))
 		}, notCanonical),
-		sub("duplicate_payload_b64_identical", replaceOnce(`,"checksum":"`, `,"payload_b64":"DUPLICATE","checksum":"`), notBase64),
+		sub("duplicate_payload_b64_identical", func(t *testing.T, valid, payload []byte) []byte {
+			t.Helper()
+			return replaceOnce(`,"checksum":"`, `,"payload_b64":"`+payloadB64Of(t, valid)+`","checksum":"`)(t, valid, payload)
+		}, notBase64),
 		sub("duplicate_payload_b64_conflicting", replaceOnce(`,"checksum":"`, `,"payload_b64":"Zm9vYmFy","checksum":"`), notBase64),
 		sub("duplicate_checksum_identical", duplicateChecksum(same), notBase64),
 		sub("duplicate_checksum_conflicting", duplicateChecksum(fixed(strings.Repeat("b", 64))), notBase64),
@@ -186,8 +191,16 @@ func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
 		sub("payload_b64_unpadded", reframe(func(encoded string) string {
 			return strings.TrimRight(encoded, "=")
 		}), notBase64),
+		// Go's stdlib base64 decoder silently SKIPS raw \n and \r (the reason
+		// the production frame derives the body length instead of decoding
+		// permissively). These two rows plant those exact raw bytes inside the
+		// body, so the canonical decoder refuses what a skipping decoder would
+		// have accepted.
 		sub("payload_b64_embedded_newline", reframe(func(encoded string) string {
-			return encoded[:4] + "\\n" + encoded[4:]
+			return encoded[:4] + "\n" + encoded[4:]
+		}), notBase64),
+		sub("payload_b64_embedded_carriage_return", reframe(func(encoded string) string {
+			return encoded[:4] + "\r" + encoded[4:]
 		}), notBase64),
 		{
 			name:    "checksum_mismatch_zeroed",
@@ -349,8 +362,13 @@ func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
 func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 	dir := t.TempDir()
 	root := BlockStorePath(dir)
-	store, _, _ := storeAtGenesis(t, dir)
-	sibling := storeSameHeightSibling(t, store)
+	store, live, cfg := storeAtGenesis(t, dir)
+	// Three canonical rows, so the swap below hits a MIDDLE one: row 0 stays
+	// anchored and the tip is untouched, which is the only shape in which the
+	// envelope is provably the sole guard on the edit.
+	appendCanonicalBlock(t, store, live, cfg)
+	appendCanonicalBlock(t, store, live, cfg)
+	sibling := storeSameHeightSibling(t, store, devnetGenesisBlockHash, 1)
 	marker := filepath.Join(root, "index.json")
 	valid, err := os.ReadFile(marker) // #nosec G304 -- test-local path.
 	if err != nil {
@@ -367,10 +385,10 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 		if err := json.Unmarshal(payload, &index); err != nil {
 			t.Fatalf("decode index payload: %v", err)
 		}
-		if len(index.Canonical) == 0 {
-			t.Fatalf("index has no canonical rows")
+		if len(index.Canonical) < 3 {
+			t.Fatalf("a middle-row swap needs >= 3 canonical rows, got %d", len(index.Canonical))
 		}
-		index.Canonical[len(index.Canonical)-1] = hex.EncodeToString(sibling[:])
+		index.Canonical[1] = hex.EncodeToString(sibling[:])
 		edited, err := json.MarshalIndent(index, "", "  ")
 		if err != nil {
 			t.Fatalf("encode index payload: %v", err)
@@ -423,12 +441,17 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 	}, rows)
 
 	// The envelope is the ONLY guard on that swap: with the checksum
-	// recomputed the store opens, which is why it may never be waived.
+	// recomputed the store opens AND the genesis anchor still passes, because
+	// the edited row is not row 0. That is why it may never be waived.
 	if err := os.WriteFile(marker, swapRow(t, valid, payload, true), 0o600); err != nil {
 		t.Fatalf("plant recomputed swap: %v", err)
 	}
-	if _, err := OpenBlockStore(root); err != nil {
+	swapped, err := OpenBlockStore(root)
+	if err != nil {
 		t.Fatalf("recomputed-checksum swap must clear the envelope: %v", err)
+	}
+	if err := swapped.VerifyGenesisAnchor(devnetGenesisBlockHash); err != nil {
+		t.Fatalf("a middle-row swap leaves row 0 anchored: %v", err)
 	}
 
 	if err := os.WriteFile(marker, valid, 0o600); err != nil {
@@ -440,16 +463,17 @@ func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
 }
 
 // storeSameHeightSibling writes a complete header/block/undo set for a
-// non-canonical block at the tip's height, so a swapped row points at a block
-// every downstream identity check accepts.
-func storeSameHeightSibling(t *testing.T, store *BlockStore) [32]byte {
+// NON-canonical block at `height` on top of `parent`, so a swapped row points
+// at a block every downstream identity check accepts. Its timestamp is one no
+// canonical block uses, which is what keeps it off the chain.
+func storeSameHeightSibling(t *testing.T, store *BlockStore, parent [32]byte, height uint64) [32]byte {
 	t.Helper()
 	parsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(genesis): %v", err)
 	}
-	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 0, 1)
-	blockBytes := buildSingleTxBlock(t, parsed.Header.PrevBlockHash, consensus.POW_LIMIT, parsed.Header.Timestamp+1, coinbase)
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, 1)
+	blockBytes := buildSingleTxBlock(t, parent, consensus.POW_LIMIT, parsed.Header.Timestamp+1_000, coinbase)
 	siblingParsed, err := consensus.ParseBlockBytes(blockBytes)
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(sibling): %v", err)
@@ -461,7 +485,7 @@ func storeSameHeightSibling(t *testing.T, store *BlockStore) [32]byte {
 	if err := store.StoreBlock(hash, siblingParsed.HeaderBytes, blockBytes); err != nil {
 		t.Fatalf("StoreBlock(sibling): %v", err)
 	}
-	if err := store.PutUndo(hash, &BlockUndo{BlockHeight: 0}); err != nil {
+	if err := store.PutUndo(hash, &BlockUndo{BlockHeight: height}); err != nil {
 		t.Fatalf("PutUndo(sibling): %v", err)
 	}
 	return hash
@@ -626,8 +650,8 @@ func TestReconcileCrashRecoveryOverEnvelopedFiles(t *testing.T) {
 	}
 }
 
-// appendCanonicalBlock applies one real block on top of the canonical genesis
-// and returns its hash.
+// appendCanonicalBlock applies one real block on top of the LIVE tip and
+// returns its hash, so repeated calls extend the canonical chain.
 func appendCanonicalBlock(t *testing.T, store *BlockStore, live *ChainState, cfg SyncConfig) [32]byte {
 	t.Helper()
 	engine, err := NewSyncEngine(live, store, cfg)
@@ -638,11 +662,12 @@ func appendCanonicalBlock(t *testing.T, store *BlockStore, live *ChainState, cfg
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(genesis): %v", err)
 	}
-	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, 1)
-	block := buildSingleTxBlock(t, devnetGenesisBlockHash, consensus.POW_LIMIT, parsed.Header.Timestamp+1, coinbase)
+	height := live.Height + 1
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, 1)
+	block := buildSingleTxBlock(t, live.TipHash, consensus.POW_LIMIT, parsed.Header.Timestamp+height, coinbase)
 	summary, err := engine.ApplyBlock(block, nil)
 	if err != nil {
-		t.Fatalf("ApplyBlock(block1): %v", err)
+		t.Fatalf("ApplyBlock(height %d): %v", height, err)
 	}
 	return summary.BlockHash
 }

--- a/clients/go/node/store_envelope_test.go
+++ b/clients/go/node/store_envelope_test.go
@@ -1,0 +1,728 @@
+package node
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// storeEnvelopeVectors are the RUB-1134 cross-client vectors. Both clients
+// embed these SAME literals: given identical payload bytes, the preimage,
+// checksum and complete envelope bytes must be byte-identical in Go and Rust.
+// Rust twin: `store_envelope_v1_cross_client_vectors`. The two empty-payload
+// rows differ only by domain tag, so they pin domain separation; the two
+// non-empty rows pin the length term and the base64 body. Row 4's payload is
+// the exact Go empty canonical-index payload, so its envelope is also the
+// on-disk marker pinned by TestCreateBlockStoreCommitsExactEmptyMarker.
+var storeEnvelopeVectors = []struct {
+	name         string
+	kind         storeEnvelopeKind
+	payload      string
+	wantChecksum string
+	wantEnvelope string
+}{
+	{
+		name:         "chainstate_empty_payload",
+		kind:         storeEnvelopeChainState,
+		payload:      "",
+		wantChecksum: "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
+		wantEnvelope: `{"version":1,"payload_b64":"","checksum":"51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe"}` + "\n",
+	},
+	{
+		name:         "chainstate_small_payload",
+		kind:         storeEnvelopeChainState,
+		payload:      "{\"version\":1}\n",
+		wantChecksum: "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0",
+		wantEnvelope: `{"version":1,"payload_b64":"eyJ2ZXJzaW9uIjoxfQo=","checksum":"6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0"}` + "\n",
+	},
+	{
+		name:         "blockstore_index_empty_payload",
+		kind:         storeEnvelopeBlockIndex,
+		payload:      "",
+		wantChecksum: "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a",
+		wantEnvelope: `{"version":1,"payload_b64":"","checksum":"bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a"}` + "\n",
+	},
+	{
+		name:         "blockstore_index_empty_marker_payload",
+		kind:         storeEnvelopeBlockIndex,
+		payload:      "{\n  \"canonical\": [],\n  \"version\": 1\n}\n",
+		wantChecksum: "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15",
+		wantEnvelope: `{"version":1,"payload_b64":"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=","checksum":"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15"}` + "\n",
+	},
+}
+
+// TestStoreEnvelopeV1CrossClientVectors pins the frame, the preimage and the
+// checksum. The expected checksum is ALSO recomputed here from the contract's
+// stated preimage (ASCII(domain) || uint64_be(len) || payload), so the pin
+// cannot drift with the production helper.
+func TestStoreEnvelopeV1CrossClientVectors(t *testing.T) {
+	for _, tc := range storeEnvelopeVectors {
+		t.Run(tc.name, func(t *testing.T) {
+			var length [8]byte
+			binary.BigEndian.PutUint64(length[:], uint64(len(tc.payload)))
+			hasher := sha3.New256()
+			hasher.Write([]byte(tc.kind.domain))
+			hasher.Write(length[:])
+			hasher.Write([]byte(tc.payload))
+			if got := hex.EncodeToString(hasher.Sum(nil)); got != tc.wantChecksum {
+				t.Fatalf("independent preimage checksum = %s, want %s", got, tc.wantChecksum)
+			}
+			if got := storeEnvelopeChecksum(tc.kind.domain, []byte(tc.payload)); hex.EncodeToString(got[:]) != tc.wantChecksum {
+				t.Fatalf("storeEnvelopeChecksum = %x, want %s", got, tc.wantChecksum)
+			}
+
+			raw, err := marshalStoreEnvelope(tc.kind, []byte(tc.payload))
+			if err != nil {
+				t.Fatalf("marshalStoreEnvelope: %v", err)
+			}
+			if string(raw) != tc.wantEnvelope {
+				t.Fatalf("envelope =\n%q\nwant\n%q", raw, tc.wantEnvelope)
+			}
+			if !bytes.HasSuffix(raw, []byte("\n")) {
+				t.Fatalf("envelope must end with exactly one LF: %q", raw)
+			}
+			back, err := openStoreEnvelope(tc.kind, raw)
+			if err != nil {
+				t.Fatalf("openStoreEnvelope: %v", err)
+			}
+			if string(back) != tc.payload {
+				t.Fatalf("round trip = %q, want %q", back, tc.payload)
+			}
+		})
+	}
+
+	// Domain separation: the same payload under the other domain tag must not
+	// verify, and the two pinned empty-payload checksums differ.
+	if storeEnvelopeVectors[0].wantChecksum == storeEnvelopeVectors[2].wantChecksum {
+		t.Fatalf("domain tags must produce distinct checksums for the same payload")
+	}
+	raw, err := marshalStoreEnvelope(storeEnvelopeChainState, []byte("{\"version\":1}\n"))
+	if err != nil {
+		t.Fatalf("marshalStoreEnvelope: %v", err)
+	}
+	if _, err := openStoreEnvelope(storeEnvelopeBlockIndex, raw); !errors.Is(err, ErrStoreIntegrity) ||
+		err.Error() != errStoreChecksumMismatch.Error() {
+		t.Fatalf("cross-domain open = %v, want %v", err, errStoreChecksumMismatch)
+	}
+}
+
+// storeIntegrityRow is one hostile/malformed on-disk body. `body` receives the
+// VALID envelope bytes and the valid inner payload bytes for that file and
+// returns the bytes to plant.
+type storeIntegrityRow struct {
+	name    string
+	body    func(t *testing.T, valid, payload []byte) []byte
+	wantMsg string // exact message, when the contract pins one
+	wantSub string // substring, when the message carries a variable
+	// notIntegrity marks the inner-schema class, which is deliberately OUTSIDE
+	// the STORE_INTEGRITY identity: those bytes are intact on disk.
+	notIntegrity bool
+}
+
+// storeEnvelopeSharedRejectRows are the frame-level rows both protected files
+// must reject identically. Per-file rows (legacy message, payload edits) are
+// added by each caller.
+func storeEnvelopeSharedRejectRows() []storeIntegrityRow {
+	replaceOnce := func(old, new string) func(*testing.T, []byte, []byte) []byte {
+		return func(t *testing.T, valid, _ []byte) []byte {
+			t.Helper()
+			out := strings.Replace(string(valid), old, new, 1)
+			if out == string(valid) {
+				t.Fatalf("row did not modify the envelope")
+			}
+			return []byte(out)
+		}
+	}
+	// replaceChecksum rewrites the checksum field through `next`.
+	replaceChecksum := func(next func(string) string) func(*testing.T, []byte, []byte) []byte {
+		return func(t *testing.T, valid, payload []byte) []byte {
+			t.Helper()
+			return replaceOnce(hexChecksumOf(t, valid), next(hexChecksumOf(t, valid)))(t, valid, payload)
+		}
+	}
+	// duplicateChecksum appends a SECOND checksum field carrying `next` of the
+	// real one, so both the identical and the conflicting spelling are reachable.
+	duplicateChecksum := func(next func(string) string) func(*testing.T, []byte, []byte) []byte {
+		return func(t *testing.T, valid, payload []byte) []byte {
+			t.Helper()
+			return replaceOnce(`"}`+"\n", `","checksum":"`+next(hexChecksumOf(t, valid))+`"}`+"\n")(t, valid, payload)
+		}
+	}
+	// reframe rebuilds the whole envelope from an alternative SPELLING of the
+	// base64 body, keeping a correct checksum over the real payload.
+	reframe := func(spell func(string) string) func(*testing.T, []byte, []byte) []byte {
+		return func(t *testing.T, _, payload []byte) []byte {
+			t.Helper()
+			checksum := storeEnvelopeChecksum(storeEnvelopeChainState.domain, payload)
+			return fmt.Appendf(nil, "{\"version\":1,\"payload_b64\":%q,\"checksum\":%q}\n",
+				spell(base64.StdEncoding.EncodeToString(payload)), hex.EncodeToString(checksum[:]))
+		}
+	}
+	static := func(out string) func(*testing.T, []byte, []byte) []byte {
+		return func(*testing.T, []byte, []byte) []byte { return []byte(out) }
+	}
+	same := func(value string) string { return value }
+	fixed := func(value string) func(string) string { return func(string) string { return value } }
+	const (
+		notObject      = "is not a single JSON object"
+		notCanonical   = "envelope is not the canonical encoding"
+		notBase64      = "payload_b64 is not canonical padded base64"
+		badChecksumHex = "checksum must be 64 lowercase hex characters"
+	)
+	sub := func(name string, body func(*testing.T, []byte, []byte) []byte, want string) storeIntegrityRow {
+		return storeIntegrityRow{name: name, body: body, wantSub: want}
+	}
+	// A duplicated field lands INSIDE the derived body slice (the body length
+	// is len(raw) - frame, not a searched delimiter), so the canonical-base64
+	// check is what refuses it. Both clients derive the same slice and
+	// therefore return that same message; those rows pin the agreement.
+	return []storeIntegrityRow{
+		sub("empty_file", static(""), notObject),
+		sub("not_an_object", static("[]\n"), notObject),
+		sub("json_null", static("null\n"), notObject),
+		sub("version_zero", replaceOnce(`{"version":1,`, `{"version":0,`), "unsupported store envelope version 0"),
+		sub("version_two", replaceOnce(`{"version":1,`, `{"version":2,`), "unsupported store envelope version 2"),
+		sub("version_wrong_type", replaceOnce(`{"version":1,`, `{"version":"1",`), notCanonical),
+		sub("version_null", replaceOnce(`{"version":1,`, `{"version":null,`), notCanonical),
+		sub("unknown_field", replaceOnce(`{"version":1,`, `{"version":1,"extra":0,`), notCanonical),
+		sub("field_order_swapped", func(t *testing.T, _, payload []byte) []byte {
+			t.Helper()
+			checksum := storeEnvelopeChecksum(storeEnvelopeChainState.domain, payload)
+			return fmt.Appendf(nil, "{\"payload_b64\":%q,\"version\":1,\"checksum\":%q}\n",
+				base64.StdEncoding.EncodeToString(payload), hex.EncodeToString(checksum[:]))
+		}, notCanonical),
+		sub("duplicate_payload_b64_identical", replaceOnce(`,"checksum":"`, `,"payload_b64":"DUPLICATE","checksum":"`), notBase64),
+		sub("duplicate_payload_b64_conflicting", replaceOnce(`,"checksum":"`, `,"payload_b64":"Zm9vYmFy","checksum":"`), notBase64),
+		sub("duplicate_checksum_identical", duplicateChecksum(same), notBase64),
+		sub("duplicate_checksum_conflicting", duplicateChecksum(fixed(strings.Repeat("b", 64))), notBase64),
+		sub("missing_checksum", replaceOnce(`","checksum":"`, `","checksu":"`), notCanonical),
+		sub("missing_payload_b64", replaceOnce(`,"payload_b64":"`, `,"payloadb64":"`), notCanonical),
+		sub("trailing_second_json_value", func(_ *testing.T, valid, _ []byte) []byte {
+			return append(append([]byte(nil), valid...), []byte(`{"version":1}`)...)
+		}, notCanonical),
+		sub("no_trailing_newline", func(_ *testing.T, valid, _ []byte) []byte {
+			return bytes.TrimSuffix(valid, []byte("\n"))
+		}, notCanonical),
+		sub("leading_whitespace", func(_ *testing.T, valid, _ []byte) []byte {
+			return append([]byte(" "), valid...)
+		}, notCanonical),
+		sub("checksum_uppercase_hex", replaceChecksum(strings.ToUpper), badChecksumHex),
+		sub("checksum_not_hex", replaceChecksum(fixed(strings.Repeat("z", 64))), badChecksumHex),
+		sub("checksum_short", replaceChecksum(fixed(strings.Repeat("a", 63))), notCanonical),
+		sub("payload_b64_unpadded", reframe(func(encoded string) string {
+			return strings.TrimRight(encoded, "=")
+		}), notBase64),
+		sub("payload_b64_embedded_newline", reframe(func(encoded string) string {
+			return encoded[:4] + "\\n" + encoded[4:]
+		}), notBase64),
+		{
+			name:    "checksum_mismatch_zeroed",
+			body:    replaceChecksum(fixed(strings.Repeat("0", 64))),
+			wantMsg: errStoreChecksumMismatch.Error(),
+		},
+		{
+			// Shared with the undo-class rows (blockstore_test.go): one interior
+			// symbol changes, so the file stays canonical base64 and only the
+			// checksum can catch it.
+			name: "payload_base64_bitflip",
+			body: func(t *testing.T, valid, payload []byte) []byte {
+				t.Helper()
+				return replaceOnce(payloadB64Of(t, valid), flipBase64Symbol(payloadB64Of(t, valid)))(t, valid, payload)
+			},
+			wantMsg: errStoreChecksumMismatch.Error(),
+		},
+	}
+}
+
+func decodeValidEnvelope(t *testing.T, valid []byte) storeEnvelopeDisk {
+	t.Helper()
+	var probe storeEnvelopeDisk
+	if err := json.Unmarshal(bytes.TrimSuffix(valid, []byte("\n")), &probe); err != nil {
+		t.Fatalf("decode valid envelope: %v", err)
+	}
+	return probe
+}
+
+func hexChecksumOf(t *testing.T, valid []byte) string {
+	return decodeValidEnvelope(t, valid).Checksum
+}
+
+func payloadB64Of(t *testing.T, valid []byte) string {
+	return decodeValidEnvelope(t, valid).PayloadB64
+}
+
+// runStoreIntegrityRows plants each row at `path`, calls `load`, and pins the
+// message, the ErrStoreIntegrity identity, the fs.ErrNotExist exclusion, and
+// that the refusal never rewrote the file. Rust twin: run_store_integrity_rows.
+func runStoreIntegrityRows(t *testing.T, path string, valid, payload []byte, load func() error, rows []storeIntegrityRow) {
+	t.Helper()
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			body := row.body(t, valid, payload)
+			if err := os.WriteFile(path, body, 0o600); err != nil {
+				t.Fatalf("plant body: %v", err)
+			}
+			err := load()
+			if err == nil {
+				t.Fatalf("row must be rejected")
+			}
+			if row.wantMsg != "" && err.Error() != row.wantMsg {
+				t.Fatalf("message = %q, want %q", err.Error(), row.wantMsg)
+			}
+			if row.wantSub != "" && !strings.Contains(err.Error(), row.wantSub) {
+				t.Fatalf("message = %q, want substring %q", err.Error(), row.wantSub)
+			}
+			if got := errors.Is(err, ErrStoreIntegrity); got == row.notIntegrity {
+				t.Fatalf("errors.Is(err, ErrStoreIntegrity) = %v for %v", got, err)
+			}
+			if errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("a corrupt file must never satisfy fs.ErrNotExist: %v", err)
+			}
+			after, readErr := os.ReadFile(path) // #nosec G304 -- test-local path.
+			if readErr != nil {
+				t.Fatalf("read back: %v", readErr)
+			}
+			if !bytes.Equal(after, body) {
+				t.Fatalf("a failed load rewrote the file: got %q want %q", after, body)
+			}
+		})
+	}
+}
+
+// TestLoadChainStateRejectsIntegrityFailures: every malformed, legacy,
+// checksum-mismatched or parse-valid-but-edited chainstate.json fails BEFORE
+// the inner decode, with the pinned identity, and never rides the absent-file
+// fallback. Rust twin: `load_chainstate_rejects_integrity_failures`.
+func TestLoadChainStateRejectsIntegrityFailures(t *testing.T) {
+	dir := t.TempDir()
+	path := ChainStatePath(dir)
+	state := NewChainState()
+	state.HasTip = true
+	state.Height = 9
+	state.AlreadyGenerated = 4_200
+	state.TipHash = [32]byte{0x11, 0x22}
+	if err := state.Save(path); err != nil {
+		t.Fatalf("save chainstate: %v", err)
+	}
+	valid, err := os.ReadFile(path) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read chainstate: %v", err)
+	}
+	payload, err := openStoreEnvelope(storeEnvelopeChainState, valid)
+	if err != nil {
+		t.Fatalf("open valid envelope: %v", err)
+	}
+
+	rows := append(storeEnvelopeSharedRejectRows(),
+		storeIntegrityRow{
+			// The whole pre-envelope file, byte for byte: what a first
+			// post-upgrade startup finds on disk.
+			name:    "legacy_unversioned_chainstate",
+			body:    func(_ *testing.T, _, payload []byte) []byte { return payload },
+			wantMsg: errStoreLegacyChainState.Error(),
+		},
+		storeIntegrityRow{
+			name: "legacy_unversioned_with_trailing_garbage",
+			body: func(_ *testing.T, _, payload []byte) []byte {
+				return append(append([]byte(nil), payload...), []byte("trailing")...)
+			},
+			wantMsg: errStoreLegacyChainState.Error(),
+		},
+		storeIntegrityRow{
+			// already_generated is a SCALAR outside the UTXO set and the tip is
+			// preserved, so the payload stays parse-valid and every downstream
+			// chainstate check passes: only the stale checksum catches it.
+			name: "already_generated_edited_stale_checksum",
+			body: func(t *testing.T, valid, payload []byte) []byte {
+				t.Helper()
+				edited := bytes.Replace(payload, []byte(`"already_generated": 4200`), []byte(`"already_generated": 4201`), 1)
+				if bytes.Equal(edited, payload) {
+					t.Fatalf("already_generated edit did not apply: %s", payload)
+				}
+				return []byte(strings.Replace(string(valid), payloadB64Of(t, valid),
+					base64.StdEncoding.EncodeToString(edited), 1))
+			},
+			wantMsg: errStoreChecksumMismatch.Error(),
+		},
+		storeIntegrityRow{
+			// A checksum-VALID envelope over a malformed inner payload: the
+			// bytes on disk are intact, so this is a schema fault and stays
+			// OUTSIDE the STORE_INTEGRITY identity.
+			name: "inner_payload_malformed",
+			body: func(t *testing.T, _, _ []byte) []byte {
+				t.Helper()
+				raw, err := marshalStoreEnvelope(storeEnvelopeChainState, []byte("{not json"))
+				if err != nil {
+					t.Fatalf("marshalStoreEnvelope: %v", err)
+				}
+				return raw
+			},
+			wantSub:      "decode chainstate",
+			notIntegrity: true,
+		},
+	)
+	runStoreIntegrityRows(t, path, valid, payload, func() error {
+		_, err := LoadChainState(path)
+		return err
+	}, rows)
+
+	// Positive control on the same path: the valid envelope still round-trips.
+	if err := os.WriteFile(path, valid, 0o600); err != nil {
+		t.Fatalf("restore valid envelope: %v", err)
+	}
+	loaded, err := LoadChainState(path)
+	if err != nil {
+		t.Fatalf("valid envelope must load: %v", err)
+	}
+	if !loaded.HasTip || loaded.Height != 9 || loaded.AlreadyGenerated != 4_200 {
+		t.Fatalf("round trip lost state: %+v", loaded)
+	}
+}
+
+// TestBlockstoreIndexRejectsIntegrityFailures: the same frame rows plus the
+// canonical-row swap, through the real OpenBlockStore path. Rust twin:
+// `blockstore_index_rejects_integrity_failures`.
+func TestBlockstoreIndexRejectsIntegrityFailures(t *testing.T) {
+	dir := t.TempDir()
+	root := BlockStorePath(dir)
+	store, _, _ := storeAtGenesis(t, dir)
+	sibling := storeSameHeightSibling(t, store)
+	marker := filepath.Join(root, "index.json")
+	valid, err := os.ReadFile(marker) // #nosec G304 -- test-local path.
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	payload, err := openStoreEnvelope(storeEnvelopeBlockIndex, valid)
+	if err != nil {
+		t.Fatalf("open valid envelope: %v", err)
+	}
+
+	swapRow := func(t *testing.T, valid []byte, payload []byte, recompute bool) []byte {
+		t.Helper()
+		var index blockStoreIndexDisk
+		if err := json.Unmarshal(payload, &index); err != nil {
+			t.Fatalf("decode index payload: %v", err)
+		}
+		if len(index.Canonical) == 0 {
+			t.Fatalf("index has no canonical rows")
+		}
+		index.Canonical[len(index.Canonical)-1] = hex.EncodeToString(sibling[:])
+		edited, err := json.MarshalIndent(index, "", "  ")
+		if err != nil {
+			t.Fatalf("encode index payload: %v", err)
+		}
+		edited = append(edited, '\n')
+		if recompute {
+			raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, edited)
+			if err != nil {
+				t.Fatalf("marshalStoreEnvelope: %v", err)
+			}
+			return raw
+		}
+		return []byte(strings.Replace(string(valid), payloadB64Of(t, valid),
+			base64.StdEncoding.EncodeToString(edited), 1))
+	}
+
+	rows := append(storeEnvelopeSharedRejectRows(),
+		storeIntegrityRow{
+			name:    "legacy_unversioned_blockstore_index",
+			body:    func(_ *testing.T, _, payload []byte) []byte { return payload },
+			wantMsg: errStoreLegacyBlockIndex.Error(),
+		},
+		storeIntegrityRow{
+			// The swapped row names a same-height sibling whose header, block
+			// and undo artifacts ALL exist, so the stored-identity and undo
+			// bindings both pass: only the envelope catches the file edit.
+			name: "canonical_row_swapped_to_existing_sibling",
+			body: func(t *testing.T, valid, payload []byte) []byte {
+				return swapRow(t, valid, payload, false)
+			},
+			wantMsg: errStoreChecksumMismatch.Error(),
+		},
+		storeIntegrityRow{
+			name: "inner_payload_malformed",
+			body: func(t *testing.T, _, _ []byte) []byte {
+				t.Helper()
+				raw, err := marshalStoreEnvelope(storeEnvelopeBlockIndex, []byte(`{"version":1,"canonical":["zz"]}`))
+				if err != nil {
+					t.Fatalf("marshalStoreEnvelope: %v", err)
+				}
+				return raw
+			},
+			wantSub:      "decode blockstore index",
+			notIntegrity: true,
+		},
+	)
+	runStoreIntegrityRows(t, marker, valid, payload, func() error {
+		_, err := OpenBlockStore(root)
+		return err
+	}, rows)
+
+	// The envelope is the ONLY guard on that swap: with the checksum
+	// recomputed over the swapped payload the store opens, which is exactly
+	// why the checksum may never be waived.
+	if err := os.WriteFile(marker, swapRow(t, valid, payload, true), 0o600); err != nil {
+		t.Fatalf("plant recomputed swap: %v", err)
+	}
+	if _, err := OpenBlockStore(root); err != nil {
+		t.Fatalf("recomputed-checksum swap must clear the envelope: %v", err)
+	}
+
+	if err := os.WriteFile(marker, valid, 0o600); err != nil {
+		t.Fatalf("restore valid marker: %v", err)
+	}
+	if _, err := OpenBlockStore(root); err != nil {
+		t.Fatalf("valid marker must open: %v", err)
+	}
+}
+
+// storeSameHeightSibling writes a complete header/block/undo artifact set for a
+// non-canonical block at the canonical tip's height, so a swapped index row can
+// point at a block every downstream identity check accepts.
+func storeSameHeightSibling(t *testing.T, store *BlockStore) [32]byte {
+	t.Helper()
+	parsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 0, 1)
+	blockBytes := buildSingleTxBlock(t, parsed.Header.PrevBlockHash, consensus.POW_LIMIT, parsed.Header.Timestamp+1, coinbase)
+	siblingParsed, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(sibling): %v", err)
+	}
+	hash, err := consensus.BlockHash(siblingParsed.HeaderBytes)
+	if err != nil {
+		t.Fatalf("BlockHash(sibling): %v", err)
+	}
+	if err := store.StoreBlock(hash, siblingParsed.HeaderBytes, blockBytes); err != nil {
+		t.Fatalf("StoreBlock(sibling): %v", err)
+	}
+	if err := store.PutUndo(hash, &BlockUndo{BlockHeight: 0}); err != nil {
+		t.Fatalf("PutUndo(sibling): %v", err)
+	}
+	return hash
+}
+
+// TestStartupGenesisAnchorMismatchFails pins the RUB-1134 genesis anchor: a
+// non-empty canonical index whose row 0 is not the configured genesis hash is
+// a foreign datadir and is refused BEFORE reconcile adopts the index; an EMPTY
+// canonical index skips the anchor. Startup wiring lives in
+// cmd/rubin-node/main.go, which calls this method before
+// ReconcileChainStateWithBlockStore. Rust twin:
+// `startup_genesis_anchor_mismatch_fails`.
+func TestStartupGenesisAnchorMismatchFails(t *testing.T) {
+	empty := mustCreateBlockStore(t, BlockStorePath(t.TempDir()))
+	if err := empty.VerifyGenesisAnchor([32]byte{0xff}); err != nil {
+		t.Fatalf("an empty canonical index must skip the anchor: %v", err)
+	}
+
+	dir := t.TempDir()
+	store, _, cfg := storeAtGenesis(t, dir)
+	if err := store.VerifyGenesisAnchor(devnetGenesisBlockHash); err != nil {
+		t.Fatalf("a legitimate datadir must pass the anchor: %v", err)
+	}
+
+	// A coherent FOREIGN datadir: both envelopes verify and the tips agree, so
+	// only the anchor refuses it.
+	foreign := [32]byte{0xab}
+	err := store.VerifyGenesisAnchor(foreign)
+	if err == nil {
+		t.Fatalf("a foreign canonical index must be refused")
+	}
+	if err.Error() != errStoreGenesisAnchor.Error() {
+		t.Fatalf("message = %q, want %q", err.Error(), errStoreGenesisAnchor.Error())
+	}
+	if !errors.Is(err, ErrStoreIntegrity) {
+		t.Fatalf("anchor failure must carry the ErrStoreIntegrity identity: %v", err)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("anchor failure must never satisfy fs.ErrNotExist: %v", err)
+	}
+
+	// The anchor precedes adoption: the refused store is untouched, and the
+	// reconcile that would have adopted it is never reached on the wired path.
+	snapshot, err := store.CanonicalIndexSnapshot()
+	if err != nil || len(snapshot) != 1 || snapshot[0] != hex.EncodeToString(devnetGenesisBlockHash[:]) {
+		t.Fatalf("anchor refusal mutated the canonical index: %v (%v)", snapshot, err)
+	}
+	if _, err := ReconcileChainStateWithBlockStore(NewChainState(), store, cfg); err != nil {
+		t.Fatalf("reconcile over the anchored store: %v", err)
+	}
+}
+
+// TestAbsentChainstateRebuildsByReplay: an ABSENT chainstate.json keeps the
+// NewChainState-plus-full-validated-replay repair path over an enveloped
+// index, and a corrupt one does NOT. Rust twin:
+// `absent_chainstate_rebuilds_by_replay`.
+func TestAbsentChainstateRebuildsByReplay(t *testing.T) {
+	dir := t.TempDir()
+	store, live, cfg := storeAtGenesis(t, dir)
+	path := ChainStatePath(dir)
+	if err := live.Save(path); err != nil {
+		t.Fatalf("save chainstate: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove chainstate: %v", err)
+	}
+
+	rebuilt, err := LoadChainState(path)
+	if err != nil {
+		t.Fatalf("absent chainstate must load as a fresh state: %v", err)
+	}
+	if rebuilt.HasTip || len(rebuilt.Utxos) != 0 {
+		t.Fatalf("absent chainstate must load empty: %+v", rebuilt)
+	}
+	changed, err := ReconcileChainStateWithBlockStore(rebuilt, store, cfg)
+	if err != nil {
+		t.Fatalf("replay from an absent chainstate: %v", err)
+	}
+	if !changed || !rebuilt.HasTip || rebuilt.Height != 0 || rebuilt.TipHash != devnetGenesisBlockHash {
+		t.Fatalf("replay did not rebuild the tip: changed=%v state=%+v", changed, rebuilt)
+	}
+
+	// The absent-file fallback must NOT extend to a corrupt file.
+	if err := os.WriteFile(path, []byte("{\"version\":1}\n"), 0o600); err != nil {
+		t.Fatalf("plant legacy chainstate: %v", err)
+	}
+	if _, err := LoadChainState(path); err == nil || err.Error() != errStoreLegacyChainState.Error() {
+		t.Fatalf("legacy chainstate = %v, want %v", err, errStoreLegacyChainState)
+	}
+}
+
+// TestReconcileCrashRecoveryOverEnvelopedFiles re-proves every baseline
+// crash-recovery reconcile scenario over enveloped files: a crash at each
+// atomic-write boundary (scratch open/write, rename, parent sync) for each of
+// the two files, in BOTH write orders, then reopen from disk and reconcile.
+// Rust twin: `reconcile_crash_recovery_over_enveloped_files`.
+func TestReconcileCrashRecoveryOverEnvelopedFiles(t *testing.T) {
+	for _, boundary := range []string{"scratch_open", "scratch_write", "rename", "parent_sync"} {
+		for _, order := range []string{"index_first", "chainstate_first"} {
+			t.Run(boundary+"_"+order, func(t *testing.T) {
+				dir := t.TempDir()
+				store, live, cfg := storeAtGenesis(t, dir)
+				chainStatePath := ChainStatePath(dir)
+				if err := live.Save(chainStatePath); err != nil {
+					t.Fatalf("baseline save: %v", err)
+				}
+				block1 := appendCanonicalBlock(t, store, live, cfg)
+
+				crashed := crashAtBoundary(t, boundary, order, store, live, chainStatePath)
+
+				// Whatever the crash left on disk, the reopened datadir must be
+				// envelope-clean and reconcile back to the canonical tip.
+				reopened := mustOpenBlockStore(t, BlockStorePath(dir))
+				state, err := LoadChainState(chainStatePath)
+				if err != nil {
+					t.Fatalf("post-crash chainstate load: %v", err)
+				}
+				if _, err := ReconcileChainStateWithBlockStore(state, reopened, cfg); err != nil {
+					t.Fatalf("post-crash reconcile: %v", err)
+				}
+				tipHeight, tipHash, ok, err := reopened.Tip()
+				if err != nil || !ok {
+					t.Fatalf("post-crash tip: ok=%v err=%v", ok, err)
+				}
+				if !state.HasTip || state.Height != tipHeight || state.TipHash != tipHash {
+					t.Fatalf("reconcile did not restore the canonical tip: state=%+v tip=(%d,%x)", state, tipHeight, tipHash)
+				}
+				if crashed && tipHash == block1 && state.Height != 1 {
+					t.Fatalf("committed index row lost its replay: %+v", state)
+				}
+			})
+		}
+	}
+}
+
+// appendCanonicalBlock applies one real block on top of the canonical genesis
+// and returns its hash.
+func appendCanonicalBlock(t *testing.T, store *BlockStore, live *ChainState, cfg SyncConfig) [32]byte {
+	t.Helper()
+	engine, err := NewSyncEngine(live, store, cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	parsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+	coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, 1)
+	block := buildSingleTxBlock(t, devnetGenesisBlockHash, consensus.POW_LIMIT, parsed.Header.Timestamp+1, coinbase)
+	summary, err := engine.ApplyBlock(block, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(block1): %v", err)
+	}
+	return summary.BlockHash
+}
+
+// crashAtBoundary injects one failure at one atomic-write boundary while the
+// two files are written in the given order, scoped to the file the row names,
+// and reports whether the injected write actually failed.
+func crashAtBoundary(t *testing.T, boundary, order string, store *BlockStore, live *ChainState, chainStatePath string) bool {
+	t.Helper()
+	victim := store.indexPath
+	if order == "chainstate_first" {
+		victim = chainStatePath
+	}
+	armed := false
+	withAtomicWriteOps(t, func(ops *atomicWriteOps) {
+		previousOpen, previousRename, previousSync := ops.openScratch, ops.rename, ops.syncParent
+		scratch := filepath.Join(filepath.Dir(victim), atomicWriteScratchLeaf)
+		ops.openScratch = func(path string, flag int, mode os.FileMode) (atomicWriteScratchFile, error) {
+			if path == scratch && boundary == "scratch_open" {
+				armed = true
+				return nil, os.ErrPermission
+			}
+			if path == scratch && boundary == "scratch_write" {
+				armed = true
+				return &atomicScratchStub{writeErr: os.ErrPermission}, nil
+			}
+			return previousOpen(path, flag, mode)
+		}
+		ops.rename = func(from, to string) error {
+			if to == victim && boundary == "rename" {
+				armed = true
+				return os.ErrPermission
+			}
+			return previousRename(from, to)
+		}
+		ops.syncParent = func(path string) error {
+			if path == filepath.Dir(victim) && boundary == "parent_sync" {
+				armed = true
+				return os.ErrPermission
+			}
+			return previousSync(path)
+		}
+	})
+
+	writes := []func() error{
+		func() error { return saveBlockStoreIndex(store.indexPath, store.index) },
+		func() error { return live.Save(chainStatePath) },
+	}
+	if order == "chainstate_first" {
+		writes[0], writes[1] = writes[1], writes[0]
+	}
+	failed := false
+	for _, write := range writes {
+		if err := write(); err != nil {
+			failed = true
+			break
+		}
+	}
+	if !armed {
+		t.Fatalf("boundary %s (%s) was never reached", boundary, order)
+	}
+	return failed
+}

--- a/clients/go/node/undo.go
+++ b/clients/go/node/undo.go
@@ -437,8 +437,10 @@ func blockUndoFromDisk(disk blockUndoDisk) (*BlockUndo, error) {
 //	{"version":1,"block_hash":"<64hex>","payload_b64":"<b64>","checksum":"<64hex>"}\n
 //
 // checksum = SHA3-256("RUBIN_BLOCK_UNDO_V1" || block_hash[32] ||
-// uint64_be(len(payload)) || payload). The length term makes the preimage
-// injective, so no two (hash, payload) pairs share a digest by concatenation.
+// uint64_be(len(payload)) || payload). The length prefix makes the preimage
+// encoding unambiguous: no two distinct (hash, payload) pairs serialize to
+// the same preimage bytes, so concatenation cannot alias one frame into
+// another.
 // The trailing LF counts against the read bound but is NOT in the preimage.
 //
 // Rust twin: the same section in crates/rubin-node/src/undo.rs. Both clients

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -2828,39 +2828,52 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// Commits the devnet genesis as canonical row 0 plus a complete
-    /// header/block/undo set for a NON-canonical same-height block, so a
-    /// swapped row points at a block every downstream identity check accepts.
-    fn store_with_same_height_sibling(root: &Path) -> (BlockStore, [u8; 32]) {
+    /// Commits the devnet genesis plus two more canonical rows, and a complete
+    /// header/block/undo set for a NON-canonical block at the MIDDLE height, so
+    /// a row swapped there points at a block every downstream identity check
+    /// accepts while row 0 stays anchored and the tip stays untouched.
+    /// Go twin: `storeAtGenesis` + `appendCanonicalBlock` + `storeSameHeightSibling`.
+    fn store_with_middle_sibling(root: &Path) -> (BlockStore, [u8; 32]) {
         use crate::genesis::devnet_genesis_block_bytes;
         use crate::undo::{BlockUndo, TxUndo};
 
         let mut store = BlockStore::create(root).expect("create");
         let genesis = devnet_genesis_block_bytes();
-        let header = &genesis[..BLOCK_HEADER_BYTES];
-        let undo = BlockUndo {
-            block_height: 0,
+        // `commit_canonical_block` binds undo.block_height to the commit height.
+        let undo_at = |block_height: u64| BlockUndo {
+            block_height,
             previous_already_generated: 0,
             txs: vec![TxUndo { spent: vec![] }],
         };
-        store
-            .commit_canonical_block(
-                0,
-                block_hash(header).expect("hash"),
-                header,
-                &genesis,
-                &undo,
-            )
-            .expect("commit genesis");
+        // Distinct stored blocks derived from the genesis bytes: `open` reads no
+        // artifact, so a unique header hash is all the canonical index needs.
+        let variant = |tag: u8| {
+            let mut bytes = genesis.clone();
+            bytes[BLOCK_HEADER_BYTES - 1] ^= tag;
+            let hash = block_hash(&bytes[..BLOCK_HEADER_BYTES]).expect("hash variant header");
+            (hash, bytes)
+        };
+        for (height, tag) in [(0u64, 0u8), (1, 0x01), (2, 0x02)] {
+            let (hash, bytes) = variant(tag);
+            store
+                .commit_canonical_block(
+                    height,
+                    hash,
+                    &bytes[..BLOCK_HEADER_BYTES],
+                    &bytes,
+                    &undo_at(height),
+                )
+                .expect("commit canonical row");
+        }
 
-        // Same height, different nonce; stored but NOT the canonical row.
-        let mut sibling = genesis.clone();
-        sibling[BLOCK_HEADER_BYTES - 1] ^= 0x01;
-        let sibling_hash = block_hash(&sibling[..BLOCK_HEADER_BYTES]).expect("hash sibling header");
+        // Middle height, different nonce; stored but NOT the canonical row.
+        let (sibling_hash, sibling) = variant(0x03);
         store
             .store_block(sibling_hash, &sibling[..BLOCK_HEADER_BYTES], &sibling)
             .expect("store sibling");
-        store.put_undo(sibling_hash, &undo).expect("sibling undo");
+        store
+            .put_undo(sibling_hash, &undo_at(1))
+            .expect("sibling undo");
         (store, sibling_hash)
     }
 
@@ -2876,7 +2889,7 @@ mod tests {
 
         let dir = fresh_datadir("rubin-bs-integrity");
         let root = block_store_path(&dir);
-        let (_store, sibling_hash) = store_with_same_height_sibling(&root);
+        let (_store, sibling_hash) = store_with_middle_sibling(&root);
         let marker = root.join("index.json");
         let valid = std::fs::read(&marker).expect("read marker");
         let payload =
@@ -2886,9 +2899,11 @@ mod tests {
         fn swapped_payload(payload: &[u8], sibling: [u8; 32]) -> Vec<u8> {
             let mut index: BlockStoreIndexDisk =
                 serde_json::from_slice(payload).expect("decode index payload");
-            assert!(!index.canonical.is_empty(), "index has no canonical rows");
-            let last = index.canonical.len() - 1;
-            index.canonical[last] = hex::encode(sibling);
+            assert!(
+                index.canonical.len() >= 3,
+                "a middle-row swap needs >= 3 canonical rows"
+            );
+            index.canonical[1] = hex::encode(sibling);
             let mut edited = serde_json::to_vec_pretty(&index).expect("encode index payload");
             edited.push(b'\n');
             edited
@@ -2935,11 +2950,18 @@ mod tests {
         assert!(!payload_b64_of(&valid).is_empty());
 
         // The envelope is the ONLY guard on that swap: with the checksum
-        // recomputed the store opens, which is why it may never be waived.
+        // recomputed the store opens AND the genesis anchor still passes,
+        // because the edited row is not row 0. Hence it may never be waived.
         let swapped = swapped_payload(&payload, sibling_hash);
         std::fs::write(&marker, rewrap(STORE_ENVELOPE_BLOCK_INDEX, &swapped))
             .expect("plant recomputed swap");
-        BlockStore::open(&root).expect("recomputed-checksum swap must clear the envelope");
+        let genesis_hash =
+            block_hash(&crate::genesis::devnet_genesis_block_bytes()[..BLOCK_HEADER_BYTES])
+                .expect("genesis hash");
+        BlockStore::open(&root)
+            .expect("recomputed-checksum swap must clear the envelope")
+            .verify_genesis_anchor(genesis_hash)
+            .expect("a middle-row swap leaves row 0 anchored");
 
         std::fs::write(&marker, &valid).expect("restore valid marker");
         BlockStore::open(&root).expect("valid marker must open");
@@ -2964,7 +2986,7 @@ mod tests {
         let genesis_hash =
             block_hash(&crate::genesis::devnet_genesis_block_bytes()[..BLOCK_HEADER_BYTES])
                 .expect("genesis hash");
-        let (store, _sibling) = store_with_same_height_sibling(&root);
+        let (store, _sibling) = store_with_middle_sibling(&root);
         store
             .verify_genesis_anchor(genesis_hash)
             .expect("a legitimate datadir must pass the anchor");
@@ -2982,7 +3004,7 @@ mod tests {
             index_before,
             "the anchor refusal must not mutate the canonical index"
         );
-        assert_eq!(store.canonical_len(), 1);
+        assert_eq!(store.canonical_len(), 3);
         let _ = std::fs::remove_dir_all(&empty_dir);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -460,17 +460,13 @@ impl BlockStore {
         Ok(Some(self.canonical_hash_by_height[height as usize]))
     }
 
-    /// RUB-1134 genesis anchor: whenever the loaded canonical index is
-    /// non-empty, row 0 MUST equal the configured genesis hash for the active
-    /// network. An EMPTY canonical index skips the anchor (a fresh store has
-    /// no rows to anchor). Failure is the distinct fail-closed foreign-datadir
-    /// class carrying the STORE_INTEGRITY identity, not an envelope-integrity
-    /// failure, and never an absent-file error.
-    ///
-    /// Startup wiring (`main.rs`) calls this BEFORE
-    /// `reconcile_chain_state_with_block_store`, so no replay, truncate, or
-    /// reconcile adoption ever consumes an index whose row 0 names a foreign
-    /// chain. Go twin: `BlockStore.VerifyGenesisAnchor`.
+    /// RUB-1134 genesis anchor: a non-empty canonical index MUST carry the
+    /// configured genesis hash at row 0; an EMPTY index skips the anchor.
+    /// Failure is the fail-closed foreign-datadir class carrying the
+    /// STORE_INTEGRITY identity, never an envelope or absent-file error.
+    /// Startup (`main.rs`) calls this BEFORE
+    /// `reconcile_chain_state_with_block_store`, so no replay, truncate or
+    /// adoption ever consumes a foreign index.
     pub fn verify_genesis_anchor(&self, genesis_hash: [u8; 32]) -> Result<(), String> {
         match self.canonical_hash(0)? {
             None => Ok(()),
@@ -480,9 +476,8 @@ impl BlockStore {
     }
 
     /// Test-only: re-persists the canonical index through the ordinary atomic
-    /// write path, without changing any canonical state, so a crash-injection
-    /// row can fail exactly that write. Go twin: the direct
-    /// `saveBlockStoreIndex` call in `crashAtBoundary`.
+    /// write path without changing canonical state, so a crash-injection row
+    /// can fail exactly that write.
     #[cfg(test)]
     pub(crate) fn resave_canonical_index_for_test(&self) -> Result<(), String> {
         save_blockstore_index(&self.index_path, &self.index)
@@ -1048,10 +1043,9 @@ fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
     let raw = read_file_from_dir_unbounded(parent, name)
         .map_err(|e| format!("read blockstore index {}: {e}", path.display()))?;
     // RUB-1134: every present marker must clear the strict store_envelope_v1
-    // (layout, canonical base64, domain-tagged checksum) BEFORE the inner
-    // index decode below. The STORE_INTEGRITY message is returned verbatim
-    // (Go returns the same string) and is never an absent-file error, so the
-    // strict-open rejection above stays the only missing-marker path.
+    // BEFORE the inner index decode below. The STORE_INTEGRITY message is Go's
+    // verbatim and is never an absent-file error, so the rejection above stays
+    // the only missing-marker path.
     let raw = open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &raw)?;
     // `deny_unknown_fields` plus serde's duplicate/missing-field errors,
     // `from_slice`'s trailing-input rejection and the entry check below pin the
@@ -1120,8 +1114,7 @@ fn save_blockstore_index_serializable_typed<S: serde::Serialize + ?Sized>(
     })?;
     payload.push(b'\n');
     // RUB-1134: the pre-envelope on-disk bytes become the exact envelope
-    // payload — the inner index encoding is unchanged, only the frame is new —
-    // and the existing atomic write path below is untouched.
+    // payload; the inner encoding and the atomic write path below are unchanged.
     let raw = marshal_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &payload)
         .map_err(|error| atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error))?;
     // Keep writer on raw `write_file_atomic` (no `lexical_clean`)
@@ -2636,13 +2629,9 @@ mod tests {
         for sub in ["blocks", "headers", "undo"] {
             assert!(root.join(sub).is_dir(), "{sub} must be a directory");
         }
-        // RUB-1134: the marker is the store_envelope_v1 frame over the
-        // UNCHANGED inner payload. The frame is cross-client identical for
-        // identical payload bytes (pinned by the shared vectors in
-        // store_envelope.rs); the inner field ORDER differs from Go's writer at
-        // baseline (`version` first here, `canonical` first there) and this
-        // contract does not redesign the inner formats, so the pinned bytes
-        // below are this client's.
+        // RUB-1134: the marker is the frame over the UNCHANGED inner payload.
+        // The inner field ORDER differs from Go's writer at baseline, so the
+        // pinned bytes below are this client's.
         let raw = std::fs::read_to_string(root.join("index.json")).expect("marker");
         assert_eq!(
             raw,
@@ -2805,11 +2794,8 @@ mod tests {
         let dir = fresh_datadir("rubin-bs-marker-rows");
         let root = block_store_path(&dir);
         BlockStore::create(&root).expect("create");
-        // RUB-1134: every row is planted INSIDE a valid store_envelope_v1 frame
-        // with a correct checksum, so this table keeps testing the inner marker
-        // schema exactly as before. Frame-level rejection (legacy, checksum,
-        // duplicate/unknown envelope fields) is pinned by
-        // `blockstore_index_rejects_integrity_failures`.
+        // RUB-1134: every row is planted INSIDE a valid frame, so this table
+        // keeps testing the inner marker schema.
         let write_enveloped_marker = |body: &str| {
             std::fs::write(
                 root.join("index.json"),
@@ -2842,10 +2828,9 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// Commits the devnet genesis as canonical row 0 and writes a complete
-    /// header/block/undo artifact set for a NON-canonical block at the same
-    /// height, so a swapped index row can point at a block every downstream
-    /// identity check accepts. Go twin: `storeSameHeightSibling`.
+    /// Commits the devnet genesis as canonical row 0 plus a complete
+    /// header/block/undo set for a NON-canonical same-height block, so a
+    /// swapped row points at a block every downstream identity check accepts.
     fn store_with_same_height_sibling(root: &Path) -> (BlockStore, [u8; 32]) {
         use crate::genesis::devnet_genesis_block_bytes;
         use crate::undo::{BlockUndo, TxUndo};
@@ -2868,8 +2853,7 @@ mod tests {
             )
             .expect("commit genesis");
 
-        // Same height, different nonce: a real stored block whose artifacts all
-        // exist and which is NOT the canonical row.
+        // Same height, different nonce; stored but NOT the canonical row.
         let mut sibling = genesis.clone();
         sibling[BLOCK_HEADER_BYTES - 1] ^= 0x01;
         let sibling_hash = block_hash(&sibling[..BLOCK_HEADER_BYTES]).expect("hash sibling header");
@@ -2881,8 +2865,7 @@ mod tests {
     }
 
     /// The shared frame rows plus the canonical-row swap, through the real
-    /// `BlockStore::open` path. Go twin:
-    /// `TestBlockstoreIndexRejectsIntegrityFailures`.
+    /// `BlockStore::open` path.
     #[test]
     fn blockstore_index_rejects_integrity_failures() {
         use crate::store_envelope::tests::{
@@ -2900,16 +2883,16 @@ mod tests {
             crate::store_envelope::open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &valid)
                 .expect("open valid envelope");
 
-        let swapped_payload = move |payload: &[u8]| -> Vec<u8> {
+        fn swapped_payload(payload: &[u8], sibling: [u8; 32]) -> Vec<u8> {
             let mut index: BlockStoreIndexDisk =
                 serde_json::from_slice(payload).expect("decode index payload");
             assert!(!index.canonical.is_empty(), "index has no canonical rows");
             let last = index.canonical.len() - 1;
-            index.canonical[last] = hex::encode(sibling_hash);
+            index.canonical[last] = hex::encode(sibling);
             let mut edited = serde_json::to_vec_pretty(&index).expect("encode index payload");
             edited.push(b'\n');
             edited
-        };
+        }
 
         let mut rows = shared_reject_rows();
         rows.push(StoreIntegrityRow {
@@ -2920,12 +2903,11 @@ mod tests {
             not_integrity: false,
         });
         rows.push(StoreIntegrityRow {
-            // The swapped row names a same-height sibling whose header, block
-            // and undo artifacts ALL exist, so the stored-identity and undo
-            // bindings both pass: only the envelope catches the file edit.
+            // The sibling's artifacts ALL exist, so the stored-identity and
+            // undo bindings pass: only the envelope catches the file edit.
             name: "canonical_row_swapped_to_existing_sibling",
             body: Box::new(move |valid, payload| {
-                restamp_payload_keeping_checksum(valid, &swapped_payload(payload))
+                restamp_payload_keeping_checksum(valid, &swapped_payload(payload, sibling_hash))
             }),
             want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR),
             want_sub: None,
@@ -2953,15 +2935,9 @@ mod tests {
         assert!(!payload_b64_of(&valid).is_empty());
 
         // The envelope is the ONLY guard on that swap: with the checksum
-        // recomputed over the swapped payload the store opens, which is exactly
-        // why the checksum may never be waived.
-        let mut swapped: BlockStoreIndexDisk =
-            serde_json::from_slice(&payload).expect("decode index payload");
-        let last = swapped.canonical.len() - 1;
-        swapped.canonical[last] = hex::encode(sibling_hash);
-        let mut swapped_bytes = serde_json::to_vec_pretty(&swapped).expect("encode index payload");
-        swapped_bytes.push(b'\n');
-        std::fs::write(&marker, rewrap(STORE_ENVELOPE_BLOCK_INDEX, &swapped_bytes))
+        // recomputed the store opens, which is why it may never be waived.
+        let swapped = swapped_payload(&payload, sibling_hash);
+        std::fs::write(&marker, rewrap(STORE_ENVELOPE_BLOCK_INDEX, &swapped))
             .expect("plant recomputed swap");
         BlockStore::open(&root).expect("recomputed-checksum swap must clear the envelope");
 
@@ -2970,10 +2946,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
-    /// not the configured genesis hash is a foreign datadir and is refused
-    /// BEFORE reconcile adopts the index; an EMPTY canonical index skips the
-    /// anchor. Go twin: `TestStartupGenesisAnchorMismatchFails`.
+    /// The RUB-1134 genesis anchor: a non-empty index whose row 0 is not the
+    /// configured genesis hash is refused BEFORE reconcile adopts it; an EMPTY
+    /// index skips the anchor. Go twin: `TestStartupGenesisAnchorMismatchFails`.
     #[test]
     fn startup_genesis_anchor_mismatch_fails() {
         use crate::store_envelope::STORE_GENESIS_ANCHOR_ERR;
@@ -2994,8 +2969,7 @@ mod tests {
             .verify_genesis_anchor(genesis_hash)
             .expect("a legitimate datadir must pass the anchor");
 
-        // A coherent FOREIGN datadir: both envelopes verify and the tips agree,
-        // so only the anchor refuses it.
+        // A coherent FOREIGN datadir: only the anchor refuses it.
         let index_before = std::fs::read(root.join("index.json")).expect("index before");
         assert_eq!(
             store

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -14,6 +14,10 @@ use crate::io_utils::{
     AtomicWriteError, AtomicWriteOperation, BLOCK_FILE_MAX_BYTES, HEADER_FILE_MAX_BYTES,
     UNDO_FILE_MAX_BYTES,
 };
+use crate::store_envelope::{
+    marshal_store_envelope, open_store_envelope, STORE_ENVELOPE_BLOCK_INDEX,
+    STORE_GENESIS_ANCHOR_ERR,
+};
 use crate::undo::{marshal_undo_envelope, unmarshal_undo_envelope, BlockUndo};
 use std::ffi::OsStr;
 
@@ -454,6 +458,34 @@ impl BlockStore {
             return Ok(None);
         }
         Ok(Some(self.canonical_hash_by_height[height as usize]))
+    }
+
+    /// RUB-1134 genesis anchor: whenever the loaded canonical index is
+    /// non-empty, row 0 MUST equal the configured genesis hash for the active
+    /// network. An EMPTY canonical index skips the anchor (a fresh store has
+    /// no rows to anchor). Failure is the distinct fail-closed foreign-datadir
+    /// class carrying the STORE_INTEGRITY identity, not an envelope-integrity
+    /// failure, and never an absent-file error.
+    ///
+    /// Startup wiring (`main.rs`) calls this BEFORE
+    /// `reconcile_chain_state_with_block_store`, so no replay, truncate, or
+    /// reconcile adoption ever consumes an index whose row 0 names a foreign
+    /// chain. Go twin: `BlockStore.VerifyGenesisAnchor`.
+    pub fn verify_genesis_anchor(&self, genesis_hash: [u8; 32]) -> Result<(), String> {
+        match self.canonical_hash(0)? {
+            None => Ok(()),
+            Some(row0) if row0 == genesis_hash => Ok(()),
+            Some(_) => Err(STORE_GENESIS_ANCHOR_ERR.to_string()),
+        }
+    }
+
+    /// Test-only: re-persists the canonical index through the ordinary atomic
+    /// write path, without changing any canonical state, so a crash-injection
+    /// row can fail exactly that write. Go twin: the direct
+    /// `saveBlockStoreIndex` call in `crashAtBoundary`.
+    #[cfg(test)]
+    pub(crate) fn resave_canonical_index_for_test(&self) -> Result<(), String> {
+        save_blockstore_index(&self.index_path, &self.index)
     }
 
     pub fn tip(&self) -> Result<Option<(u64, [u8; 32])>, String> {
@@ -1015,6 +1047,12 @@ fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
     // A missing marker is an error, never an implicit empty index.
     let raw = read_file_from_dir_unbounded(parent, name)
         .map_err(|e| format!("read blockstore index {}: {e}", path.display()))?;
+    // RUB-1134: every present marker must clear the strict store_envelope_v1
+    // (layout, canonical base64, domain-tagged checksum) BEFORE the inner
+    // index decode below. The STORE_INTEGRITY message is returned verbatim
+    // (Go returns the same string) and is never an absent-file error, so the
+    // strict-open rejection above stays the only missing-marker path.
+    let raw = open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &raw)?;
     // `deny_unknown_fields` plus serde's duplicate/missing-field errors,
     // `from_slice`'s trailing-input rejection and the entry check below pin the
     // exact marker schema: exactly one `version` and one `canonical` field, in
@@ -1073,14 +1111,19 @@ fn save_blockstore_index_serializable_typed<S: serde::Serialize + ?Sized>(
     path: &Path,
     index: &S,
 ) -> Result<(), AtomicWriteError> {
-    let mut raw = serde_json::to_vec_pretty(index).map_err(|error| {
+    let mut payload = serde_json::to_vec_pretty(index).map_err(|error| {
         atomic_write_error_before(
             path,
             AtomicWriteOperation::Overwrite,
             format!("encode blockstore index: {error}"),
         )
     })?;
-    raw.push(b'\n');
+    payload.push(b'\n');
+    // RUB-1134: the pre-envelope on-disk bytes become the exact envelope
+    // payload — the inner index encoding is unchanged, only the frame is new —
+    // and the existing atomic write path below is untouched.
+    let raw = marshal_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &payload)
+        .map_err(|error| atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error))?;
     // Keep writer on raw `write_file_atomic` (no `lexical_clean`)
     // so the index file persists to the same physical directory
     // that block / header / undo writers use and that
@@ -1207,7 +1250,8 @@ mod tests {
 
     use super::{
         block_store_path, read_file_by_path, write_file_if_absent, write_file_if_absent_with,
-        BlockStore, BLOCK_FILE_MAX_BYTES, BLOCK_STORE_DIR_NAME, HEADER_FILE_MAX_BYTES,
+        BlockStore, BlockStoreIndexDisk, BLOCK_FILE_MAX_BYTES, BLOCK_STORE_DIR_NAME,
+        HEADER_FILE_MAX_BYTES, STORE_ENVELOPE_BLOCK_INDEX,
     };
 
     /// RUB-1057: bound+1 refusal at the two caller paths whose production
@@ -2592,8 +2636,26 @@ mod tests {
         for sub in ["blocks", "headers", "undo"] {
             assert!(root.join(sub).is_dir(), "{sub} must be a directory");
         }
+        // RUB-1134: the marker is the store_envelope_v1 frame over the
+        // UNCHANGED inner payload. The frame is cross-client identical for
+        // identical payload bytes (pinned by the shared vectors in
+        // store_envelope.rs); the inner field ORDER differs from Go's writer at
+        // baseline (`version` first here, `canonical` first there) and this
+        // contract does not redesign the inner formats, so the pinned bytes
+        // below are this client's.
         let raw = std::fs::read_to_string(root.join("index.json")).expect("marker");
-        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("marker json");
+        assert_eq!(
+            raw,
+            concat!(
+                r#"{"version":1,"payload_b64":"ewogICJ2ZXJzaW9uIjogMSwKICAiY2Fub25pY2FsIjogW10KfQo=","#,
+                r#""checksum":"4553e2cde806137955ef1ec93f14575cf5434d4c70c44eae6409257ddc332093"}"#,
+                "\n"
+            )
+        );
+        let payload =
+            crate::store_envelope::open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, raw.as_bytes())
+                .expect("open marker envelope");
+        let parsed: serde_json::Value = serde_json::from_slice(&payload).expect("marker json");
         assert_eq!(parsed, serde_json::json!({"version": 1, "canonical": []}));
         BlockStore::open(&root).expect("strict open of a freshly created store");
         std::fs::remove_dir_all(&dir).expect("cleanup");
@@ -2743,27 +2805,34 @@ mod tests {
         let dir = fresh_datadir("rubin-bs-marker-rows");
         let root = block_store_path(&dir);
         BlockStore::create(&root).expect("create");
+        // RUB-1134: every row is planted INSIDE a valid store_envelope_v1 frame
+        // with a correct checksum, so this table keeps testing the inner marker
+        // schema exactly as before. Frame-level rejection (legacy, checksum,
+        // duplicate/unknown envelope fields) is pinned by
+        // `blockstore_index_rejects_integrity_failures`.
+        let write_enveloped_marker = |body: &str| {
+            std::fs::write(
+                root.join("index.json"),
+                crate::store_envelope::tests::rewrap(STORE_ENVELOPE_BLOCK_INDEX, body.as_bytes()),
+            )
+            .expect("write marker");
+        };
         for (name, body) in rows {
-            std::fs::write(root.join("index.json"), body.as_bytes()).expect("write marker");
+            write_enveloped_marker(&body);
             assert!(
                 BlockStore::open(&root).is_err(),
                 "marker row {name} must be rejected"
             );
         }
         // The accepted rows: empty marker, and a well-formed lowercase entry.
-        std::fs::write(root.join("index.json"), br#"{"version":1,"canonical":[]}"#)
-            .expect("write marker");
+        write_enveloped_marker(r#"{"version":1,"canonical":[]}"#);
         assert_eq!(
             BlockStore::open(&root)
                 .expect("empty marker accepted")
                 .canonical_len(),
             0
         );
-        std::fs::write(
-            root.join("index.json"),
-            format!(r#"{{"canonical":["{hash}"],"version":1}}"#).as_bytes(),
-        )
-        .expect("write marker");
+        write_enveloped_marker(&format!(r#"{{"canonical":["{hash}"],"version":1}}"#));
         assert_eq!(
             BlockStore::open(&root)
                 .expect("field order is free")
@@ -2771,6 +2840,177 @@ mod tests {
             1
         );
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Commits the devnet genesis as canonical row 0 and writes a complete
+    /// header/block/undo artifact set for a NON-canonical block at the same
+    /// height, so a swapped index row can point at a block every downstream
+    /// identity check accepts. Go twin: `storeSameHeightSibling`.
+    fn store_with_same_height_sibling(root: &Path) -> (BlockStore, [u8; 32]) {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+
+        let mut store = BlockStore::create(root).expect("create");
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let undo = BlockUndo {
+            block_height: 0,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+        store
+            .commit_canonical_block(
+                0,
+                block_hash(header).expect("hash"),
+                header,
+                &genesis,
+                &undo,
+            )
+            .expect("commit genesis");
+
+        // Same height, different nonce: a real stored block whose artifacts all
+        // exist and which is NOT the canonical row.
+        let mut sibling = genesis.clone();
+        sibling[BLOCK_HEADER_BYTES - 1] ^= 0x01;
+        let sibling_hash = block_hash(&sibling[..BLOCK_HEADER_BYTES]).expect("hash sibling header");
+        store
+            .store_block(sibling_hash, &sibling[..BLOCK_HEADER_BYTES], &sibling)
+            .expect("store sibling");
+        store.put_undo(sibling_hash, &undo).expect("sibling undo");
+        (store, sibling_hash)
+    }
+
+    /// The shared frame rows plus the canonical-row swap, through the real
+    /// `BlockStore::open` path. Go twin:
+    /// `TestBlockstoreIndexRejectsIntegrityFailures`.
+    #[test]
+    fn blockstore_index_rejects_integrity_failures() {
+        use crate::store_envelope::tests::{
+            payload_b64_of, restamp_payload_keeping_checksum, rewrap, run_store_integrity_rows,
+            shared_reject_rows, StoreIntegrityRow,
+        };
+        use crate::store_envelope::{STORE_CHECKSUM_MISMATCH_ERR, STORE_LEGACY_BLOCK_INDEX_ERR};
+
+        let dir = fresh_datadir("rubin-bs-integrity");
+        let root = block_store_path(&dir);
+        let (_store, sibling_hash) = store_with_same_height_sibling(&root);
+        let marker = root.join("index.json");
+        let valid = std::fs::read(&marker).expect("read marker");
+        let payload =
+            crate::store_envelope::open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &valid)
+                .expect("open valid envelope");
+
+        let swapped_payload = move |payload: &[u8]| -> Vec<u8> {
+            let mut index: BlockStoreIndexDisk =
+                serde_json::from_slice(payload).expect("decode index payload");
+            assert!(!index.canonical.is_empty(), "index has no canonical rows");
+            let last = index.canonical.len() - 1;
+            index.canonical[last] = hex::encode(sibling_hash);
+            let mut edited = serde_json::to_vec_pretty(&index).expect("encode index payload");
+            edited.push(b'\n');
+            edited
+        };
+
+        let mut rows = shared_reject_rows();
+        rows.push(StoreIntegrityRow {
+            name: "legacy_unversioned_blockstore_index",
+            body: Box::new(|_, payload| payload.to_vec()),
+            want_msg: Some(STORE_LEGACY_BLOCK_INDEX_ERR),
+            want_sub: None,
+            not_integrity: false,
+        });
+        rows.push(StoreIntegrityRow {
+            // The swapped row names a same-height sibling whose header, block
+            // and undo artifacts ALL exist, so the stored-identity and undo
+            // bindings both pass: only the envelope catches the file edit.
+            name: "canonical_row_swapped_to_existing_sibling",
+            body: Box::new(move |valid, payload| {
+                restamp_payload_keeping_checksum(valid, &swapped_payload(payload))
+            }),
+            want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR),
+            want_sub: None,
+            not_integrity: false,
+        });
+        rows.push(StoreIntegrityRow {
+            name: "inner_payload_malformed",
+            body: Box::new(|_, _| {
+                rewrap(
+                    STORE_ENVELOPE_BLOCK_INDEX,
+                    br#"{"version":1,"canonical":["zz"]}"#,
+                )
+            }),
+            want_msg: None,
+            want_sub: Some("canonical[0]"),
+            not_integrity: true,
+        });
+        run_store_integrity_rows(
+            &marker,
+            &valid,
+            &payload,
+            || BlockStore::open(&root).map(|_| ()),
+            &rows,
+        );
+        assert!(!payload_b64_of(&valid).is_empty());
+
+        // The envelope is the ONLY guard on that swap: with the checksum
+        // recomputed over the swapped payload the store opens, which is exactly
+        // why the checksum may never be waived.
+        let mut swapped: BlockStoreIndexDisk =
+            serde_json::from_slice(&payload).expect("decode index payload");
+        let last = swapped.canonical.len() - 1;
+        swapped.canonical[last] = hex::encode(sibling_hash);
+        let mut swapped_bytes = serde_json::to_vec_pretty(&swapped).expect("encode index payload");
+        swapped_bytes.push(b'\n');
+        std::fs::write(&marker, rewrap(STORE_ENVELOPE_BLOCK_INDEX, &swapped_bytes))
+            .expect("plant recomputed swap");
+        BlockStore::open(&root).expect("recomputed-checksum swap must clear the envelope");
+
+        std::fs::write(&marker, &valid).expect("restore valid marker");
+        BlockStore::open(&root).expect("valid marker must open");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
+    /// not the configured genesis hash is a foreign datadir and is refused
+    /// BEFORE reconcile adopts the index; an EMPTY canonical index skips the
+    /// anchor. Go twin: `TestStartupGenesisAnchorMismatchFails`.
+    #[test]
+    fn startup_genesis_anchor_mismatch_fails() {
+        use crate::store_envelope::STORE_GENESIS_ANCHOR_ERR;
+
+        let empty_dir = fresh_datadir("rubin-bs-anchor-empty");
+        let empty = BlockStore::create(block_store_path(&empty_dir)).expect("create");
+        empty
+            .verify_genesis_anchor([0xff; 32])
+            .expect("an empty canonical index must skip the anchor");
+
+        let dir = fresh_datadir("rubin-bs-anchor");
+        let root = block_store_path(&dir);
+        let genesis_hash =
+            block_hash(&crate::genesis::devnet_genesis_block_bytes()[..BLOCK_HEADER_BYTES])
+                .expect("genesis hash");
+        let (store, _sibling) = store_with_same_height_sibling(&root);
+        store
+            .verify_genesis_anchor(genesis_hash)
+            .expect("a legitimate datadir must pass the anchor");
+
+        // A coherent FOREIGN datadir: both envelopes verify and the tips agree,
+        // so only the anchor refuses it.
+        let index_before = std::fs::read(root.join("index.json")).expect("index before");
+        assert_eq!(
+            store
+                .verify_genesis_anchor([0xab; 32])
+                .expect_err("a foreign canonical index must be refused"),
+            STORE_GENESIS_ANCHOR_ERR
+        );
+        assert_eq!(
+            std::fs::read(root.join("index.json")).expect("index after"),
+            index_before,
+            "the anchor refusal must not mutate the canonical index"
+        );
+        assert_eq!(store.canonical_len(), 1);
+        let _ = std::fs::remove_dir_all(&empty_dir);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Rule 10 at the LOADER layer: a missing marker must error even though the

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -120,10 +120,8 @@ impl ChainState {
             )
         })?;
         payload.push(b'\n');
-        // RUB-1134: the pre-envelope on-disk bytes become the exact envelope
-        // payload — the inner `ChainStateDisk` encoding is unchanged, only the
-        // frame is new — and the existing atomic write path (temp, sync,
-        // rename, parent-sync) below is untouched.
+        // RUB-1134: the pre-envelope bytes become the exact envelope payload;
+        // the inner encoding and the atomic write path below are unchanged.
         let raw =
             marshal_store_envelope(STORE_ENVELOPE_CHAIN_STATE, &payload).map_err(|error| {
                 atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error)
@@ -368,11 +366,9 @@ pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
     };
     // RUB-1134: an ABSENT file keeps the `ChainState::new()`-plus-full-replay
     // repair path above; every PRESENT file must clear the strict envelope
-    // (layout, canonical base64, domain-tagged checksum) BEFORE the inner
-    // `ChainStateDisk` decode runs. The STORE_INTEGRITY message is returned
-    // verbatim (Go returns the same string), and it is a different arm from
-    // the NotFound branch, so a corrupt file can never ride the absent-file
-    // fallback.
+    // BEFORE the inner `ChainStateDisk` decode runs. This is a different arm
+    // from the NotFound branch, so a corrupt file can never ride the
+    // absent-file fallback; the STORE_INTEGRITY message is Go's verbatim.
     let payload = open_store_envelope(STORE_ENVELOPE_CHAIN_STATE, &raw)?;
     let disk: ChainStateDisk = serde_json::from_slice(&payload)
         .map_err(|e| format!("parse chainstate {}: {e}", path.display()))?;
@@ -846,9 +842,8 @@ mod tests {
     }
 
     /// Every malformed, legacy, checksum-mismatched or parse-valid-but-edited
-    /// `chainstate.json` fails BEFORE the inner decode, with the pinned
-    /// identity, and never rides the absent-file fallback. Go twin:
-    /// `TestLoadChainStateRejectsIntegrityFailures`.
+    /// `chainstate.json` fails BEFORE the inner decode with the pinned identity
+    /// and never rides the absent-file fallback.
     #[test]
     fn load_chainstate_rejects_integrity_failures() {
         use crate::store_envelope::tests::{
@@ -873,8 +868,6 @@ mod tests {
 
         let mut rows = shared_reject_rows();
         rows.push(StoreIntegrityRow {
-            // The whole pre-envelope file, byte for byte: what a first
-            // post-upgrade startup finds on disk.
             name: "legacy_unversioned_chainstate",
             body: Box::new(|_, payload| payload.to_vec()),
             want_msg: Some(STORE_LEGACY_CHAINSTATE_ERR),
@@ -894,9 +887,8 @@ mod tests {
         });
         rows.push(StoreIntegrityRow {
             // `already_generated` is a SCALAR outside the UTXO set and the tip
-            // is preserved, so the payload stays parse-valid and every
-            // downstream chainstate check passes: only the stale checksum
-            // catches it.
+            // is preserved, so every downstream check passes and only the
+            // stale checksum catches it.
             name: "already_generated_edited_stale_checksum",
             body: Box::new(|valid, payload| {
                 let edited = String::from_utf8_lossy(payload).replacen(
@@ -912,9 +904,7 @@ mod tests {
             not_integrity: false,
         });
         rows.push(StoreIntegrityRow {
-            // A checksum-VALID envelope over a malformed inner payload: the
-            // bytes on disk are intact, so this is a schema fault and stays
-            // OUTSIDE the STORE_INTEGRITY identity.
+            // Checksum-VALID envelope, malformed payload: a schema fault.
             name: "inner_payload_malformed",
             body: Box::new(|_, _| rewrap(STORE_ENVELOPE_CHAIN_STATE, b"{not json")),
             want_msg: None,
@@ -930,15 +920,13 @@ mod tests {
             &rows,
         );
 
-        // Positive control on the same path: the valid envelope round-trips.
         std::fs::write(&path, &valid).expect("restore valid envelope");
         let loaded = load_chain_state(&path).expect("valid envelope must load");
         assert_eq!(
             (loaded.has_tip, loaded.height, loaded.already_generated),
             (true, 9, 4_200)
         );
-        // An ABSENT file keeps the fresh-state repair path; a corrupt one does
-        // not, so no STORE_INTEGRITY failure can ride the absent-file fallback.
+        // An ABSENT file keeps the fresh-state repair path; a corrupt one cannot.
         std::fs::remove_file(&path).expect("remove chainstate");
         assert_eq!(
             load_chain_state(&path).expect("absent chainstate"),
@@ -963,9 +951,8 @@ mod tests {
         };
         let mut payload = serde_json::to_vec_pretty(&bad).expect("json");
         payload.push(b'\n');
-        // RUB-1134: planted INSIDE a valid store_envelope_v1 frame, so this row
-        // still tests the INNER version check rather than being absorbed by the
-        // envelope's legacy verdict.
+        // RUB-1134: planted INSIDE a valid frame, so this row still tests the
+        // INNER version check rather than the envelope's legacy verdict.
         std::fs::write(
             &path,
             crate::store_envelope::tests::rewrap(STORE_ENVELOPE_CHAIN_STATE, &payload),

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -17,6 +17,9 @@ use crate::io_utils::{
     atomic_write_error_before, parse_hex32, reclaim_atomic_write_parent,
     reclaim_atomic_write_scratch, write_file_atomic_typed, AtomicWriteError, AtomicWriteOperation,
 };
+use crate::store_envelope::{
+    marshal_store_envelope, open_store_envelope, STORE_ENVELOPE_CHAIN_STATE,
+};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
 const CHAIN_STATE_DISK_VERSION: u32 = 1;
@@ -109,14 +112,22 @@ impl ChainState {
         let disk = state_to_disk(self).map_err(|error| {
             atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error)
         })?;
-        let mut raw = serde_json::to_vec_pretty(&disk).map_err(|error| {
+        let mut payload = serde_json::to_vec_pretty(&disk).map_err(|error| {
             atomic_write_error_before(
                 path,
                 AtomicWriteOperation::Overwrite,
                 format!("encode chainstate: {error}"),
             )
         })?;
-        raw.push(b'\n');
+        payload.push(b'\n');
+        // RUB-1134: the pre-envelope on-disk bytes become the exact envelope
+        // payload — the inner `ChainStateDisk` encoding is unchanged, only the
+        // frame is new — and the existing atomic write path (temp, sync,
+        // rename, parent-sync) below is untouched.
+        let raw =
+            marshal_store_envelope(STORE_ENVELOPE_CHAIN_STATE, &payload).map_err(|error| {
+                atomic_write_error_before(path, AtomicWriteOperation::Overwrite, error)
+            })?;
         // Parent creation is delegated to `write_file_atomic`, which
         // runs `fs::create_dir_all(effective_parent(path))` on the
         // actual write target. `effective_parent` maps a bare-filename
@@ -355,7 +366,15 @@ pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ChainState::new()),
         Err(e) => return Err(format!("read chainstate {}: {e}", path.display())),
     };
-    let disk: ChainStateDisk = serde_json::from_slice(&raw)
+    // RUB-1134: an ABSENT file keeps the `ChainState::new()`-plus-full-replay
+    // repair path above; every PRESENT file must clear the strict envelope
+    // (layout, canonical base64, domain-tagged checksum) BEFORE the inner
+    // `ChainStateDisk` decode runs. The STORE_INTEGRITY message is returned
+    // verbatim (Go returns the same string), and it is a different arm from
+    // the NotFound branch, so a corrupt file can never ride the absent-file
+    // fallback.
+    let payload = open_store_envelope(STORE_ENVELOPE_CHAIN_STATE, &raw)?;
+    let disk: ChainStateDisk = serde_json::from_slice(&payload)
         .map_err(|e| format!("parse chainstate {}: {e}", path.display()))?;
     chain_state_from_disk(disk)
 }
@@ -495,7 +514,7 @@ mod tests {
 
     use super::{
         chain_state_path, copy_utxo_entry, copy_utxo_set, load_chain_state, ChainState,
-        ChainStateDisk, CHAIN_STATE_FILE_NAME,
+        ChainStateDisk, CHAIN_STATE_FILE_NAME, STORE_ENVELOPE_CHAIN_STATE,
     };
     use rubin_consensus::constants::POW_LIMIT;
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
@@ -826,6 +845,108 @@ mod tests {
         assert_eq!(st.utxo_exposure_count_by_suite_id(0x99), 0);
     }
 
+    /// Every malformed, legacy, checksum-mismatched or parse-valid-but-edited
+    /// `chainstate.json` fails BEFORE the inner decode, with the pinned
+    /// identity, and never rides the absent-file fallback. Go twin:
+    /// `TestLoadChainStateRejectsIntegrityFailures`.
+    #[test]
+    fn load_chainstate_rejects_integrity_failures() {
+        use crate::store_envelope::tests::{
+            restamp_payload_keeping_checksum, rewrap, run_store_integrity_rows, shared_reject_rows,
+            StoreIntegrityRow,
+        };
+        use crate::store_envelope::{STORE_CHECKSUM_MISMATCH_ERR, STORE_LEGACY_CHAINSTATE_ERR};
+
+        let dir = unique_temp_path("rubin-chainstate-integrity");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = chain_state_path(&dir);
+        let mut state = ChainState::new();
+        state.has_tip = true;
+        state.height = 9;
+        state.already_generated = 4_200;
+        state.tip_hash = [0x11; 32];
+        state.save(&path).expect("save chainstate");
+        let valid = std::fs::read(&path).expect("read chainstate");
+        let payload =
+            crate::store_envelope::open_store_envelope(STORE_ENVELOPE_CHAIN_STATE, &valid)
+                .expect("open valid envelope");
+
+        let mut rows = shared_reject_rows();
+        rows.push(StoreIntegrityRow {
+            // The whole pre-envelope file, byte for byte: what a first
+            // post-upgrade startup finds on disk.
+            name: "legacy_unversioned_chainstate",
+            body: Box::new(|_, payload| payload.to_vec()),
+            want_msg: Some(STORE_LEGACY_CHAINSTATE_ERR),
+            want_sub: None,
+            not_integrity: false,
+        });
+        rows.push(StoreIntegrityRow {
+            name: "legacy_unversioned_with_trailing_garbage",
+            body: Box::new(|_, payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"trailing");
+                out
+            }),
+            want_msg: Some(STORE_LEGACY_CHAINSTATE_ERR),
+            want_sub: None,
+            not_integrity: false,
+        });
+        rows.push(StoreIntegrityRow {
+            // `already_generated` is a SCALAR outside the UTXO set and the tip
+            // is preserved, so the payload stays parse-valid and every
+            // downstream chainstate check passes: only the stale checksum
+            // catches it.
+            name: "already_generated_edited_stale_checksum",
+            body: Box::new(|valid, payload| {
+                let edited = String::from_utf8_lossy(payload).replacen(
+                    "\"already_generated\": 4200",
+                    "\"already_generated\": 4201",
+                    1,
+                );
+                assert_ne!(edited.as_bytes(), payload, "the edit did not apply");
+                restamp_payload_keeping_checksum(valid, edited.as_bytes())
+            }),
+            want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR),
+            want_sub: None,
+            not_integrity: false,
+        });
+        rows.push(StoreIntegrityRow {
+            // A checksum-VALID envelope over a malformed inner payload: the
+            // bytes on disk are intact, so this is a schema fault and stays
+            // OUTSIDE the STORE_INTEGRITY identity.
+            name: "inner_payload_malformed",
+            body: Box::new(|_, _| rewrap(STORE_ENVELOPE_CHAIN_STATE, b"{not json")),
+            want_msg: None,
+            want_sub: Some("parse chainstate"),
+            not_integrity: true,
+        });
+
+        run_store_integrity_rows(
+            &path,
+            &valid,
+            &payload,
+            || load_chain_state(&path).map(|_| ()),
+            &rows,
+        );
+
+        // Positive control on the same path: the valid envelope round-trips.
+        std::fs::write(&path, &valid).expect("restore valid envelope");
+        let loaded = load_chain_state(&path).expect("valid envelope must load");
+        assert_eq!(
+            (loaded.has_tip, loaded.height, loaded.already_generated),
+            (true, 9, 4_200)
+        );
+        // An ABSENT file keeps the fresh-state repair path; a corrupt one does
+        // not, so no STORE_INTEGRITY failure can ride the absent-file fallback.
+        std::fs::remove_file(&path).expect("remove chainstate");
+        assert_eq!(
+            load_chain_state(&path).expect("absent chainstate"),
+            ChainState::new()
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
     #[test]
     fn load_chainstate_rejects_wrong_version() {
         let dir = unique_temp_path("rubin-chainstate-version-test");
@@ -840,11 +961,19 @@ mod tests {
             already_generated: 0,
             utxos: vec![],
         };
-        let raw = serde_json::to_vec_pretty(&bad).expect("json");
-        std::fs::write(&path, raw).expect("write");
+        let mut payload = serde_json::to_vec_pretty(&bad).expect("json");
+        payload.push(b'\n');
+        // RUB-1134: planted INSIDE a valid store_envelope_v1 frame, so this row
+        // still tests the INNER version check rather than being absorbed by the
+        // envelope's legacy verdict.
+        std::fs::write(
+            &path,
+            crate::store_envelope::tests::rewrap(STORE_ENVELOPE_CHAIN_STATE, &payload),
+        )
+        .expect("write");
 
         let err = load_chain_state(&path).unwrap_err();
-        assert!(err.contains("unsupported chainstate version"));
+        assert!(err.contains("unsupported chainstate version"), "{err}");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -1215,9 +1215,8 @@ mod tests {
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// An ABSENT `chainstate.json` keeps the `ChainState::new()`-plus-full-
-    /// validated-replay repair path over an enveloped index, and a corrupt one
-    /// does NOT. Go twin: `TestAbsentChainstateRebuildsByReplay`.
+    /// An ABSENT `chainstate.json` keeps the full-validated-replay repair path
+    /// over an enveloped index; a corrupt one does NOT.
     #[test]
     fn absent_chainstate_rebuilds_by_replay() {
         use crate::chainstate::{chain_state_path, load_chain_state};
@@ -1250,12 +1249,47 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    /// The hostile "both together" row: a first post-upgrade startup finds BOTH
+    /// files pre-envelope. Startup opens the blockstore before it loads the
+    /// chainstate, so the index verdict is the one an operator sees; each file
+    /// is refused on its own class and neither is rewritten.
+    #[test]
+    fn both_legacy_files_fail_closed_at_first_startup() {
+        use crate::chainstate::{chain_state_path, load_chain_state};
+        use crate::store_envelope::{STORE_LEGACY_BLOCK_INDEX_ERR, STORE_LEGACY_CHAINSTATE_ERR};
+
+        let dir = fresh_dir("rubin-recover-both-legacy");
+        drop(create_store_in(&dir));
+        let (index, chainstate) = (
+            block_store_path(&dir).join("index.json"),
+            chain_state_path(&dir),
+        );
+        // Exactly the pre-envelope encodings the two writers now wrap as payloads.
+        let legacy_index = b"{\n  \"canonical\": [],\n  \"version\": 1\n}\n";
+        let legacy_chainstate = b"{\n  \"version\": 1,\n  \"utxos\": []\n}\n";
+        fs::write(&index, legacy_index).expect("plant legacy index");
+        fs::write(&chainstate, legacy_chainstate).expect("plant legacy chainstate");
+
+        assert_eq!(
+            BlockStore::open(block_store_path(&dir)).expect_err("legacy index"),
+            STORE_LEGACY_BLOCK_INDEX_ERR
+        );
+        assert_eq!(
+            load_chain_state(&chainstate).expect_err("legacy chainstate"),
+            STORE_LEGACY_CHAINSTATE_ERR
+        );
+        assert_eq!(fs::read(&index).expect("re-read index"), legacy_index);
+        assert_eq!(
+            fs::read(&chainstate).expect("re-read chainstate"),
+            legacy_chainstate
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     /// Re-proves every baseline crash-recovery reconcile scenario over
-    /// enveloped files. A crash is injected at each atomic-write boundary
-    /// (scratch open, scratch write, rename, parent sync) while the canonical
-    /// index and the chainstate snapshot are written in BOTH orders, and the
-    /// datadir is then reopened from disk and reconciled. Go twin:
-    /// `TestReconcileCrashRecoveryOverEnvelopedFiles`.
+    /// enveloped files: a crash at each atomic-write boundary (scratch open,
+    /// scratch write, rename, parent sync) with the index and the snapshot
+    /// written in BOTH orders, then reopen from disk and reconcile.
     #[test]
     fn reconcile_crash_recovery_over_enveloped_files() {
         use crate::chainstate::{chain_state_path, load_chain_state};
@@ -1273,12 +1307,10 @@ mod tests {
                 let path = chain_state_path(&dir);
                 let store = create_store_in(&dir);
                 let (genesis_hash, mut store, state) = apply_genesis(store);
-                // The pre-crash snapshot on disk: genesis only.
                 state.save(&path).expect("baseline save");
 
-                // One real canonical block on top, committed by the engine, so
-                // the index on disk is ahead of the snapshot exactly as after
-                // an ordinary connect.
+                // One canonical block on top, so the index is ahead of the
+                // snapshot exactly as after an ordinary connect.
                 let g_parsed =
                     parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
                 let block1 =
@@ -1295,8 +1327,8 @@ mod tests {
                     block_hash(&parse_block_bytes(&block1).expect("parse b1").header_bytes)
                         .expect("hash b1");
 
-                // Crash at one boundary of the FIRST write in this order; the
-                // second write never runs, exactly as after a real crash.
+                // Crash at one boundary of the FIRST write; the second never
+                // runs, as after a real crash.
                 {
                     let scope = AtomicWriteTestScope::new();
                     scope.fail_at(boundary, 1, "crash");
@@ -1313,8 +1345,7 @@ mod tests {
                     );
                 }
 
-                // Whatever the crash left on disk, the reopened datadir must be
-                // envelope-clean and reconcile back to the canonical tip.
+                // The reopened datadir must reconcile back to the tip.
                 let mut reopened =
                     BlockStore::open(block_store_path(&dir)).expect("reopen blockstore");
                 let mut recovered = load_chain_state(&path).expect("post-crash chainstate load");

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -1215,6 +1215,128 @@ mod tests {
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    /// An ABSENT `chainstate.json` keeps the `ChainState::new()`-plus-full-
+    /// validated-replay repair path over an enveloped index, and a corrupt one
+    /// does NOT. Go twin: `TestAbsentChainstateRebuildsByReplay`.
+    #[test]
+    fn absent_chainstate_rebuilds_by_replay() {
+        use crate::chainstate::{chain_state_path, load_chain_state};
+        use crate::store_envelope::STORE_LEGACY_CHAINSTATE_ERR;
+
+        let dir = fresh_dir("rubin-recover-absent-chainstate");
+        let store = create_store_in(&dir);
+        let (genesis_hash, mut store, state) = apply_genesis(store);
+        let path = chain_state_path(&dir);
+        state.save(&path).expect("save chainstate");
+        fs::remove_file(&path).expect("remove chainstate");
+
+        let mut rebuilt = load_chain_state(&path).expect("absent chainstate must load fresh");
+        assert_eq!(rebuilt, ChainState::new());
+        let changed =
+            reconcile_chain_state_with_block_store(&mut rebuilt, &mut store, &devnet_cfg())
+                .expect("replay from an absent chainstate");
+        assert!(changed, "replay must rebuild the tip");
+        assert_eq!(
+            (rebuilt.has_tip, rebuilt.height, rebuilt.tip_hash),
+            (true, 0, genesis_hash)
+        );
+
+        // The absent-file fallback must NOT extend to a corrupt file.
+        fs::write(&path, b"{\"version\":1}\n").expect("plant legacy chainstate");
+        assert_eq!(
+            load_chain_state(&path).expect_err("legacy chainstate"),
+            STORE_LEGACY_CHAINSTATE_ERR
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Re-proves every baseline crash-recovery reconcile scenario over
+    /// enveloped files. A crash is injected at each atomic-write boundary
+    /// (scratch open, scratch write, rename, parent sync) while the canonical
+    /// index and the chainstate snapshot are written in BOTH orders, and the
+    /// datadir is then reopened from disk and reconciled. Go twin:
+    /// `TestReconcileCrashRecoveryOverEnvelopedFiles`.
+    #[test]
+    fn reconcile_crash_recovery_over_enveloped_files() {
+        use crate::chainstate::{chain_state_path, load_chain_state};
+        use crate::io_utils::{AtomicWriteTestOp, AtomicWriteTestScope};
+        use crate::test_helpers::height_one_coinbase_only_block;
+
+        for boundary in [
+            AtomicWriteTestOp::ExclusiveOpen,
+            AtomicWriteTestOp::Write,
+            AtomicWriteTestOp::Rename,
+            AtomicWriteTestOp::ParentSync,
+        ] {
+            for index_first in [true, false] {
+                let dir = fresh_dir("rubin-recover-crash-envelope");
+                let path = chain_state_path(&dir);
+                let store = create_store_in(&dir);
+                let (genesis_hash, mut store, state) = apply_genesis(store);
+                // The pre-crash snapshot on disk: genesis only.
+                state.save(&path).expect("baseline save");
+
+                // One real canonical block on top, committed by the engine, so
+                // the index on disk is ahead of the snapshot exactly as after
+                // an ordinary connect.
+                let g_parsed =
+                    parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+                let block1 =
+                    height_one_coinbase_only_block(genesis_hash, g_parsed.header.timestamp + 1);
+                let mut engine = SyncEngine::new(ChainState::new(), Some(store), devnet_cfg())
+                    .expect("sync engine");
+                engine
+                    .apply_block(&devnet_genesis_block_bytes(), None)
+                    .expect("apply genesis");
+                engine.apply_block(&block1, None).expect("apply block1");
+                let live = engine.chain_state_snapshot();
+                store = engine.block_store_snapshot().expect("blockstore");
+                let b1_hash =
+                    block_hash(&parse_block_bytes(&block1).expect("parse b1").header_bytes)
+                        .expect("hash b1");
+
+                // Crash at one boundary of the FIRST write in this order; the
+                // second write never runs, exactly as after a real crash.
+                {
+                    let scope = AtomicWriteTestScope::new();
+                    scope.fail_at(boundary, 1, "crash");
+                    if index_first {
+                        store
+                            .resave_canonical_index_for_test()
+                            .expect_err("injected crash");
+                    } else {
+                        live.save(&path).expect_err("injected crash");
+                    }
+                    assert!(
+                        scope.operations().contains(&boundary),
+                        "boundary {boundary:?} was never reached"
+                    );
+                }
+
+                // Whatever the crash left on disk, the reopened datadir must be
+                // envelope-clean and reconcile back to the canonical tip.
+                let mut reopened =
+                    BlockStore::open(block_store_path(&dir)).expect("reopen blockstore");
+                let mut recovered = load_chain_state(&path).expect("post-crash chainstate load");
+                reconcile_chain_state_with_block_store(
+                    &mut recovered,
+                    &mut reopened,
+                    &devnet_cfg(),
+                )
+                .expect("post-crash reconcile");
+                let (tip_height, tip_hash) =
+                    reopened.tip().expect("tip read").expect("tip present");
+                assert_eq!(
+                    (recovered.has_tip, recovered.height, recovered.tip_hash),
+                    (true, tip_height, tip_hash),
+                    "boundary {boundary:?} index_first={index_first} did not restore the tip"
+                );
+                assert_eq!(tip_hash, b1_hash, "the committed canonical row was lost");
+                let _ = fs::remove_dir_all(&dir);
+            }
+        }
+    }
+
     /// The canonical index plus the block/header/undo artifact counts, so a
     /// failing path can be shown to add no durable write of its own.
     fn durable_state(root: &std::path::Path) -> (Vec<u8>, [usize; 3]) {

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -14,6 +14,7 @@ pub mod p2p_runtime;
 pub mod p2p_service;
 mod production_rotation_schedule;
 pub mod relay_pool;
+mod store_envelope;
 pub mod sync;
 pub mod sync_disconnect;
 pub mod sync_reorg;

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -2532,7 +2532,7 @@ mod tests {
         assert_eq!(code, 2, "{err}");
         assert!(
             err.contains(
-                "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch."
+                "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch"
             ),
             "unexpected refusal: {err}"
         );

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -371,20 +371,23 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     if !cfg.dry_run {
         // RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
         // not the configured genesis hash is a foreign datadir. Checked BEFORE
-        // the reconcile so no replay, truncate, or reconcile adoption ever
-        // consumes a foreign index; an empty index skips the anchor. `--dry-run`
-        // adopts nothing and stays a read-only report, so the anchor is enforced
-        // only on this mutating path — the same placement as the Go twin in
-        // `clients/go/cmd/rubin-node/main.go`. A genesis file that carries no
-        // genesis hash for a custom chain_id leaves nothing to anchor AGAINST;
-        // that configuration is refused later by `runtime_genesis_hash` before
-        // any service starts, and Go cannot reach it at all (its genesis parse
-        // requires the hash).
-        if let Some(genesis_hash) = genesis_cfg.genesis_hash {
-            if let Err(err) = block_store.verify_genesis_anchor(genesis_hash) {
-                let _ = writeln!(stderr, "canonical index genesis anchor failed: {err}");
+        // the reconcile so no replay, truncate or adoption consumes a foreign
+        // index; an empty index skips it. `--dry-run` adopts nothing, so the
+        // anchor is enforced only on this mutating path, as in the Go twin.
+        // A genesis file carrying no hash leaves nothing to anchor AGAINST, so
+        // the `runtime_genesis_hash` refusal is hoisted here from its later
+        // call site: it must precede the reconcile, which rewrites the snapshot
+        // and can truncate the index. Go refuses that config even earlier.
+        let genesis_hash = match runtime_genesis_hash(&genesis_cfg) {
+            Ok(hash) => hash,
+            Err(err) => {
+                let _ = writeln!(stderr, "{err}");
                 return 2;
             }
+        };
+        if let Err(err) = block_store.verify_genesis_anchor(genesis_hash) {
+            let _ = writeln!(stderr, "canonical index genesis anchor failed: {err}");
+            return 2;
         }
         if let Err(err) =
             reconcile_chain_state_with_block_store(&mut chain_state, &mut block_store, &sync_cfg)
@@ -2424,6 +2427,57 @@ mod tests {
         let err = runtime_genesis_hash(&genesis_cfg).unwrap_err();
         assert!(err.contains("genesis_hash_hex"), "unexpected error: {err}");
 
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// RUB-1134: a custom chain_id with no genesis hash leaves the anchor
+    /// nothing to check, so the mutating path refuses it AT the anchor site,
+    /// before `reconcile_chain_state_with_block_store` adopts the index and
+    /// rewrites the snapshot. Pinned by the refusal being the genesis-hash one
+    /// (a reconcile verdict means the decision moved after adoption) plus both
+    /// files byte-unchanged.
+    #[test]
+    fn hashless_genesis_refuses_before_reconcile_adopts_the_index() {
+        let dir = unique_temp_dir("rubin-node-bin-anchor-hashless");
+        let d = dir.display().to_string();
+        let mine = [
+            "--datadir",
+            &d,
+            "--create-store",
+            "--mine-blocks",
+            "1",
+            "--mine-exit",
+        ];
+        let (code, err) = cli(&mine);
+        assert_eq!(code, 0, "{err}");
+        let chain_state_file = chain_state_path(&dir);
+        rubin_node::ChainState::new()
+            .save(&chain_state_file)
+            .expect("reset chainstate to the encoded empty state");
+        let index_file = block_store_path(&dir).join("index.json");
+        let before = (
+            fs::read(&chain_state_file).expect("stale chainstate"),
+            fs::read(&index_file).expect("canonical index"),
+        );
+
+        let genesis_file = dir.join("genesis.json");
+        fs::write(
+            &genesis_file,
+            "{\"chain_id_hex\":\"0x1111111111111111111111111111111111111111111111111111111111111111\"}",
+        )
+        .expect("write genesis");
+        let g = genesis_file.display().to_string();
+        let (code, err) = cli(&["--datadir", &d, "--genesis-file", &g]);
+        assert_eq!(code, 2, "{err}");
+        assert!(
+            err.contains("genesis_hash_hex"),
+            "unexpected refusal: {err}"
+        );
+        let after = (
+            fs::read(&chain_state_file).expect("re-read chainstate"),
+            fs::read(&index_file).expect("re-read index"),
+        );
+        assert_eq!(after, before, "the refusal must precede reconcile");
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -2481,6 +2481,78 @@ mod tests {
         fs::remove_dir_all(&dir).expect("cleanup");
     }
 
+    /// RUB-1134: the genesis anchor is wired into `run()`, not only into
+    /// `BlockStore::verify_genesis_anchor` — the blockstore unit row stays green
+    /// with this call site deleted. Row 0 here is a COHERENT foreign genesis
+    /// (header, block bytes and index row all agree, so every stored-identity
+    /// check passes and only the anchor can refuse it), so a mutating startup
+    /// must exit 2 on the anchor message with the datadir byte-unchanged, while
+    /// `--dry-run` adopts nothing and still exits 0. Go mirror:
+    /// `TestRunGenesisAnchorRefusesForeignDatadir`.
+    #[test]
+    fn genesis_anchor_refuses_foreign_datadir() {
+        let dir = unique_temp_dir("rubin-node-bin-anchor-foreign");
+        seed_block_store(&dir);
+
+        // Another chain's genesis: flip one header byte, then re-derive the
+        // hash so the header/block/index triple stays self-consistent.
+        let mut block = rubin_node::devnet_genesis_block_bytes();
+        block[rubin_consensus::BLOCK_HEADER_BYTES - 1] ^= 0x01;
+        let header = block[..rubin_consensus::BLOCK_HEADER_BYTES].to_vec();
+        let foreign = rubin_consensus::block_hash(&header).expect("hash the foreign genesis");
+        assert_ne!(
+            foreign,
+            rubin_node::genesis::devnet_genesis_hash(),
+            "fixture is not foreign"
+        );
+        let mut store = BlockStore::open(block_store_path(&dir)).expect("open block store");
+        store
+            .commit_canonical_block(
+                0,
+                foreign,
+                &header,
+                &block,
+                &rubin_node::undo::BlockUndo {
+                    block_height: 0,
+                    previous_already_generated: 0,
+                    txs: Vec::new(),
+                },
+            )
+            .expect("commit the foreign canonical row 0");
+        drop(store);
+
+        let index_file = block_store_path(&dir).join("index.json");
+        let before = fs::read(&index_file).expect("canonical index");
+
+        // `--mine-blocks`/`--mine-exit` only BOUND the run: the anchor rejects
+        // long before the miner starts, and an unbounded startup would serve
+        // forever, so the bounded form keeps the regression signal fast.
+        let d = dir.display().to_string();
+        let (code, err) = cli(&["--datadir", &d, "--mine-blocks", "1", "--mine-exit"]);
+        assert_eq!(code, 2, "{err}");
+        assert!(
+            err.contains(
+                "canonical index genesis anchor failed: STORE_INTEGRITY: canonical index genesis mismatch."
+            ),
+            "unexpected refusal: {err}"
+        );
+        assert_eq!(
+            fs::read(&index_file).expect("re-read index"),
+            before,
+            "the refused startup rewrote the canonical index"
+        );
+        assert!(
+            !chain_state_path(&dir).exists(),
+            "the refused startup wrote a chainstate"
+        );
+
+        let (code, err) = cli(&["--dry-run", "--datadir", &d]);
+        assert_eq!(code, 0, "{err}");
+        assert_eq!(fs::read(&index_file).expect("re-read index"), before);
+        assert!(!chain_state_path(&dir).exists());
+        fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
     #[test]
     fn parse_args_accepts_rpc_bind() {
         let cfg = parse_args(&[

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -369,6 +369,23 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     // the chainstate as loaded from disk. Ordinary startup is unaffected.
     // Go reference: the `if !*dryRun` guard in `cmd/rubin-node/main.go`.
     if !cfg.dry_run {
+        // RUB-1134 genesis anchor: a non-empty canonical index whose row 0 is
+        // not the configured genesis hash is a foreign datadir. Checked BEFORE
+        // the reconcile so no replay, truncate, or reconcile adoption ever
+        // consumes a foreign index; an empty index skips the anchor. `--dry-run`
+        // adopts nothing and stays a read-only report, so the anchor is enforced
+        // only on this mutating path — the same placement as the Go twin in
+        // `clients/go/cmd/rubin-node/main.go`. A genesis file that carries no
+        // genesis hash for a custom chain_id leaves nothing to anchor AGAINST;
+        // that configuration is refused later by `runtime_genesis_hash` before
+        // any service starts, and Go cannot reach it at all (its genesis parse
+        // requires the hash).
+        if let Some(genesis_hash) = genesis_cfg.genesis_hash {
+            if let Err(err) = block_store.verify_genesis_anchor(genesis_hash) {
+                let _ = writeln!(stderr, "canonical index genesis anchor failed: {err}");
+                return 2;
+            }
+        }
         if let Err(err) =
             reconcile_chain_state_with_block_store(&mut chain_state, &mut block_store, &sync_cfg)
         {

--- a/clients/rust/crates/rubin-node/src/store_envelope.rs
+++ b/clients/rust/crates/rubin-node/src/store_envelope.rs
@@ -19,11 +19,11 @@ use crate::undo::base64_encode;
 pub(crate) const STORE_INTEGRITY_PREFIX: &str = "STORE_INTEGRITY";
 
 /// Pinned cross-client messages; no repair command (there is no `--reindex`).
-pub(crate) const STORE_LEGACY_CHAINSTATE_ERR: &str = "STORE_INTEGRITY: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay.";
-pub(crate) const STORE_LEGACY_BLOCK_INDEX_ERR: &str = "STORE_INTEGRITY: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required.";
-pub(crate) const STORE_CHECKSUM_MISMATCH_ERR: &str = "STORE_INTEGRITY: checksum mismatch.";
+pub(crate) const STORE_LEGACY_CHAINSTATE_ERR: &str = "STORE_INTEGRITY: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay";
+pub(crate) const STORE_LEGACY_BLOCK_INDEX_ERR: &str = "STORE_INTEGRITY: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required";
+pub(crate) const STORE_CHECKSUM_MISMATCH_ERR: &str = "STORE_INTEGRITY: checksum mismatch";
 pub(crate) const STORE_GENESIS_ANCHOR_ERR: &str =
-    "STORE_INTEGRITY: canonical index genesis mismatch.";
+    "STORE_INTEGRITY: canonical index genesis mismatch";
 
 const STORE_ENVELOPE_PREFIX: &[u8] = br#"{"version":1,"payload_b64":""#;
 const STORE_ENVELOPE_CHECKSUM_SEP: &[u8] = br#"","checksum":""#;

--- a/clients/rust/crates/rubin-node/src/store_envelope.rs
+++ b/clients/rust/crates/rubin-node/src/store_envelope.rs
@@ -227,8 +227,11 @@ pub(crate) mod tests {
 
     /// The RUB-1134 cross-client vectors; the Go suite embeds these SAME
     /// literals. Rows 1/3 differ only by domain tag (domain separation); rows
-    /// 2/4 pin the length term and the base64 body, and row 4 is also the
-    /// on-disk creation marker.
+    /// 2/4 pin the length term and the base64 body. Row 4 pins the GO writer's
+    /// empty-marker payload and envelope: this crate's own on-disk marker
+    /// differs at baseline by INNER field order (`{version,canonical}` vs
+    /// `{canonical,version}`), so it carries a different checksum and is pinned
+    /// separately by `create_store_commits_exact_empty_marker`.
     #[rustfmt::skip]
     const VECTORS: &[(StoreEnvelopeKind, &str, &str, &str)] = &[
         (STORE_ENVELOPE_CHAIN_STATE, "", "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
@@ -342,13 +345,13 @@ pub(crate) mod tests {
             }, "envelope is not the canonical encoding"),
             // A duplicated field lands INSIDE the derived body slice, so the
             // canonical-base64 check refuses it, identically in both clients.
-            row("duplicate_payload_b64_identical", |valid, _| replace_once(valid, ",\"checksum\":\"", ",\"payload_b64\":\"DUPLICATE\",\"checksum\":\""), "payload_b64 is not canonical padded base64"),
+            row("duplicate_payload_b64_identical", |valid, _| replace_once(valid, ",\"checksum\":\"", &format!(",\"payload_b64\":\"{}\",\"checksum\":\"", payload_b64_of(valid))), "payload_b64 is not canonical padded base64"),
             row("duplicate_payload_b64_conflicting", |valid, payload| {
                 let mut other = b"x".to_vec();
                 other.extend_from_slice(payload);
                 replace_once(valid, ",\"checksum\":\"", &format!(",\"payload_b64\":\"{}\",\"checksum\":\"", base64_encode(&other)))
             }, "payload_b64 is not canonical padded base64"),
-            row("duplicate_checksum_identical", |valid, _| replace_once(valid, "\"}\n", &format!("\",\"checksum\":\"{}\"}}\n", "0".repeat(64))), "payload_b64 is not canonical padded base64"),
+            row("duplicate_checksum_identical", |valid, _| replace_once(valid, "\"}\n", &format!("\",\"checksum\":\"{}\"}}\n", checksum_hex_of(valid))), "payload_b64 is not canonical padded base64"),
             row("duplicate_checksum_conflicting", |valid, _| replace_once(valid, "\"}\n", &format!("\",\"checksum\":\"{}\"}}\n", "b".repeat(64))), "payload_b64 is not canonical padded base64"),
             row("missing_checksum", |valid, _| replace_once(valid, "\",\"checksum\":\"", "\",\"checksu\":\""), "envelope is not the canonical encoding"),
             row("missing_payload_b64", |valid, _| replace_once(valid, ",\"payload_b64\":\"", ",\"payloadb64\":\""), "envelope is not the canonical encoding"),
@@ -363,9 +366,17 @@ pub(crate) mod tests {
                     base64_encode(payload).trim_end_matches('='),
                     hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
             }, "payload_b64 is not canonical padded base64"),
+            // Raw \n and \r are the bytes a permissive decoder skips; rationale
+            // and the byte-identical twins: `storeEnvelopeSharedRejectRows`.
             row("payload_b64_embedded_newline", |_, payload| {
                 let encoded = base64_encode(payload);
-                format!("{{\"version\":1,\"payload_b64\":\"{}\\n{}\",\"checksum\":\"{}\"}}\n",
+                format!("{{\"version\":1,\"payload_b64\":\"{}\n{}\",\"checksum\":\"{}\"}}\n",
+                    &encoded[..4], &encoded[4..],
+                    hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
+            }, "payload_b64 is not canonical padded base64"),
+            row("payload_b64_embedded_carriage_return", |_, payload| {
+                let encoded = base64_encode(payload);
+                format!("{{\"version\":1,\"payload_b64\":\"{}\r{}\",\"checksum\":\"{}\"}}\n",
                     &encoded[..4], &encoded[4..],
                     hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
             }, "payload_b64 is not canonical padded base64"),

--- a/clients/rust/crates/rubin-node/src/store_envelope.rs
+++ b/clients/rust/crates/rubin-node/src/store_envelope.rs
@@ -1,30 +1,10 @@
-//! store_envelope_v1 (RUB-1134)
-//!
-//! The persisted chainstate snapshot (`chainstate.json`) and the canonical
-//! blockstore index (`index.json`) are each stored as one compact JSON object
-//! binding the exact inner payload bytes to a domain-tagged checksum:
-//!
-//! ```text
-//! {"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n
-//! ```
-//!
-//! `checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload)`.
-//! The length term makes the preimage injective. The trailing LF is NOT in the
-//! preimage. Domain tags: `RUBIN_CHAINSTATE_V1` and
-//! `RUBIN_BLOCKSTORE_INDEX_V1`. Both files are per-datadir singletons, so the
-//! domain tag is the identity; chain identity is enforced by the separate
-//! genesis anchor (`BlockStore::verify_genesis_anchor`), never by an envelope
-//! field.
-//!
-//! Deliberately UNBOUNDED: both payloads grow with accumulated state, so per
-//! the RUB-1057 standing decision no read or save size bound exists here and
-//! none may be added.
-//!
-//! Go twin `clients/go/node/store_envelope.go` carries the full rationale (why
-//! this is a 3-field sibling of `undo_envelope_v1` rather than a reuse, and
-//! the claim boundary: local-corruption detection, NOT authentication). Both
-//! clients must emit byte-identical envelopes for the same payload bytes; the
-//! mirrored cross-client vectors pin those bytes in both test suites.
+//! store_envelope_v1 (RUB-1134): `chainstate.json` and the canonical blockstore
+//! `index.json` are each stored as
+//! `{"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n` with
+//! `checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload)`
+//! over the exact inner payload bytes (trailing LF excluded). The authoritative
+//! rationale is `clients/go/node/store_envelope.go`; this is its byte-exact
+//! mirror and the vectors below pin the bytes.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -33,27 +13,18 @@ use sha3::{Digest, Sha3_256};
 use crate::blockstore::valid_canonical_hash_hex;
 use crate::undo::base64_encode;
 
-/// Stable cross-client prefix of every envelope, version, base64, checksum and
-/// genesis-anchor rejection class in the RUB-1134 error_contract. Go's
-/// `ErrStoreIntegrity` carries the same identity through `errors.Is`; here the
-/// error channel is `String`, so the prefix IS the identity and the loaders
-/// return these messages verbatim. The inner payload-decode class is
-/// deliberately OUTSIDE this prefix: a file that clears the checksum is intact
-/// on disk, so a failure past it is a schema fault, not an integrity fault.
+/// Stable prefix of every envelope/version/base64/checksum/genesis-anchor
+/// rejection class (Go: `ErrStoreIntegrity`). The channel here is `String`, so
+/// the prefix IS the identity; the inner payload-decode class stays OUTSIDE it.
 pub(crate) const STORE_INTEGRITY_PREFIX: &str = "STORE_INTEGRITY";
 
-/// Pinned cross-client messages. Go returns these same strings. Deliberately
-/// no repair command: this build ships no `--reindex`.
+/// Pinned cross-client messages; no repair command (there is no `--reindex`).
 pub(crate) const STORE_LEGACY_CHAINSTATE_ERR: &str = "STORE_INTEGRITY: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay.";
 pub(crate) const STORE_LEGACY_BLOCK_INDEX_ERR: &str = "STORE_INTEGRITY: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required.";
 pub(crate) const STORE_CHECKSUM_MISMATCH_ERR: &str = "STORE_INTEGRITY: checksum mismatch.";
 pub(crate) const STORE_GENESIS_ANCHOR_ERR: &str =
     "STORE_INTEGRITY: canonical index genesis mismatch.";
 
-/// The layout is fully determined by these fixed segments plus the 64-character
-/// checksum, so the reader validates it by index arithmetic instead of decoding
-/// JSON: no value is materialized on the accept path and `payload_b64` is a
-/// SLICE of the caller's buffer. Go twin: `storeEnvelopePrefix` and friends.
 const STORE_ENVELOPE_PREFIX: &[u8] = br#"{"version":1,"payload_b64":""#;
 const STORE_ENVELOPE_CHECKSUM_SEP: &[u8] = br#"","checksum":""#;
 const STORE_ENVELOPE_SUFFIX: &[u8] = b"\"}\n";
@@ -65,9 +36,6 @@ const STORE_ENVELOPE_FRAME_BYTES: usize = STORE_ENVELOPE_PREFIX.len()
     + STORE_CHECKSUM_HEX_LEN
     + STORE_ENVELOPE_SUFFIX.len();
 
-/// Per-file parameters of the shared frame: the checksum domain tag, the noun
-/// used in shape errors, and the pinned legacy message for a pre-envelope file
-/// of that class.
 #[derive(Clone, Copy)]
 pub(crate) struct StoreEnvelopeKind {
     domain: &'static [u8],
@@ -87,9 +55,7 @@ pub(crate) const STORE_ENVELOPE_BLOCK_INDEX: StoreEnvelopeKind = StoreEnvelopeKi
     legacy_err: STORE_LEGACY_BLOCK_INDEX_ERR,
 };
 
-/// The writer's shape; the reader never decodes into it. Field ORDER is part of
-/// the format: `serde` and `encoding/json` both emit declaration order, which is
-/// what makes the two clients' bytes identical for identical payloads.
+/// Writer shape only; field ORDER is part of the format.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StoreEnvelopeDisk {
@@ -98,9 +64,6 @@ struct StoreEnvelopeDisk {
     checksum: String,
 }
 
-/// Streams the preimage into the hash rather than materializing it; the
-/// payload can be large (unbounded class) and the whole point of this path is
-/// one decision before any inner decode. Go twin: `storeEnvelopeChecksum`.
 fn store_envelope_checksum(domain: &[u8], payload: &[u8]) -> [u8; 32] {
     let mut hasher = Sha3_256::new();
     hasher.update(domain);
@@ -109,9 +72,7 @@ fn store_envelope_checksum(domain: &[u8], payload: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-/// Wraps the exact payload bytes in the v1 frame. New writes emit v1 only;
-/// there is deliberately no size bound on either side (RUB-1057 standing
-/// decision for both protected files).
+/// Wraps the exact payload bytes in v1; no size bound (RUB-1057).
 pub(crate) fn marshal_store_envelope(
     kind: StoreEnvelopeKind,
     payload: &[u8],
@@ -127,12 +88,11 @@ pub(crate) fn marshal_store_envelope(
     Ok(raw)
 }
 
-/// Runs the validation order on one protected file: strict canonical layout
-/// (subsuming shape, version-literal, duplicate, unknown, missing, null,
-/// wrong-type, ordering, whitespace and trailing-token rejection, with
-/// unversioned legacy classified before the exact-field-set verdict), canonical
-/// padded base64, then the constant-time checksum compare. Only after checksum
-/// success does the caller decode the inner schema. Go twin: `openStoreEnvelope`.
+/// The validation order for one protected file: strict canonical layout (which
+/// subsumes shape, version, duplicate, unknown, missing, null, wrong-type,
+/// ordering, whitespace and trailing-token rejection, legacy classified first),
+/// canonical padded base64, then the constant-time checksum compare. Only then
+/// may the caller decode the inner schema.
 pub(crate) fn open_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result<Vec<u8>, String> {
     let (payload_b64, checksum_hex) = split_store_envelope(kind, raw)?;
     let payload = decode_canonical_store_base64(payload_b64)?;
@@ -146,11 +106,9 @@ pub(crate) fn open_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result
     Ok(payload)
 }
 
-/// Validates the canonical layout and returns sub-slices of `raw`. The body
-/// length is DERIVED (`raw.len() - frame`) rather than searched for, so any
-/// inserted, removed, reordered, duplicated or renamed field shifts the trailing
-/// segments and fails. On failure it hands off to
-/// `classify_store_envelope_failure`, the only path that parses JSON at all.
+/// Returns sub-slices of `raw`. The body length is DERIVED (`raw.len() -
+/// frame`), never searched for, so any inserted, removed, reordered, duplicated
+/// or renamed field shifts the tail and fails.
 fn split_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result<(&[u8], &[u8]), String> {
     let Some(body) = raw.len().checked_sub(STORE_ENVELOPE_FRAME_BYTES) else {
         return Err(classify_store_envelope_failure(kind, raw));
@@ -174,14 +132,11 @@ fn split_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result<(&[u8], &
     Ok((&raw[payload_at..checksum_sep_at], checksum_hex))
 }
 
-/// Names WHY a file that failed the layout check failed it; runs only on files
-/// already being rejected, so its JSON scan is never paid on the accept path. It
-/// deserializes ONE value and does NOT require EOF, and duplicate keys last-win
-/// (both mirrored by the Go twin), so a legacy file with trailing garbage still
-/// reports the actionable legacy message. A pre-envelope legacy file carries
-/// NEITHER `payload_b64` NOR `checksum` — both legacy inner schemas carry their
-/// own top-level `"version": 1`, which is why legacy detection keys on the
-/// envelope fields and runs before the version verdicts.
+/// Names WHY a file failed the layout check; runs only on already-rejected
+/// files. It deserializes ONE value, does NOT require EOF, and duplicate keys
+/// last-win (as in Go), so a legacy file with trailing garbage still reports the
+/// legacy message. Legacy detection keys on the ENVELOPE fields and precedes
+/// the version verdicts: both legacy schemas carry a top-level `"version": 1`.
 fn classify_store_envelope_failure(kind: StoreEnvelopeKind, raw: &[u8]) -> String {
     let mut deserializer = serde_json::Deserializer::from_slice(raw);
     let Ok(probe) = Map::<String, Value>::deserialize(&mut deserializer) else {
@@ -193,9 +148,8 @@ fn classify_store_envelope_failure(kind: StoreEnvelopeKind, raw: &[u8]) -> Strin
     if !probe.contains_key("payload_b64") && !probe.contains_key("checksum") {
         return kind.legacy_err.to_string();
     }
-    // `as_u64` is None for null, strings and non-integral numbers, so those
-    // spellings fall through to the generic verdict exactly as the Go twin's
-    // pointer probe does.
+    // `as_u64` is None for null, strings and non-integral numbers, which fall
+    // through to the generic verdict exactly as Go's probe does.
     match probe.get("version").and_then(Value::as_u64) {
         Some(version) if version != u64::from(STORE_ENVELOPE_VERSION) => {
             format!("{STORE_INTEGRITY_PREFIX}: unsupported store envelope version {version}")
@@ -204,13 +158,9 @@ fn classify_store_envelope_failure(kind: StoreEnvelopeKind, raw: &[u8]) -> Strin
     }
 }
 
-/// Accepts only the one padded RFC 4648 spelling of the payload. Sibling of the
-/// undo-class decoder (`undo.rs`), which is module-private and carries the
-/// UNDO_INTEGRITY identity in its message; this contract forbids touching
-/// undo.rs, so the rules are restated here with the store identity:
-/// non-alphabet bytes are rejected symbol by symbol (so JSON-escaped whitespace
-/// a permissive decoder would skip cannot slip through), and the bits the
-/// padding discards must be zero (so "Zh==" cannot stand in for "Zg==").
+/// Accepts only the one padded RFC 4648 spelling: non-alphabet bytes are
+/// rejected symbol by symbol (JSON-escaped whitespace a permissive decoder would
+/// skip cannot slip through) and the bits padding discards must be zero.
 fn decode_canonical_store_base64(value: &[u8]) -> Result<Vec<u8>, String> {
     let not_canonical =
         || format!("{STORE_INTEGRITY_PREFIX}: payload_b64 is not canonical padded base64");
@@ -220,8 +170,7 @@ fn decode_canonical_store_base64(value: &[u8]) -> Result<Vec<u8>, String> {
     let quads = value.len() / 4;
     let mut out = Vec::with_capacity(quads.saturating_mul(3));
     for (index, quad) in value.chunks_exact(4).enumerate() {
-        // Padding is legal only in the final quad; anywhere else `=` is not an
-        // alphabet symbol and fails below.
+        // Padding is legal only in the final quad; elsewhere `=` fails below.
         let pad = if index + 1 != quads {
             0
         } else if quad[3] == b'=' {
@@ -237,9 +186,7 @@ fn decode_canonical_store_base64(value: &[u8]) -> Result<Vec<u8>, String> {
         for symbol in &quad[..4 - pad] {
             packed = (packed << 6) | base64_symbol_value(*symbol).ok_or_else(not_canonical)?;
         }
-        // The final quad carries 6*(4-pad) bits but only 8*(3-pad) are data;
-        // the 2*pad low bits are padding and a canonical encoder leaves them
-        // zero.
+        // A canonical encoder leaves the 2*pad discarded low bits zero.
         if packed & ((1u32 << (2 * pad)) - 1) != 0 {
             return Err(not_canonical());
         }
@@ -267,9 +214,6 @@ fn base64_symbol_value(symbol: u8) -> Option<u32> {
     Some(value)
 }
 
-/// Data-independent comparison of the stored and computed digests. No `subtle`
-/// crate is available and this contract forbids adding one, so the fold is
-/// written out; both inputs are fixed-size arrays, so no length term leaks.
 fn constant_time_eq32(a: &[u8; 32], b: &[u8; 32]) -> bool {
     a.iter()
         .zip(b.iter())
@@ -281,36 +225,24 @@ fn constant_time_eq32(a: &[u8; 32], b: &[u8; 32]) -> bool {
 pub(crate) mod tests {
     use super::*;
 
-    /// The RUB-1134 cross-client vectors. The Go suite embeds these SAME
-    /// literals (`storeEnvelopeVectors` in clients/go/node/store_envelope_test.go):
-    /// given identical payload bytes, the preimage, checksum and complete
-    /// envelope bytes must be byte-identical in Go and Rust.
-    ///
-    /// The two empty-payload rows differ only by domain tag, so they pin
-    /// domain separation; the two non-empty rows pin the length term and the
-    /// base64 body. Row 4's payload is the exact Go empty canonical-index
-    /// payload, so its envelope is also the on-disk creation marker pinned by
-    /// `create_store_commits_exact_empty_marker`.
+    /// The RUB-1134 cross-client vectors; the Go suite embeds these SAME
+    /// literals. Rows 1/3 differ only by domain tag (domain separation); rows
+    /// 2/4 pin the length term and the base64 body, and row 4 is also the
+    /// on-disk creation marker.
     #[rustfmt::skip]
     const VECTORS: &[(StoreEnvelopeKind, &str, &str, &str)] = &[
-        (STORE_ENVELOPE_CHAIN_STATE, "",
-         "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
+        (STORE_ENVELOPE_CHAIN_STATE, "", "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
          "{\"version\":1,\"payload_b64\":\"\",\"checksum\":\"51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe\"}\n"),
-        (STORE_ENVELOPE_CHAIN_STATE, "{\"version\":1}\n",
-         "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0",
+        (STORE_ENVELOPE_CHAIN_STATE, "{\"version\":1}\n", "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0",
          "{\"version\":1,\"payload_b64\":\"eyJ2ZXJzaW9uIjoxfQo=\",\"checksum\":\"6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0\"}\n"),
-        (STORE_ENVELOPE_BLOCK_INDEX, "",
-         "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a",
+        (STORE_ENVELOPE_BLOCK_INDEX, "", "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a",
          "{\"version\":1,\"payload_b64\":\"\",\"checksum\":\"bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a\"}\n"),
-        (STORE_ENVELOPE_BLOCK_INDEX, "{\n  \"canonical\": [],\n  \"version\": 1\n}\n",
-         "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15",
+        (STORE_ENVELOPE_BLOCK_INDEX, "{\n  \"canonical\": [],\n  \"version\": 1\n}\n", "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15",
          "{\"version\":1,\"payload_b64\":\"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=\",\"checksum\":\"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15\"}\n"),
     ];
 
-    /// Pins the frame, the preimage and the checksum. The expected checksum is
-    /// ALSO recomputed from the contract's stated preimage
-    /// (ASCII(domain) || uint64_be(len) || payload) with a locally written
-    /// hash call, so the pin cannot drift with the production helper.
+    /// Pins the frame, preimage and checksum, recomputing the checksum locally
+    /// so the pin cannot drift with the production helper.
     #[test]
     fn store_envelope_v1_cross_client_vectors() {
         for (kind, payload, want_checksum, want_envelope) in VECTORS {
@@ -336,8 +268,7 @@ pub(crate) mod tests {
             assert_eq!(back, payload.as_bytes());
         }
 
-        // Domain separation: the same payload under the other domain tag must
-        // not verify, and the two pinned empty-payload checksums differ.
+        // Domain separation: the same payload under the other tag must not verify.
         assert_ne!(VECTORS[0].2, VECTORS[2].2);
         let raw = marshal_store_envelope(STORE_ENVELOPE_CHAIN_STATE, b"{\"version\":1}\n")
             .expect("marshal");
@@ -347,21 +278,14 @@ pub(crate) mod tests {
         );
     }
 
-    /// One hostile/malformed on-disk body. `body` receives the VALID envelope
-    /// bytes and the valid inner payload bytes for that file and returns the
-    /// bytes to plant. Go twin: `storeIntegrityRow`.
+    /// One malformed on-disk body. Go twin: `storeIntegrityRow`.
     pub(crate) struct StoreIntegrityRow {
         pub(crate) name: &'static str,
-        // One boxed builder per row: (valid envelope, valid payload) -> planted
-        // bytes. Not a nested structure, so no `type` alias earns its keep.
-        #[allow(clippy::type_complexity)]
+        #[allow(clippy::type_complexity)] // (valid envelope, valid payload) -> planted bytes
         pub(crate) body: Box<dyn Fn(&[u8], &[u8]) -> Vec<u8>>,
-        /// Exact message, when the contract pins one.
-        pub(crate) want_msg: Option<&'static str>,
-        /// Substring, when the message carries a variable.
-        pub(crate) want_sub: Option<&'static str>,
-        /// The inner-schema class is deliberately OUTSIDE the STORE_INTEGRITY
-        /// identity: those bytes are intact on disk.
+        pub(crate) want_msg: Option<&'static str>, // exact, when pinned
+        pub(crate) want_sub: Option<&'static str>, // substring, when variable
+        /// The inner-schema class is deliberately OUTSIDE STORE_INTEGRITY.
         pub(crate) not_integrity: bool,
     }
 
@@ -386,20 +310,17 @@ pub(crate) mod tests {
         envelope.payload_b64
     }
 
-    /// Re-wraps `payload` under `kind` with a FRESH checksum.
     pub(crate) fn rewrap(kind: StoreEnvelopeKind, payload: &[u8]) -> Vec<u8> {
         marshal_store_envelope(kind, payload).expect("marshal")
     }
 
-    /// Replaces the base64 body WITHOUT touching the checksum, so only the
-    /// checksum comparison can catch the edit.
+    /// Replaces the base64 body WITHOUT touching the checksum.
     pub(crate) fn restamp_payload_keeping_checksum(valid: &[u8], payload: &[u8]) -> Vec<u8> {
         replace_once(valid, &payload_b64_of(valid), &base64_encode(payload))
     }
 
-    /// The frame-level rows both protected files must reject identically.
-    /// Per-file rows (legacy message, payload edits) are added by each caller.
-    /// Go twin: `storeEnvelopeSharedRejectRows`.
+    /// The frame-level rows both protected files must reject identically;
+    /// per-file rows are added by each caller.
     #[rustfmt::skip]
     pub(crate) fn shared_reject_rows() -> Vec<StoreIntegrityRow> {
         fn row(name: &'static str, body: fn(&[u8], &[u8]) -> Vec<u8>, want_sub: &'static str) -> StoreIntegrityRow {
@@ -419,10 +340,8 @@ pub(crate) mod tests {
                     base64_encode(payload),
                     hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
             }, "envelope is not the canonical encoding"),
-            // A duplicated field lands INSIDE the derived body slice (the body
-            // length is raw.len() - frame, not a searched delimiter), so the
-            // canonical-base64 check is what refuses it. Both clients derive
-            // the same slice and therefore return this same message.
+            // A duplicated field lands INSIDE the derived body slice, so the
+            // canonical-base64 check refuses it, identically in both clients.
             row("duplicate_payload_b64_identical", |valid, _| replace_once(valid, ",\"checksum\":\"", ",\"payload_b64\":\"DUPLICATE\",\"checksum\":\""), "payload_b64 is not canonical padded base64"),
             row("duplicate_payload_b64_conflicting", |valid, payload| {
                 let mut other = b"x".to_vec();
@@ -451,8 +370,7 @@ pub(crate) mod tests {
                     hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
             }, "payload_b64 is not canonical padded base64"),
             StoreIntegrityRow { name: "checksum_mismatch_zeroed", body: Box::new(|valid, _| replace_once(valid, &checksum_hex_of(valid), &"0".repeat(64))), want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR), want_sub: None, not_integrity: false },
-            // One interior base64 symbol changes, so the file stays canonical
-            // base64 and only the checksum can catch it.
+            // Stays canonical base64, so only the checksum can catch it.
             StoreIntegrityRow { name: "payload_base64_bitflip", body: Box::new(|valid, _| { let encoded = payload_b64_of(valid); replace_once(valid, &encoded, &flip_base64_symbol(&encoded)) }), want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR), want_sub: None, not_integrity: false },
         ]
     }
@@ -468,10 +386,6 @@ pub(crate) mod tests {
 
     /// Plants each row at `path`, calls `load`, and pins the message, the
     /// STORE_INTEGRITY identity, and that the refusal never rewrote the file.
-    /// (The absent-file exclusion Go states as `fs.ErrNotExist` is structural
-    /// here: the loaders return `String`, and the absent-file branch is a
-    /// distinct `ErrorKind::NotFound` arm that never sees these bytes.)
-    /// Go twin: `runStoreIntegrityRows`.
     pub(crate) fn run_store_integrity_rows(
         path: &std::path::Path,
         valid: &[u8],

--- a/clients/rust/crates/rubin-node/src/store_envelope.rs
+++ b/clients/rust/crates/rubin-node/src/store_envelope.rs
@@ -1,0 +1,506 @@
+//! store_envelope_v1 (RUB-1134)
+//!
+//! The persisted chainstate snapshot (`chainstate.json`) and the canonical
+//! blockstore index (`index.json`) are each stored as one compact JSON object
+//! binding the exact inner payload bytes to a domain-tagged checksum:
+//!
+//! ```text
+//! {"version":1,"payload_b64":"<b64>","checksum":"<64hex>"}\n
+//! ```
+//!
+//! `checksum = SHA3-256(ASCII(domain_tag) || uint64_be(len(payload)) || payload)`.
+//! The length term makes the preimage injective. The trailing LF is NOT in the
+//! preimage. Domain tags: `RUBIN_CHAINSTATE_V1` and
+//! `RUBIN_BLOCKSTORE_INDEX_V1`. Both files are per-datadir singletons, so the
+//! domain tag is the identity; chain identity is enforced by the separate
+//! genesis anchor (`BlockStore::verify_genesis_anchor`), never by an envelope
+//! field.
+//!
+//! Deliberately UNBOUNDED: both payloads grow with accumulated state, so per
+//! the RUB-1057 standing decision no read or save size bound exists here and
+//! none may be added.
+//!
+//! Go twin `clients/go/node/store_envelope.go` carries the full rationale (why
+//! this is a 3-field sibling of `undo_envelope_v1` rather than a reuse, and
+//! the claim boundary: local-corruption detection, NOT authentication). Both
+//! clients must emit byte-identical envelopes for the same payload bytes; the
+//! mirrored cross-client vectors pin those bytes in both test suites.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use sha3::{Digest, Sha3_256};
+
+use crate::blockstore::valid_canonical_hash_hex;
+use crate::undo::base64_encode;
+
+/// Stable cross-client prefix of every envelope, version, base64, checksum and
+/// genesis-anchor rejection class in the RUB-1134 error_contract. Go's
+/// `ErrStoreIntegrity` carries the same identity through `errors.Is`; here the
+/// error channel is `String`, so the prefix IS the identity and the loaders
+/// return these messages verbatim. The inner payload-decode class is
+/// deliberately OUTSIDE this prefix: a file that clears the checksum is intact
+/// on disk, so a failure past it is a schema fault, not an integrity fault.
+pub(crate) const STORE_INTEGRITY_PREFIX: &str = "STORE_INTEGRITY";
+
+/// Pinned cross-client messages. Go returns these same strings. Deliberately
+/// no repair command: this build ships no `--reindex`.
+pub(crate) const STORE_LEGACY_CHAINSTATE_ERR: &str = "STORE_INTEGRITY: legacy/unversioned chainstate; delete chainstate.json and restart to rebuild by validated replay.";
+pub(crate) const STORE_LEGACY_BLOCK_INDEX_ERR: &str = "STORE_INTEGRITY: legacy/unversioned blockstore index; pre-devnet datadir reset and full resync required.";
+pub(crate) const STORE_CHECKSUM_MISMATCH_ERR: &str = "STORE_INTEGRITY: checksum mismatch.";
+pub(crate) const STORE_GENESIS_ANCHOR_ERR: &str =
+    "STORE_INTEGRITY: canonical index genesis mismatch.";
+
+/// The layout is fully determined by these fixed segments plus the 64-character
+/// checksum, so the reader validates it by index arithmetic instead of decoding
+/// JSON: no value is materialized on the accept path and `payload_b64` is a
+/// SLICE of the caller's buffer. Go twin: `storeEnvelopePrefix` and friends.
+const STORE_ENVELOPE_PREFIX: &[u8] = br#"{"version":1,"payload_b64":""#;
+const STORE_ENVELOPE_CHECKSUM_SEP: &[u8] = br#"","checksum":""#;
+const STORE_ENVELOPE_SUFFIX: &[u8] = b"\"}\n";
+
+const STORE_ENVELOPE_VERSION: u32 = 1;
+const STORE_CHECKSUM_HEX_LEN: usize = 64;
+const STORE_ENVELOPE_FRAME_BYTES: usize = STORE_ENVELOPE_PREFIX.len()
+    + STORE_ENVELOPE_CHECKSUM_SEP.len()
+    + STORE_CHECKSUM_HEX_LEN
+    + STORE_ENVELOPE_SUFFIX.len();
+
+/// Per-file parameters of the shared frame: the checksum domain tag, the noun
+/// used in shape errors, and the pinned legacy message for a pre-envelope file
+/// of that class.
+#[derive(Clone, Copy)]
+pub(crate) struct StoreEnvelopeKind {
+    domain: &'static [u8],
+    noun: &'static str,
+    legacy_err: &'static str,
+}
+
+pub(crate) const STORE_ENVELOPE_CHAIN_STATE: StoreEnvelopeKind = StoreEnvelopeKind {
+    domain: b"RUBIN_CHAINSTATE_V1",
+    noun: "chainstate",
+    legacy_err: STORE_LEGACY_CHAINSTATE_ERR,
+};
+
+pub(crate) const STORE_ENVELOPE_BLOCK_INDEX: StoreEnvelopeKind = StoreEnvelopeKind {
+    domain: b"RUBIN_BLOCKSTORE_INDEX_V1",
+    noun: "blockstore index",
+    legacy_err: STORE_LEGACY_BLOCK_INDEX_ERR,
+};
+
+/// The writer's shape; the reader never decodes into it. Field ORDER is part of
+/// the format: `serde` and `encoding/json` both emit declaration order, which is
+/// what makes the two clients' bytes identical for identical payloads.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoreEnvelopeDisk {
+    version: u32,
+    payload_b64: String,
+    checksum: String,
+}
+
+/// Streams the preimage into the hash rather than materializing it; the
+/// payload can be large (unbounded class) and the whole point of this path is
+/// one decision before any inner decode. Go twin: `storeEnvelopeChecksum`.
+fn store_envelope_checksum(domain: &[u8], payload: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha3_256::new();
+    hasher.update(domain);
+    hasher.update((payload.len() as u64).to_be_bytes());
+    hasher.update(payload);
+    hasher.finalize().into()
+}
+
+/// Wraps the exact payload bytes in the v1 frame. New writes emit v1 only;
+/// there is deliberately no size bound on either side (RUB-1057 standing
+/// decision for both protected files).
+pub(crate) fn marshal_store_envelope(
+    kind: StoreEnvelopeKind,
+    payload: &[u8],
+) -> Result<Vec<u8>, String> {
+    let envelope = StoreEnvelopeDisk {
+        version: STORE_ENVELOPE_VERSION,
+        payload_b64: base64_encode(payload),
+        checksum: hex::encode(store_envelope_checksum(kind.domain, payload)),
+    };
+    let mut raw =
+        serde_json::to_vec(&envelope).map_err(|e| format!("encode {} envelope: {e}", kind.noun))?;
+    raw.push(b'\n');
+    Ok(raw)
+}
+
+/// Runs the validation order on one protected file: strict canonical layout
+/// (subsuming shape, version-literal, duplicate, unknown, missing, null,
+/// wrong-type, ordering, whitespace and trailing-token rejection, with
+/// unversioned legacy classified before the exact-field-set verdict), canonical
+/// padded base64, then the constant-time checksum compare. Only after checksum
+/// success does the caller decode the inner schema. Go twin: `openStoreEnvelope`.
+pub(crate) fn open_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result<Vec<u8>, String> {
+    let (payload_b64, checksum_hex) = split_store_envelope(kind, raw)?;
+    let payload = decode_canonical_store_base64(payload_b64)?;
+    // `split_store_envelope` already proved this is 64 lowercase hex.
+    let mut stored = [0u8; 32];
+    hex::decode_to_slice(checksum_hex, &mut stored)
+        .map_err(|_| format!("{STORE_INTEGRITY_PREFIX}: checksum is not hexadecimal"))?;
+    if !constant_time_eq32(&stored, &store_envelope_checksum(kind.domain, &payload)) {
+        return Err(STORE_CHECKSUM_MISMATCH_ERR.to_string());
+    }
+    Ok(payload)
+}
+
+/// Validates the canonical layout and returns sub-slices of `raw`. The body
+/// length is DERIVED (`raw.len() - frame`) rather than searched for, so any
+/// inserted, removed, reordered, duplicated or renamed field shifts the trailing
+/// segments and fails. On failure it hands off to
+/// `classify_store_envelope_failure`, the only path that parses JSON at all.
+fn split_store_envelope(kind: StoreEnvelopeKind, raw: &[u8]) -> Result<(&[u8], &[u8]), String> {
+    let Some(body) = raw.len().checked_sub(STORE_ENVELOPE_FRAME_BYTES) else {
+        return Err(classify_store_envelope_failure(kind, raw));
+    };
+    let payload_at = STORE_ENVELOPE_PREFIX.len();
+    let checksum_sep_at = payload_at + body;
+    let checksum_at = checksum_sep_at + STORE_ENVELOPE_CHECKSUM_SEP.len();
+    let suffix_at = checksum_at + STORE_CHECKSUM_HEX_LEN;
+    if &raw[..payload_at] != STORE_ENVELOPE_PREFIX
+        || &raw[checksum_sep_at..checksum_at] != STORE_ENVELOPE_CHECKSUM_SEP
+        || &raw[suffix_at..] != STORE_ENVELOPE_SUFFIX
+    {
+        return Err(classify_store_envelope_failure(kind, raw));
+    }
+    let checksum_hex = &raw[checksum_at..suffix_at];
+    if !valid_canonical_hash_hex(&String::from_utf8_lossy(checksum_hex)) {
+        return Err(format!(
+            "{STORE_INTEGRITY_PREFIX}: checksum must be 64 lowercase hex characters"
+        ));
+    }
+    Ok((&raw[payload_at..checksum_sep_at], checksum_hex))
+}
+
+/// Names WHY a file that failed the layout check failed it; runs only on files
+/// already being rejected, so its JSON scan is never paid on the accept path. It
+/// deserializes ONE value and does NOT require EOF, and duplicate keys last-win
+/// (both mirrored by the Go twin), so a legacy file with trailing garbage still
+/// reports the actionable legacy message. A pre-envelope legacy file carries
+/// NEITHER `payload_b64` NOR `checksum` — both legacy inner schemas carry their
+/// own top-level `"version": 1`, which is why legacy detection keys on the
+/// envelope fields and runs before the version verdicts.
+fn classify_store_envelope_failure(kind: StoreEnvelopeKind, raw: &[u8]) -> String {
+    let mut deserializer = serde_json::Deserializer::from_slice(raw);
+    let Ok(probe) = Map::<String, Value>::deserialize(&mut deserializer) else {
+        return format!(
+            "{STORE_INTEGRITY_PREFIX}: {} is not a single JSON object",
+            kind.noun
+        );
+    };
+    if !probe.contains_key("payload_b64") && !probe.contains_key("checksum") {
+        return kind.legacy_err.to_string();
+    }
+    // `as_u64` is None for null, strings and non-integral numbers, so those
+    // spellings fall through to the generic verdict exactly as the Go twin's
+    // pointer probe does.
+    match probe.get("version").and_then(Value::as_u64) {
+        Some(version) if version != u64::from(STORE_ENVELOPE_VERSION) => {
+            format!("{STORE_INTEGRITY_PREFIX}: unsupported store envelope version {version}")
+        }
+        _ => format!("{STORE_INTEGRITY_PREFIX}: envelope is not the canonical encoding"),
+    }
+}
+
+/// Accepts only the one padded RFC 4648 spelling of the payload. Sibling of the
+/// undo-class decoder (`undo.rs`), which is module-private and carries the
+/// UNDO_INTEGRITY identity in its message; this contract forbids touching
+/// undo.rs, so the rules are restated here with the store identity:
+/// non-alphabet bytes are rejected symbol by symbol (so JSON-escaped whitespace
+/// a permissive decoder would skip cannot slip through), and the bits the
+/// padding discards must be zero (so "Zh==" cannot stand in for "Zg==").
+fn decode_canonical_store_base64(value: &[u8]) -> Result<Vec<u8>, String> {
+    let not_canonical =
+        || format!("{STORE_INTEGRITY_PREFIX}: payload_b64 is not canonical padded base64");
+    if !value.len().is_multiple_of(4) {
+        return Err(not_canonical());
+    }
+    let quads = value.len() / 4;
+    let mut out = Vec::with_capacity(quads.saturating_mul(3));
+    for (index, quad) in value.chunks_exact(4).enumerate() {
+        // Padding is legal only in the final quad; anywhere else `=` is not an
+        // alphabet symbol and fails below.
+        let pad = if index + 1 != quads {
+            0
+        } else if quad[3] == b'=' {
+            if quad[2] == b'=' {
+                2
+            } else {
+                1
+            }
+        } else {
+            0
+        };
+        let mut packed = 0u32;
+        for symbol in &quad[..4 - pad] {
+            packed = (packed << 6) | base64_symbol_value(*symbol).ok_or_else(not_canonical)?;
+        }
+        // The final quad carries 6*(4-pad) bits but only 8*(3-pad) are data;
+        // the 2*pad low bits are padding and a canonical encoder leaves them
+        // zero.
+        if packed & ((1u32 << (2 * pad)) - 1) != 0 {
+            return Err(not_canonical());
+        }
+        packed <<= 6 * pad;
+        out.push((packed >> 16) as u8);
+        if pad < 2 {
+            out.push((packed >> 8) as u8);
+        }
+        if pad < 1 {
+            out.push(packed as u8);
+        }
+    }
+    Ok(out)
+}
+
+fn base64_symbol_value(symbol: u8) -> Option<u32> {
+    let value = match symbol {
+        b'A'..=b'Z' => u32::from(symbol - b'A'),
+        b'a'..=b'z' => u32::from(symbol - b'a') + 26,
+        b'0'..=b'9' => u32::from(symbol - b'0') + 52,
+        b'+' => 62,
+        b'/' => 63,
+        _ => return None,
+    };
+    Some(value)
+}
+
+/// Data-independent comparison of the stored and computed digests. No `subtle`
+/// crate is available and this contract forbids adding one, so the fold is
+/// written out; both inputs are fixed-size arrays, so no length term leaks.
+fn constant_time_eq32(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    /// The RUB-1134 cross-client vectors. The Go suite embeds these SAME
+    /// literals (`storeEnvelopeVectors` in clients/go/node/store_envelope_test.go):
+    /// given identical payload bytes, the preimage, checksum and complete
+    /// envelope bytes must be byte-identical in Go and Rust.
+    ///
+    /// The two empty-payload rows differ only by domain tag, so they pin
+    /// domain separation; the two non-empty rows pin the length term and the
+    /// base64 body. Row 4's payload is the exact Go empty canonical-index
+    /// payload, so its envelope is also the on-disk creation marker pinned by
+    /// `create_store_commits_exact_empty_marker`.
+    #[rustfmt::skip]
+    const VECTORS: &[(StoreEnvelopeKind, &str, &str, &str)] = &[
+        (STORE_ENVELOPE_CHAIN_STATE, "",
+         "51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe",
+         "{\"version\":1,\"payload_b64\":\"\",\"checksum\":\"51e3d3a67f6a7c4439465328314723099ea753c512f22a1f197e1528b1f24afe\"}\n"),
+        (STORE_ENVELOPE_CHAIN_STATE, "{\"version\":1}\n",
+         "6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0",
+         "{\"version\":1,\"payload_b64\":\"eyJ2ZXJzaW9uIjoxfQo=\",\"checksum\":\"6d8ced24b9b3f05ed1aebb46c3bfe0a0bfc96508ce51e1ca6de3dc643ec659d0\"}\n"),
+        (STORE_ENVELOPE_BLOCK_INDEX, "",
+         "bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a",
+         "{\"version\":1,\"payload_b64\":\"\",\"checksum\":\"bf1cd3af0b95b8861e3abf40b776f315117e55b28b5c5dbdb811d3fd33018e5a\"}\n"),
+        (STORE_ENVELOPE_BLOCK_INDEX, "{\n  \"canonical\": [],\n  \"version\": 1\n}\n",
+         "7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15",
+         "{\"version\":1,\"payload_b64\":\"ewogICJjYW5vbmljYWwiOiBbXSwKICAidmVyc2lvbiI6IDEKfQo=\",\"checksum\":\"7c120c21bc3ffdda6482c8d18a3c669542e89d8500928ce166700a7c7a40fe15\"}\n"),
+    ];
+
+    /// Pins the frame, the preimage and the checksum. The expected checksum is
+    /// ALSO recomputed from the contract's stated preimage
+    /// (ASCII(domain) || uint64_be(len) || payload) with a locally written
+    /// hash call, so the pin cannot drift with the production helper.
+    #[test]
+    fn store_envelope_v1_cross_client_vectors() {
+        for (kind, payload, want_checksum, want_envelope) in VECTORS {
+            let mut hasher = Sha3_256::new();
+            hasher.update(kind.domain);
+            hasher.update((payload.len() as u64).to_be_bytes());
+            hasher.update(payload.as_bytes());
+            let independent: [u8; 32] = hasher.finalize().into();
+            assert_eq!(hex::encode(independent), *want_checksum, "{payload:?}");
+            assert_eq!(
+                hex::encode(store_envelope_checksum(kind.domain, payload.as_bytes())),
+                *want_checksum,
+                "{payload:?}"
+            );
+
+            let raw = marshal_store_envelope(*kind, payload.as_bytes()).expect("marshal");
+            assert_eq!(String::from_utf8_lossy(&raw), *want_envelope);
+            assert!(
+                raw.ends_with(b"\n"),
+                "envelope must end with exactly one LF"
+            );
+            let back = open_store_envelope(*kind, &raw).expect("open");
+            assert_eq!(back, payload.as_bytes());
+        }
+
+        // Domain separation: the same payload under the other domain tag must
+        // not verify, and the two pinned empty-payload checksums differ.
+        assert_ne!(VECTORS[0].2, VECTORS[2].2);
+        let raw = marshal_store_envelope(STORE_ENVELOPE_CHAIN_STATE, b"{\"version\":1}\n")
+            .expect("marshal");
+        assert_eq!(
+            open_store_envelope(STORE_ENVELOPE_BLOCK_INDEX, &raw).expect_err("cross-domain"),
+            STORE_CHECKSUM_MISMATCH_ERR
+        );
+    }
+
+    /// One hostile/malformed on-disk body. `body` receives the VALID envelope
+    /// bytes and the valid inner payload bytes for that file and returns the
+    /// bytes to plant. Go twin: `storeIntegrityRow`.
+    pub(crate) struct StoreIntegrityRow {
+        pub(crate) name: &'static str,
+        // One boxed builder per row: (valid envelope, valid payload) -> planted
+        // bytes. Not a nested structure, so no `type` alias earns its keep.
+        #[allow(clippy::type_complexity)]
+        pub(crate) body: Box<dyn Fn(&[u8], &[u8]) -> Vec<u8>>,
+        /// Exact message, when the contract pins one.
+        pub(crate) want_msg: Option<&'static str>,
+        /// Substring, when the message carries a variable.
+        pub(crate) want_sub: Option<&'static str>,
+        /// The inner-schema class is deliberately OUTSIDE the STORE_INTEGRITY
+        /// identity: those bytes are intact on disk.
+        pub(crate) not_integrity: bool,
+    }
+
+    fn replace_once(valid: &[u8], old: &str, new: &str) -> Vec<u8> {
+        let text = String::from_utf8_lossy(valid).into_owned();
+        let out = text.replacen(old, new, 1);
+        assert_ne!(out, text, "row did not modify the envelope");
+        out.into_bytes()
+    }
+
+    pub(crate) fn checksum_hex_of(valid: &[u8]) -> String {
+        let envelope: StoreEnvelopeDisk =
+            serde_json::from_slice(valid.strip_suffix(b"\n").unwrap_or(valid))
+                .expect("decode valid envelope");
+        envelope.checksum
+    }
+
+    pub(crate) fn payload_b64_of(valid: &[u8]) -> String {
+        let envelope: StoreEnvelopeDisk =
+            serde_json::from_slice(valid.strip_suffix(b"\n").unwrap_or(valid))
+                .expect("decode valid envelope");
+        envelope.payload_b64
+    }
+
+    /// Re-wraps `payload` under `kind` with a FRESH checksum.
+    pub(crate) fn rewrap(kind: StoreEnvelopeKind, payload: &[u8]) -> Vec<u8> {
+        marshal_store_envelope(kind, payload).expect("marshal")
+    }
+
+    /// Replaces the base64 body WITHOUT touching the checksum, so only the
+    /// checksum comparison can catch the edit.
+    pub(crate) fn restamp_payload_keeping_checksum(valid: &[u8], payload: &[u8]) -> Vec<u8> {
+        replace_once(valid, &payload_b64_of(valid), &base64_encode(payload))
+    }
+
+    /// The frame-level rows both protected files must reject identically.
+    /// Per-file rows (legacy message, payload edits) are added by each caller.
+    /// Go twin: `storeEnvelopeSharedRejectRows`.
+    #[rustfmt::skip]
+    pub(crate) fn shared_reject_rows() -> Vec<StoreIntegrityRow> {
+        fn row(name: &'static str, body: fn(&[u8], &[u8]) -> Vec<u8>, want_sub: &'static str) -> StoreIntegrityRow {
+            StoreIntegrityRow { name, body: Box::new(body), want_msg: None, want_sub: Some(want_sub), not_integrity: false }
+        }
+        vec![
+            row("empty_file", |_, _| Vec::new(), "is not a single JSON object"),
+            row("not_an_object", |_, _| b"[]\n".to_vec(), "is not a single JSON object"),
+            row("json_null", |_, _| b"null\n".to_vec(), "is not a single JSON object"),
+            row("version_zero", |valid, _| replace_once(valid, "{\"version\":1,", "{\"version\":0,"), "unsupported store envelope version 0"),
+            row("version_two", |valid, _| replace_once(valid, "{\"version\":1,", "{\"version\":2,"), "unsupported store envelope version 2"),
+            row("version_wrong_type", |valid, _| replace_once(valid, "{\"version\":1,", "{\"version\":\"1\","), "envelope is not the canonical encoding"),
+            row("version_null", |valid, _| replace_once(valid, "{\"version\":1,", "{\"version\":null,"), "envelope is not the canonical encoding"),
+            row("unknown_field", |valid, _| replace_once(valid, "{\"version\":1,", "{\"version\":1,\"extra\":0,"), "envelope is not the canonical encoding"),
+            row("field_order_swapped", |_, payload| {
+                format!("{{\"payload_b64\":\"{}\",\"version\":1,\"checksum\":\"{}\"}}\n",
+                    base64_encode(payload),
+                    hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
+            }, "envelope is not the canonical encoding"),
+            // A duplicated field lands INSIDE the derived body slice (the body
+            // length is raw.len() - frame, not a searched delimiter), so the
+            // canonical-base64 check is what refuses it. Both clients derive
+            // the same slice and therefore return this same message.
+            row("duplicate_payload_b64_identical", |valid, _| replace_once(valid, ",\"checksum\":\"", ",\"payload_b64\":\"DUPLICATE\",\"checksum\":\""), "payload_b64 is not canonical padded base64"),
+            row("duplicate_payload_b64_conflicting", |valid, payload| {
+                let mut other = b"x".to_vec();
+                other.extend_from_slice(payload);
+                replace_once(valid, ",\"checksum\":\"", &format!(",\"payload_b64\":\"{}\",\"checksum\":\"", base64_encode(&other)))
+            }, "payload_b64 is not canonical padded base64"),
+            row("duplicate_checksum_identical", |valid, _| replace_once(valid, "\"}\n", &format!("\",\"checksum\":\"{}\"}}\n", "0".repeat(64))), "payload_b64 is not canonical padded base64"),
+            row("duplicate_checksum_conflicting", |valid, _| replace_once(valid, "\"}\n", &format!("\",\"checksum\":\"{}\"}}\n", "b".repeat(64))), "payload_b64 is not canonical padded base64"),
+            row("missing_checksum", |valid, _| replace_once(valid, "\",\"checksum\":\"", "\",\"checksu\":\""), "envelope is not the canonical encoding"),
+            row("missing_payload_b64", |valid, _| replace_once(valid, ",\"payload_b64\":\"", ",\"payloadb64\":\""), "envelope is not the canonical encoding"),
+            row("trailing_second_json_value", |valid, _| { let mut out = valid.to_vec(); out.extend_from_slice(b"{\"version\":1}"); out }, "envelope is not the canonical encoding"),
+            row("no_trailing_newline", |valid, _| valid.strip_suffix(b"\n").unwrap_or(valid).to_vec(), "envelope is not the canonical encoding"),
+            row("leading_whitespace", |valid, _| { let mut out = b" ".to_vec(); out.extend_from_slice(valid); out }, "envelope is not the canonical encoding"),
+            row("checksum_uppercase_hex", |valid, _| replace_once(valid, &checksum_hex_of(valid), &checksum_hex_of(valid).to_uppercase()), "checksum must be 64 lowercase hex characters"),
+            row("checksum_not_hex", |valid, _| replace_once(valid, &checksum_hex_of(valid), &"z".repeat(64)), "checksum must be 64 lowercase hex characters"),
+            row("checksum_short", |valid, _| replace_once(valid, &checksum_hex_of(valid), &"a".repeat(63)), "envelope is not the canonical encoding"),
+            row("payload_b64_unpadded", |_, payload| {
+                format!("{{\"version\":1,\"payload_b64\":\"{}\",\"checksum\":\"{}\"}}\n",
+                    base64_encode(payload).trim_end_matches('='),
+                    hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
+            }, "payload_b64 is not canonical padded base64"),
+            row("payload_b64_embedded_newline", |_, payload| {
+                let encoded = base64_encode(payload);
+                format!("{{\"version\":1,\"payload_b64\":\"{}\\n{}\",\"checksum\":\"{}\"}}\n",
+                    &encoded[..4], &encoded[4..],
+                    hex::encode(store_envelope_checksum(STORE_ENVELOPE_CHAIN_STATE.domain, payload))).into_bytes()
+            }, "payload_b64 is not canonical padded base64"),
+            StoreIntegrityRow { name: "checksum_mismatch_zeroed", body: Box::new(|valid, _| replace_once(valid, &checksum_hex_of(valid), &"0".repeat(64))), want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR), want_sub: None, not_integrity: false },
+            // One interior base64 symbol changes, so the file stays canonical
+            // base64 and only the checksum can catch it.
+            StoreIntegrityRow { name: "payload_base64_bitflip", body: Box::new(|valid, _| { let encoded = payload_b64_of(valid); replace_once(valid, &encoded, &flip_base64_symbol(&encoded)) }), want_msg: Some(STORE_CHECKSUM_MISMATCH_ERR), want_sub: None, not_integrity: false },
+        ]
+    }
+
+    fn flip_base64_symbol(value: &str) -> String {
+        let replacement = if value.as_bytes()[1] == b'A' {
+            'B'
+        } else {
+            'A'
+        };
+        format!("{}{replacement}{}", &value[..1], &value[2..])
+    }
+
+    /// Plants each row at `path`, calls `load`, and pins the message, the
+    /// STORE_INTEGRITY identity, and that the refusal never rewrote the file.
+    /// (The absent-file exclusion Go states as `fs.ErrNotExist` is structural
+    /// here: the loaders return `String`, and the absent-file branch is a
+    /// distinct `ErrorKind::NotFound` arm that never sees these bytes.)
+    /// Go twin: `runStoreIntegrityRows`.
+    pub(crate) fn run_store_integrity_rows(
+        path: &std::path::Path,
+        valid: &[u8],
+        payload: &[u8],
+        mut load: impl FnMut() -> Result<(), String>,
+        rows: &[StoreIntegrityRow],
+    ) {
+        for row in rows {
+            let body = (row.body)(valid, payload);
+            std::fs::write(path, &body).expect("plant body");
+            let err = load().expect_err(row.name);
+            if let Some(want) = row.want_msg {
+                assert_eq!(err, want, "{}", row.name);
+            }
+            if let Some(want) = row.want_sub {
+                assert!(err.contains(want), "{}: {err}", row.name);
+            }
+            assert_eq!(
+                err.starts_with(STORE_INTEGRITY_PREFIX),
+                !row.not_integrity,
+                "{}: {err}",
+                row.name
+            );
+            assert_eq!(
+                std::fs::read(path).expect("read back"),
+                body,
+                "{}: a failed load rewrote the file",
+                row.name
+            );
+        }
+    }
+}

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -1692,7 +1692,15 @@ pub(crate) fn boundary_chain_for_test(prefix: &str) -> (SyncEngine, std::path::P
         canonical.push(hex::encode(hash));
         prev = hash;
     }
-    let index = serde_json::json!({ "version": 1, "canonical": canonical }).to_string();
+    // RUB-1134: planted through the same store_envelope_v1 frame the production
+    // saver emits, so the reopen below keeps exercising the header walk.
+    let index = crate::store_envelope::marshal_store_envelope(
+        crate::store_envelope::STORE_ENVELOPE_BLOCK_INDEX,
+        serde_json::json!({ "version": 1, "canonical": canonical })
+            .to_string()
+            .as_bytes(),
+    )
+    .expect("wrap canonical index");
     std::fs::write(root.join("index.json"), index).expect("write canonical index");
 
     chain_state.height = WINDOW_SIZE - 2;

--- a/clients/rust/crates/rubin-node/src/undo.rs
+++ b/clients/rust/crates/rubin-node/src/undo.rs
@@ -403,8 +403,10 @@ fn block_undo_from_disk(disk: BlockUndoDisk) -> Result<BlockUndo, String> {
 //   {"version":1,"block_hash":"<64hex>","payload_b64":"<b64>","checksum":"<64hex>"}\n
 //
 // checksum = SHA3-256("RUBIN_BLOCK_UNDO_V1" || block_hash[32] ||
-// uint64_be(payload.len()) || payload). The length term makes the preimage
-// injective, so no two (hash, payload) pairs share a digest by concatenation.
+// uint64_be(payload.len()) || payload). The length prefix makes the preimage
+// encoding unambiguous: no two distinct (hash, payload) pairs serialize to
+// the same preimage bytes, so concatenation cannot alias one frame into
+// another.
 // The trailing LF counts against the read bound but is NOT in the preimage.
 //
 // Go twin: the same section in clients/go/node/undo.go. Both clients must emit

--- a/conformance/devnetcv/devnetcv.go
+++ b/conformance/devnetcv/devnetcv.go
@@ -2,6 +2,7 @@ package devnetcv
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -544,14 +545,49 @@ func snapshotChainState(st *node.ChainState) (ChainStateJSON, error) {
 	if err != nil {
 		return ChainStateJSON{}, err
 	}
+	inner, err := unwrapStoreEnvelopeV1(raw)
+	if err != nil {
+		return ChainStateJSON{}, err
+	}
 	var snapshot ChainStateJSON
-	if err := json.Unmarshal(raw, &snapshot); err != nil {
+	if err := json.Unmarshal(inner, &snapshot); err != nil {
 		return ChainStateJSON{}, err
 	}
 	if snapshot.Utxos == nil {
 		snapshot.Utxos = []UtxoJSON{}
 	}
 	return snapshot, nil
+}
+
+// storeEnvelopeV1Frame is the local unwrap target for the store_envelope_v1
+// frame node.ChainState.Save now emits (RUB-1134). This package cannot import
+// node's unexported envelope helpers, so it re-parses only the two fields it
+// needs; it is not a security boundary, only a decode step for the
+// generator's own in-process snapshot.
+type storeEnvelopeV1Frame struct {
+	Version    uint32 `json:"version"`
+	PayloadB64 string `json:"payload_b64"`
+}
+
+// unwrapStoreEnvelopeV1 strictly parses the outer envelope and returns the
+// decoded inner payload bytes; it fails loudly on any shape or version
+// mismatch instead of silently falling back to the raw envelope bytes.
+func unwrapStoreEnvelopeV1(raw []byte) ([]byte, error) {
+	var frame storeEnvelopeV1Frame
+	if err := json.Unmarshal(raw, &frame); err != nil {
+		return nil, fmt.Errorf("unwrap store envelope: %w", err)
+	}
+	if frame.Version != 1 {
+		return nil, fmt.Errorf("unwrap store envelope: unsupported version %d", frame.Version)
+	}
+	if frame.PayloadB64 == "" {
+		return nil, fmt.Errorf("unwrap store envelope: missing payload_b64")
+	}
+	payload, err := base64.StdEncoding.DecodeString(frame.PayloadB64)
+	if err != nil {
+		return nil, fmt.Errorf("unwrap store envelope: decode payload_b64: %w", err)
+	}
+	return payload, nil
 }
 
 func spendableOutputFromBlock(blockBytes []byte) ([32]byte, uint64, uint32, []byte, string, error) {

--- a/scripts/devnet-smoke.sh
+++ b/scripts/devnet-smoke.sh
@@ -102,9 +102,8 @@ want_height = int(sys.argv[2])
 path = datadir / "chainstate.json"
 if not path.exists():
     raise SystemExit(1)
-# RUB-1134: chainstate.json is the store_envelope_v1 frame; the inner payload
-# encoding is unchanged. The node verifies the domain-tagged checksum on load,
-# so this reader only unwraps the v1 payload.
+# RUB-1134: unwrap the store_envelope_v1 frame (the node verifies the
+# domain-tagged checksum on load); the inner payload encoding is unchanged.
 envelope = json.loads(path.read_text())
 if envelope.get("version") != 1:
     raise SystemExit(1)

--- a/scripts/devnet-smoke.sh
+++ b/scripts/devnet-smoke.sh
@@ -92,6 +92,7 @@ wait_for_height() {
   local deadline=$((SECONDS + timeout))
   while (( SECONDS < deadline )); do
     if python3 - "${datadir}" "${want_height}" <<'PY'
+import base64
 import json
 import pathlib
 import sys
@@ -101,7 +102,13 @@ want_height = int(sys.argv[2])
 path = datadir / "chainstate.json"
 if not path.exists():
     raise SystemExit(1)
-data = json.loads(path.read_text())
+# RUB-1134: chainstate.json is the store_envelope_v1 frame; the inner payload
+# encoding is unchanged. The node verifies the domain-tagged checksum on load,
+# so this reader only unwraps the v1 payload.
+envelope = json.loads(path.read_text())
+if envelope.get("version") != 1:
+    raise SystemExit(1)
+data = json.loads(base64.b64decode(envelope["payload_b64"], validate=True))
 if data.get("has_tip") and data.get("height") == want_height:
     raise SystemExit(0)
 raise SystemExit(1)
@@ -174,12 +181,17 @@ PY
 read_state_tsv() {
   local datadir="$1"
   python3 - "${datadir}" <<'PY'
+import base64
 import json
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1]) / "chainstate.json"
-data = json.loads(path.read_text())
+# RUB-1134: unwrap the store_envelope_v1 frame; the inner payload is unchanged.
+envelope = json.loads(path.read_text())
+if envelope.get("version") != 1:
+    raise SystemExit(f"unsupported chainstate envelope version: {envelope.get('version')!r}")
+data = json.loads(base64.b64decode(envelope["payload_b64"], validate=True))
 print(
     data["height"],
     data["tip_hash"],

--- a/scripts/test_node_dry_run_parity.sh
+++ b/scripts/test_node_dry_run_parity.sh
@@ -467,11 +467,18 @@ grep -F -q -x "blockstore: empty" "${ART}/empty-capture.verify" ||
   fail "empty-chainstate capture store is not empty"
 
 TIP_HASH="$(python3 - "${BASE_DIR}/blockstore/index.json" <<'PY'
+import base64
 import json
 import sys
 
+# RUB-1134: index.json is the store_envelope_v1 frame; the inner index encoding
+# is unchanged. The node verifies the domain-tagged checksum on open, so this
+# reader only unwraps the v1 payload.
 with open(sys.argv[1], "rb") as handle:
-    canonical = json.load(handle)["canonical"]
+    envelope = json.load(handle)
+if envelope.get("version") != 1:
+    raise SystemExit(f"unsupported index envelope version: {envelope.get('version')!r}")
+canonical = json.loads(base64.b64decode(envelope["payload_b64"], validate=True))["canonical"]
 if not canonical:
     raise SystemExit("canonical index is empty")
 print(canonical[-1])

--- a/scripts/test_node_storage_lock_parity.sh
+++ b/scripts/test_node_storage_lock_parity.sh
@@ -532,13 +532,21 @@ assert_atomic_reserved_state() {
 }
 canonical_live_block_path() {
   python3 - "$1/blockstore/index.json" "$1/blockstore/blocks" <<'PY'
-import json, pathlib, sys
+import base64, binascii, json, pathlib, sys
 def require(condition, message):
     if not condition:
         raise SystemExit(message)
+# RUB-1134: index.json is the store_envelope_v1 frame; the inner index encoding
+# is unchanged. The node verifies the domain-tagged checksum on open, so this
+# reader only unwraps the v1 payload — every malformed shape stays a
+# deterministic SystemExit rather than a traceback.
 try:
-    index = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+    envelope = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+    require(isinstance(envelope, dict), "canonical block index envelope is not an object")
+    require(envelope.get("version") == 1, "canonical block index envelope is not version 1")
+    require(isinstance(envelope.get("payload_b64"), str), "canonical block index envelope has no payload")
+    index = json.loads(base64.b64decode(envelope["payload_b64"], validate=True))
+except (OSError, UnicodeError, json.JSONDecodeError, RecursionError, binascii.Error, ValueError) as exc:
     raise SystemExit(f"cannot read canonical block index: {exc}")
 require(isinstance(index, dict), "canonical block index root is not an object")
 canonical = index.get("canonical")

--- a/scripts/test_node_storage_lock_parity.sh
+++ b/scripts/test_node_storage_lock_parity.sh
@@ -536,10 +536,9 @@ import base64, binascii, json, pathlib, sys
 def require(condition, message):
     if not condition:
         raise SystemExit(message)
-# RUB-1134: index.json is the store_envelope_v1 frame; the inner index encoding
-# is unchanged. The node verifies the domain-tagged checksum on open, so this
-# reader only unwraps the v1 payload — every malformed shape stays a
-# deterministic SystemExit rather than a traceback.
+# RUB-1134: unwrap the store_envelope_v1 frame (the node verifies the
+# domain-tagged checksum on open); every malformed shape stays a deterministic
+# SystemExit rather than a traceback.
 try:
     envelope = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
     require(isinstance(envelope, dict), "canonical block index envelope is not an object")


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1134
- GitHub Issue mirror (non-authoritative): #2850

Refs: Q-XCLIENT-CHAINSTATE-INDEX-INTEGRITY-V1-01

## Summary
Both clients store chainstate.json and the canonical blockstore index.json inside a strict 3-field store_envelope_v1 frame ({"version":1,"payload_b64":...,"checksum":...} + one trailing LF) binding the exact inner payload bytes under a SHA3-256 domain-tagged length-prefixed preimage (RUBIN_CHAINSTATE_V1 / RUBIN_BLOCKSTORE_INDEX_V1), validated by index arithmetic with JSON parsed only on the reject path, canonical padded base64 only, constant-time checksum compare, and strict inner decode only after checksum success. A non-empty canonical index is additionally anchored: row 0 must equal the configured genesis hash, checked in run() before reconcile adoption in both clients (Rust also hoists the hashless-custom-genesis refusal above reconcile so no unanchored mutation precedes it). Every legacy/malformed/checksum-mismatched/genesis-mismatched file fails before inner decode, reconcile adoption, or canonical-state mutation with pinned byte-identical STORE_INTEGRITY messages (no trailing period, undo-family precedent); absent chainstate.json keeps the NewChainState-plus-full-replay path; absent index.json keeps the strict-open rejection. New writes emit v1 only; no legacy read, no silent repair, no size bound (RUB-1057 standing decision). The three raw-parsing scripts unwrap the v1 payload deterministically. Envelope helpers are 3-field siblings of the merged undo envelope (undo.go/undo.rs code untouched; one doc-comment sentence in each reworded per contract amendment_2026_08_05g to drop a digest-injectivity misclaim). Branch is rebased onto the merged RUB-1137 (Rust genesis-bootstrap parity), which turned the storage-lock parity gate and the two dry-run bin tests green with no code change.

## Invariant
Go and Rust adopt a persisted chainstate snapshot or canonical blockstore index only when one strict versioned envelope binds that file's exact payload bytes under the same SHA3-256 domain-tagged checksum preimage, and adopt a non-empty canonical index only when its row 0 equals the configured genesis hash; every legacy, malformed, checksum-mismatched, or genesis-mismatched file fails before inner decode, reconcile adoption, or canonical-state mutation, while an absent chainstate.json keeps the existing NewChainState-plus-full-replay repair path.

## Scope
- Changed files: 23
- Surfaces: clients/go (node + cmd/rubin-node), clients/rust (rubin-node crate), scripts (devnet-smoke.sh, test_node_dry_run_parity.sh, test_node_storage_lock_parity.sh), conformance/devnetcv (generator snapshot unwrap only)
- Non-scope: no inner-format redesign (cross-client inner field-order normalization is routed to the RUB-1128 rebind per amendment_2026_08_05d); no migration or repair of pre-envelope or pre-RUB-1137 datadirs; no size bound on either file (safeio.go / io_utils.rs untouched); undo.go / undo.rs semantics untouched (doc-comment sentence only, amendment_2026_08_05g); no consensus, wire, mempool, P2P, DA, miner, RPC, spec, or formal change; no new dependency, no reindex command.
- Consensus rules unchanged: YES — local persistence integrity and startup ordering only; the single consensus-adjacent call is the pre-existing genesis-hash comparison of already-configured values
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head 024bab7a (71b04625 plus three fixups: conformance devnetcv snapshot unwrap 19f0559c with generator-vs-committed byte-identity proof for all five CV-DEVNET fixtures, and two comment-only doc rewords 9014f8f4/024bab7a): TOOLING_STAGE=static tooling-check.sh auto — PASS (exit 0, golangci-lint 0 issues); scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./... && go vet ./...' — PASS; scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace --locked' — PASS (fully green incl. both dry-run bin tests); cargo clippy --workspace --all-targets --locked -- -D warnings — PASS; scripts/dev-env.sh -- bash scripts/test_node_dry_run_parity.sh — PASS; scripts/dev-env.sh -- bash scripts/test_node_storage_lock_parity.sh datadir — PASS; scripts/dev-env.sh -- bash scripts/test_node_storage_lock_parity.sh atomic-parent — PASS; go test ./node -run "^(TestStoreEnvelopeV1CrossClientVectors|TestLoadChainStateRejectsIntegrityFailures|TestBlockstoreIndexRejectsIntegrityFailures|TestStartupGenesisAnchorMismatchFails|TestAbsentChainstateRebuildsByReplay|TestReconcileCrashRecoveryOverEnvelopedFiles)$" — PASS; go test ./cmd/rubin-node -run "Anchor" — PASS; six mirrored Rust tests via cargo test -p rubin-node --lib <fully-qualified> -- --exact — PASS; git diff --check — PASS; cd conformance && go test ./... — PASS (TestDevnetFixturesReplay green at 19f0559c)
- Cross-client vectors: four mirrored envelope-byte vectors pinned with identical literals in both clients, checksums independently recomputed from the stated preimage in both suites
- Mutation receipts on record: checksum-compare skip (Go and Rust) -> vector/reject tests red; anchor method skip -> unit test red; anchor call-site deletion (Go and Rust) -> wiring tests red while unit tests stay green; hashless-hoist revert -> ordering test red showing reconcile entered; crash matrix 4 boundaries x 2 orders with armed-check
- devnet-smoke.sh: bash -n only here; full multi-node run deferred to the canonical soak stage (contract audit_2026_08_05 note)

## Follow-ups / Waivers
- RUB-1128 rebind consumes this envelope and owns the cross-client inner-encoding normalization: https://linear.app/rubinp/issue/RUB-1128
- RUB-905/914 rebase against the enveloped format before claim (recorded in the contract dependency_order)
- None otherwise
