### PR TITLE
RUB-1135: validate mine-address with the full parser domain before storage mutation

### DIFF
--- a/clients/go/cmd/rubin-node/featurebits_telemetry_test.go
+++ b/clients/go/cmd/rubin-node/featurebits_telemetry_test.go
@@ -111,8 +111,14 @@ func TestPrintFeatureBitsTelemetry(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := printFeatureBitsTelemetry(&out, bs, consensus.SIGNAL_WINDOW, deploymentsPath); err != nil {
-		t.Fatalf("printFeatureBitsTelemetry: %v", err)
+	// The production pair run() itself uses: load the rows once, then print
+	// them. There is no single-call shim between this test and startup.
+	ds, err := loadFeatureBitDeployments(deploymentsPath)
+	if err != nil {
+		t.Fatalf("loadFeatureBitDeployments: %v", err)
+	}
+	if err := printFeatureBitsTelemetryRows(&out, bs, consensus.SIGNAL_WINDOW, ds); err != nil {
+		t.Fatalf("printFeatureBitsTelemetryRows: %v", err)
 	}
 	s := out.String()
 	if !strings.Contains(s, "featurebits: name=X") ||

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -377,6 +377,25 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if canonicalNetwork, ok := node.CanonicalNetworkName(cfg.Network); ok {
 		cfg.Network = canonicalNetwork
 	}
+	// --mine-address is untrusted operator input. node.ValidateConfig above
+	// already rejected everything node.ParseMineAddress rejects
+	// (validateConfigMineAddress delegates to that same pure parser), so on
+	// this path the call below cannot fail and its error branch is defense in
+	// depth for a caller that reorders the two guards. Its purpose here is to
+	// produce the covenant_data bytes EXACTLY ONCE, before the
+	// legacy-exposure-scan chainstate read, the storage lifecycle
+	// (createOrOpenBlockStore below), chainstate load/reconcile/save and
+	// service startup: both consuming sites (the --mine-blocks miner and the
+	// devnet RPC live miner) reuse this value instead of re-parsing the
+	// string, which is what let a rejected value reach the miner after the
+	// whole storage lifecycle — or silently disable RPC mining — before
+	// RUB-1135. An empty or whitespace-only flag yields a nil address and
+	// leaves both miner configs on their built-in default.
+	mineAddress, mineAddressErr := node.ParseMineAddress(cfg.MineAddress)
+	if mineAddressErr != nil {
+		_, _ = fmt.Fprintf(stderr, "invalid mine-address: %v\n", mineAddressErr)
+		return 2
+	}
 	// pv-mode is untrusted operator input: reject an invalid mode BEFORE
 	// the legacy-exposure-scan branch (its chainstate read below) and
 	// BEFORE the storage lifecycle (createOrOpenBlockStore below), so the
@@ -624,13 +643,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	if *mineBlocks > 0 {
 		minerCfg := node.DefaultMinerConfig()
-		if cfg.MineAddress != "" {
-			addrBytes, addrErr := node.ParseMineAddress(cfg.MineAddress)
-			if addrErr != nil {
-				_, _ = fmt.Fprintf(stderr, "invalid mine-address: %v\n", addrErr)
-				return 2
-			}
-			minerCfg.MineAddress = addrBytes
+		if mineAddress != nil {
+			minerCfg.MineAddress = mineAddress
 		}
 		minerCfg.CurrentMempoolMinFeeRateFn = mempool.CurrentMinFeeRateSnapshot
 		miner, err := newMinerFn(chainState, blockStore, syncEngine, minerCfg)
@@ -678,25 +692,19 @@ func run(args []string, stdout, stderr io.Writer) int {
 	var liveMiner *node.Miner
 	if cfg.Network == "devnet" && strings.TrimSpace(cfg.RPCBindAddr) != "" && rpcBindHostIsLoopback(cfg.RPCBindAddr) {
 		minerCfg := node.DefaultMinerConfig()
-		var mineAddrErr error
-		if cfg.MineAddress != "" {
-			addrBytes, addrErr := node.ParseMineAddress(cfg.MineAddress)
-			if addrErr != nil {
-				mineAddrErr = addrErr
-				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled (invalid --mine-address): %v\n", addrErr)
-			} else {
-				minerCfg.MineAddress = addrBytes
-			}
+		// Reuses the single parse above. A rejected --mine-address never
+		// reaches this site: it exits 2 at config validation, so live mining
+		// is no longer silently disabled on operator input the startup check
+		// should have refused.
+		if mineAddress != nil {
+			minerCfg.MineAddress = mineAddress
 		}
-		if mineAddrErr == nil {
-			minerCfg.CurrentMempoolMinFeeRateFn = mempool.CurrentMinFeeRateSnapshot
-			minerCfg.CompleteDASetProvider = p2pService
-			var err error
-			liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
-			if err != nil {
-				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled: %v\n", err)
-				liveMiner = nil
-			}
+		minerCfg.CurrentMempoolMinFeeRateFn = mempool.CurrentMinFeeRateSnapshot
+		minerCfg.CompleteDASetProvider = p2pService
+		liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled: %v\n", err)
+			liveMiner = nil
 		}
 	}
 	// newDevnetRPCStateWithLifecycle is the canonical production wiring:

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -832,20 +832,6 @@ func loadFeatureBitDeployments(deploymentsPath string) ([]featureBitDeploymentJS
 	return ds, nil
 }
 
-// printFeatureBitsTelemetry loads deploymentsPath and prints its telemetry:
-// the pre-RUB-876 single-call shape, kept for callers holding only a path
-// (currently tests in this package). run() does not use it: startup
-// validates early via loadFeatureBitDeployments — before any filesystem or
-// service side effect — and later prints via printFeatureBitsTelemetryRows,
-// so the file is read exactly once per run.
-func printFeatureBitsTelemetry(w io.Writer, bs headerStore, height uint64, deploymentsPath string) error {
-	ds, err := loadFeatureBitDeployments(deploymentsPath)
-	if err != nil {
-		return err
-	}
-	return printFeatureBitsTelemetryRows(w, bs, height, ds)
-}
-
 func printFeatureBitsTelemetryRows(w io.Writer, bs headerStore, height uint64, ds []featureBitDeploymentJSON) error {
 	for _, dj := range ds {
 		d := consensus.FeatureBitDeployment{

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -3736,11 +3736,15 @@ func TestReadFileConfigBoundDeploymentsSite(t *testing.T) {
 	dir := t.TempDir()
 	var out bytes.Buffer
 	at := configBoundTestFile(t, dir, "at.json", "[]", 1<<24)
-	if err := printFeatureBitsTelemetry(&out, nil, 0, at); err != nil {
+	ds, err := loadFeatureBitDeployments(at)
+	if err != nil {
 		t.Fatalf("at-bound deployments must load: %v", err)
 	}
+	if err := printFeatureBitsTelemetryRows(&out, nil, 0, ds); err != nil {
+		t.Fatalf("at-bound deployments must print: %v", err)
+	}
 	over := configBoundTestFile(t, dir, "over.json", "[]", 1<<24+1)
-	if err := printFeatureBitsTelemetry(&out, nil, 0, over); err == nil || !strings.Contains(err.Error(), "exceeds size bound") {
+	if _, err := loadFeatureBitDeployments(over); err == nil || !strings.Contains(err.Error(), "exceeds size bound") {
 		t.Fatalf("over-bound deployments must be refused with the typed size error, got %v", err)
 	}
 }

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -583,6 +583,182 @@ func TestRunRejectsInvalidFeatureBitsDeploymentsBeforeStorage(t *testing.T) {
 	}
 }
 
+// TestRunRejectsInvalidMineAddressBeforeStorage proves the RUB-1135 guard
+// fires BEFORE any filesystem or service side effect: datadir creation,
+// chainstate load/save, blockstore open/create, reconcile, and service
+// construction — on mining and non-mining startups alike. Pre-fix the early
+// check only length-checked the decoded hex, so an unsupported-suite_id value
+// was caught at the late --mine-blocks site AFTER the whole storage lifecycle
+// (exit 2 on a mutated datadir) and, on the RPC path, not at all: it printed
+// "rpc: live mining disabled (invalid --mine-address)" and kept running. The
+// service stubs turn a regression into a failed assertion instead of a node
+// that starts and blocks on its lifecycle ctx.
+func TestRunRejectsInvalidMineAddressBeforeStorage(t *testing.T) {
+	const wantGuardStderr = "invalid config: mine_address: "
+	forbiddenStderr := []string{
+		"datadir create failed",
+		"chainstate load failed",
+		"chainstate reconcile failed",
+		"chainstate save failed",
+		"blockstore open failed",
+		"blockstore create failed",
+		"invalid mine-address",
+		"rpc: live mining disabled",
+	}
+	keyID := strings.Repeat("11", 32)
+
+	forbidServiceStart := func(t *testing.T) {
+		t.Helper()
+		prevSync, prevMempool, prevP2P, prevMiner := newSyncEngineFn, newMempoolFn, newP2PServiceFn, newMinerFn
+		newSyncEngineFn = func(*node.ChainState, *node.BlockStore, node.SyncConfig) (*node.SyncEngine, error) {
+			t.Error("sync engine constructed despite a rejected --mine-address")
+			return nil, errors.New("forbidden by test")
+		}
+		newMempoolFn = func(*node.ChainState, *node.BlockStore, [32]byte, node.MempoolConfig) (*node.Mempool, error) {
+			t.Error("mempool constructed despite a rejected --mine-address")
+			return nil, errors.New("forbidden by test")
+		}
+		newP2PServiceFn = func(p2p.ServiceConfig) (*p2p.Service, error) {
+			t.Error("p2p service constructed despite a rejected --mine-address")
+			return nil, errors.New("forbidden by test")
+		}
+		newMinerFn = func(*node.ChainState, *node.BlockStore, *node.SyncEngine, node.MinerConfig) (*node.Miner, error) {
+			t.Error("miner constructed despite a rejected --mine-address")
+			return nil, errors.New("forbidden by test")
+		}
+		t.Cleanup(func() {
+			newSyncEngineFn, newMempoolFn, newP2PServiceFn, newMinerFn = prevSync, prevMempool, prevP2P, prevMiner
+		})
+	}
+
+	runInvalid := func(t *testing.T, args []string) {
+		t.Helper()
+		forbidServiceStart(t)
+		var out, errOut bytes.Buffer
+		if code := run(args, &out, &errOut); code != 2 {
+			t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+		}
+		if !strings.Contains(errOut.String(), wantGuardStderr) {
+			t.Fatalf("stderr missing mine-address guard error: %q", errOut.String())
+		}
+		for _, marker := range forbiddenStderr {
+			if strings.Contains(errOut.String(), marker) {
+				t.Fatalf("late path reached despite a rejected --mine-address (%q): %q", marker, errOut.String())
+			}
+		}
+		if out.String() != "" {
+			t.Fatalf("expected empty stdout, got %q", out.String())
+		}
+	}
+
+	t.Run("hostile_values_clean_datadir_create_store", func(t *testing.T) {
+		for _, tc := range []struct{ name, value string }{
+			{name: "unsupported_suite_00", value: "00" + keyID},
+			{name: "unsupported_suite_02", value: "02" + keyID},
+			{name: "unsupported_suite_ff", value: "ff" + keyID},
+			{name: "prefixed_unsupported_suite_ff", value: "0Xff" + keyID},
+			{name: "padded_unsupported_suite_ff", value: "  ff" + keyID + "  "},
+			{name: "odd_length_hex", value: "abc"},
+			{name: "non_hex", value: "0xzz"},
+			{name: "short_31_bytes", value: strings.Repeat("11", 31)},
+			{name: "long_34_bytes", value: strings.Repeat("11", 34)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				datadir := filepath.Join(t.TempDir(), "data")
+				runInvalid(t, []string{
+					"--datadir", datadir, "--create-store", "--mine-blocks", "1", "--mine-exit",
+					"--mine-address", tc.value,
+				})
+				if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+					t.Fatalf("datadir must not be created on a rejected --mine-address: stat err=%v", err)
+				}
+			})
+		}
+	})
+
+	for _, leg := range []struct {
+		name      string
+		extraArgs []string
+	}{
+		{name: "non_mining_startup"},
+		{name: "mining_startup", extraArgs: []string{"--mine-blocks", "1", "--mine-exit"}},
+		{name: "dry_run", extraArgs: []string{"--dry-run"}},
+		{name: "rpc_bind_live_mining", extraArgs: []string{"--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"}},
+		{name: "legacy_exposure_scan", extraArgs: []string{"--legacy-exposure-scan", "--legacy-suite-id", "1"}},
+	} {
+		t.Run(leg.name, func(t *testing.T) {
+			datadir := preparedDatadir(t)
+			before := datadirSnapshot(t, datadir)
+			args := append([]string{"--datadir", datadir, "--mine-address", "ff" + keyID}, leg.extraArgs...)
+			runInvalid(t, args)
+			assertNoFilesystemWrite(t, before, datadirSnapshot(t, datadir))
+		})
+	}
+
+	// Mixed-violation row: mine_address is validated inside node.ValidateConfig,
+	// which runs ahead of the pv-mode guard, so its message wins.
+	t.Run("invalid_mine_address_wins_over_invalid_pv_mode", func(t *testing.T) {
+		datadir := filepath.Join(t.TempDir(), "data")
+		runInvalid(t, []string{
+			"--datadir", datadir, "--mine-address", "ff" + keyID, "--pv-mode", "nope",
+		})
+		if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+			t.Fatalf("datadir must not be created: stat err=%v", err)
+		}
+	})
+}
+
+// TestRunPassesParsedMineAddressToMiner pins the accepted side of RUB-1135:
+// a 0X-prefixed, whitespace-padded key_id — which ParseMineAddress accepts and
+// the pre-fix config check refused outright — reaches the offline-mining miner
+// as the exact suite_id||key_id bytes the parser produces.
+func TestRunPassesParsedMineAddressToMiner(t *testing.T) {
+	prev := newMinerFn
+	var captured node.MinerConfig
+	newMinerFn = func(_ *node.ChainState, _ *node.BlockStore, _ *node.SyncEngine, cfg node.MinerConfig) (*node.Miner, error) {
+		captured = cfg
+		return nil, errors.New("capture-only miner")
+	}
+	t.Cleanup(func() { newMinerFn = prev })
+
+	datadir := filepath.Join(t.TempDir(), "data")
+	var out, errOut bytes.Buffer
+	code := run([]string{
+		"--create-store", "--datadir", datadir, "--mine-blocks", "1", "--mine-exit",
+		"--mine-address", "  0X" + strings.Repeat("11", 32) + "  ",
+	}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("expected exit code 2 from the capture-only miner, got %d (stderr=%q)", code, errOut.String())
+	}
+	want := append([]byte{consensus.SUITE_ID_ML_DSA_87}, bytes.Repeat([]byte{0x11}, 32)...)
+	if !bytes.Equal(captured.MineAddress, want) {
+		t.Fatalf("miner cfg.MineAddress=%x, want %x", captured.MineAddress, want)
+	}
+}
+
+// TestRunEmptyMineAddressFlagLeavesMinerDefault pins the unset/empty flag as
+// unchanged: no address is produced and the miner keeps its built-in default.
+func TestRunEmptyMineAddressFlagLeavesMinerDefault(t *testing.T) {
+	prev := newMinerFn
+	var captured node.MinerConfig
+	newMinerFn = func(_ *node.ChainState, _ *node.BlockStore, _ *node.SyncEngine, cfg node.MinerConfig) (*node.Miner, error) {
+		captured = cfg
+		return nil, errors.New("capture-only miner")
+	}
+	t.Cleanup(func() { newMinerFn = prev })
+
+	datadir := filepath.Join(t.TempDir(), "data")
+	var out, errOut bytes.Buffer
+	if code := run([]string{
+		"--create-store", "--datadir", datadir, "--mine-blocks", "1", "--mine-exit", "--mine-address", "  ",
+	}, &out, &errOut); code != 2 {
+		t.Fatalf("expected exit code 2 from the capture-only miner, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !bytes.Equal(captured.MineAddress, node.DefaultMinerConfig().MineAddress) {
+		t.Fatalf("miner cfg.MineAddress=%x, want the default %x", captured.MineAddress, node.DefaultMinerConfig().MineAddress)
+	}
+}
+
 // TestRunEmptyFeatureBitsDeploymentsFlagSkipsValidation pins the flag's
 // pre-existing contract that an explicitly empty --featurebits-deployments
 // behaves exactly like an unset flag: no file read, no validation, no
@@ -2732,37 +2908,33 @@ func TestRunRPCBindReadyEndpointReportsLifecycle(t *testing.T) {
 	}
 }
 
-func TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr(t *testing.T) {
-	if os.Getenv("RUBIN_NODE_TEST_INVALID_MINE_ADDR_CHILD") == "1" {
-		dir := t.TempDir()
-		badSuiteMineAddr := "00" + strings.Repeat("00", 32)
-		code := run(
-			[]string{
-				"--create-store",
-				"--datadir", dir,
-				"--bind", "127.0.0.1:0",
-				"--rpc-bind", "127.0.0.1:0",
-				"--mine-address", badSuiteMineAddr,
-			},
-			os.Stdout,
-			os.Stderr,
-		)
-		os.Exit(code)
+// TestRunDevnetWithRPCBindInvalidMineAddressExitsBeforeStartup replaces the
+// pre-RUB-1135 pin that this exact input started the devnet RPC node and only
+// logged "rpc: live mining disabled (invalid --mine-address)". Silently
+// degrading mining on operator input the startup check should have refused is
+// the behavior this issue retires: the value now exits 2 on an untouched
+// filesystem, so the child-process/SIGINT dance the old pin needed is gone.
+func TestRunDevnetWithRPCBindInvalidMineAddressExitsBeforeStartup(t *testing.T) {
+	datadir := filepath.Join(t.TempDir(), "data")
+	var out, errOut bytes.Buffer
+	code := run([]string{
+		"--create-store",
+		"--datadir", datadir,
+		"--bind", "127.0.0.1:0",
+		"--rpc-bind", "127.0.0.1:0",
+		"--mine-address", "00" + strings.Repeat("00", 32),
+	}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("exit code=%d, want 2 (stdout=%q stderr=%q)", code, out.String(), errOut.String())
 	}
-
-	cmd := exec.Command(os.Args[0], "-test.run=TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr")
-	cmd.Env = append(os.Environ(), "RUBIN_NODE_TEST_INVALID_MINE_ADDR_CHILD=1")
-	stdout, stderr, err := runChildAfterRunningBanner(t, cmd)
-	if err != nil {
-		ee, ok := err.(*exec.ExitError)
-		if ok {
-			t.Fatalf("exit code=%d, want 0 (stdout=%s stderr=%s)", ee.ExitCode(), stdout, stderr)
-		}
-		t.Fatalf("unexpected error: %v (stdout=%s stderr=%s)", err, stdout, stderr)
+	if !strings.Contains(errOut.String(), "invalid config: mine_address: unsupported suite_id 0x00") {
+		t.Fatalf("stderr=%q, want the startup mine_address rejection", errOut.String())
 	}
-	s := stderr
-	if !strings.Contains(s, "rpc: live mining disabled (invalid --mine-address)") {
-		t.Fatalf("stderr=%q, want invalid mine-address log", s)
+	if strings.Contains(errOut.String(), "rpc: live mining disabled") {
+		t.Fatalf("stderr=%q, want no silent live-mining degradation", errOut.String())
+	}
+	if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+		t.Fatalf("datadir must not be created on a rejected --mine-address: stat err=%v", err)
 	}
 }
 
@@ -2812,6 +2984,16 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 				_, _ = fmt.Fprintln(os.Stderr, "DA provider regression: live miner cfg.CompleteDASetProvider=nil")
 				os.Exit(36)
 			}
+			// RUB-1135: the live-mining site consumes the single
+			// startup parse of --mine-address. The flag below is
+			// 0x-prefixed — a value the pre-fix config check refused
+			// before startup — so this row also pins that the accepted
+			// domain is exactly ParseMineAddress's.
+			wantAddr := append([]byte{consensus.SUITE_ID_ML_DSA_87}, bytes.Repeat([]byte{0x11}, 32)...)
+			if !bytes.Equal(cfg.MineAddress, wantAddr) {
+				_, _ = fmt.Fprintf(os.Stderr, "RUB-1135 regression: live miner cfg.MineAddress=%x, want %x\n", cfg.MineAddress, wantAddr)
+				os.Exit(37)
+			}
 			return nil, errors.New("test deliberate miner init abort to unblock SIGINT")
 		}
 		dir := t.TempDir()
@@ -2821,7 +3003,7 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 				"--datadir", dir,
 				"--bind", "127.0.0.1:0",
 				"--rpc-bind", "127.0.0.1:0",
-				"--mine-address", strings.Repeat("11", 32),
+				"--mine-address", "0x" + strings.Repeat("11", 32),
 			},
 			os.Stdout,
 			os.Stderr,
@@ -2844,6 +3026,9 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 		}
 		if errors.As(err, &ee) && ee.ExitCode() == 36 {
 			t.Fatalf("DA provider regression: live miner cfg.CompleteDASetProvider is nil; production wiring missing in main.go around `liveMiner, err = newMinerFn(...)` (stdout=%s stderr=%s)", stdout, stderr)
+		}
+		if errors.As(err, &ee) && ee.ExitCode() == 37 {
+			t.Fatalf("RUB-1135 regression: the live-mining site did not receive the startup-parsed --mine-address bytes (stdout=%s stderr=%s)", stdout, stderr)
 		}
 		t.Fatalf("unexpected child error: %v (stdout=%s stderr=%s)", err, stdout, stderr)
 	}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -470,17 +469,16 @@ func validateConfigLimits(cfg Config) error {
 	return nil
 }
 
+// validateConfigMineAddress accepts exactly what ParseMineAddress accepts and
+// rejects exactly what it rejects. ParseMineAddress is the single authority for
+// the accepted mine-address domain: re-deriving a hex/length rule here drifted
+// from it in both directions — an unsupported suite_id passed config validation
+// and failed only at the miner, while a 0x/0X-prefixed or whitespace-padded
+// value the parser accepts was refused before startup. The parsed bytes are
+// discarded here; cmd/rubin-node produces them once for its consuming sites.
 func validateConfigMineAddress(cfg Config) error {
-	if cfg.MineAddress != "" {
-		raw, err := hex.DecodeString(cfg.MineAddress)
-		if err != nil {
-			return fmt.Errorf("invalid mine_address hex: %w", err)
-		}
-		if len(raw) != 32 && len(raw) != 33 {
-			return fmt.Errorf("mine_address must be 32 (key_id) or 33 (suite_id||key_id) bytes, got %d", len(raw))
-		}
-	}
-	return nil
+	_, err := ParseMineAddress(cfg.MineAddress)
+	return err
 }
 
 func validateConfigRotationAndRegistry(cfg Config, network string) error {

--- a/clients/go/node/config_test.go
+++ b/clients/go/node/config_test.go
@@ -260,6 +260,39 @@ func TestParseMineAddressAcceptsKeyIDAndCanonicalEncoding(t *testing.T) {
 	}
 }
 
+// TestValidateConfigMineAddressMatchesParseMineAddressDomain pins the early
+// config-time check to the single domain authority: it must accept exactly
+// what ParseMineAddress accepts and reject exactly what it rejects, with the
+// parser's own message. The pre-fix check hex-decoded the raw string and only
+// compared the byte length, so it drifted in BOTH directions — the 0x/0X and
+// whitespace rows below were rejected although the parser accepts them, and
+// the unsupported-suite_id rows passed config validation and were caught only
+// at the miner, after the whole storage lifecycle.
+func TestValidateConfigMineAddressMatchesParseMineAddressDomain(t *testing.T) {
+	keyID := strings.Repeat("11", mineAddressKeyIDBytes)
+	cfg := DefaultConfig()
+	for _, value := range []string{
+		"", "   ",
+		keyID, "0x" + keyID, "0X" + keyID, "  " + keyID + "\t",
+		"01" + keyID, "0x01" + keyID,
+		"00" + keyID, "02" + keyID, "ff" + keyID, "0Xff" + keyID,
+		strings.Repeat("11", 31), strings.Repeat("11", 34),
+		"abc", "zz", "0xzz",
+	} {
+		cfg.MineAddress = value
+		_, parseErr := ParseMineAddress(value)
+		err := ValidateConfig(cfg)
+		switch {
+		case parseErr == nil && err != nil:
+			t.Errorf("mine_address %q: ValidateConfig rejected a ParseMineAddress-valid value: %v", value, err)
+		case parseErr != nil && err == nil:
+			t.Errorf("mine_address %q: ValidateConfig accepted a value the parser rejects (%v)", value, parseErr)
+		case parseErr != nil && !strings.Contains(err.Error(), parseErr.Error()):
+			t.Errorf("mine_address %q: ValidateConfig error %q does not carry the parser error %q", value, err, parseErr)
+		}
+	}
+}
+
 func TestValidateConfigRejectsInvalidMineAddress(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.MineAddress = "abcd"


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1135
- GitHub Issue mirror (non-authoritative): #2853

Refs: Q-GO-MINE-ADDRESS-VALIDATE-BEFORE-STORAGE-01

## Summary
Third member of the validate-before-storage startup family (RUB-665 pv-mode, RUB-876 featurebits). The early config-time mine-address check now delegates to node.ParseMineAddress — the single domain authority — instead of a raw hex-decode plus length check, closing a bidirectional domain mismatch: an unsupported-suite 33-byte value passed config validation and failed only at the miner after the whole storage lifecycle (or silently disabled RPC live mining), while 0x/0X-prefixed and whitespace-padded values the parser accepts were refused before startup. Every ParseMineAddress-rejected --mine-address now exits 2 before datadir creation, chainstate load/save, blockstore open, reconcile, or service startup on every startup leg (mining, non-mining, dry-run, rpc-bind, legacy-exposure-scan); the parsed bytes are produced exactly once and reused by the --mine-blocks miner and the devnet RPC live miner, whose silent degradation branch is deleted. Absorbed second obligation (RUB-1136): the test-only printFeatureBitsTelemetry shim is removed from main.go and its two caller files exercise the production pair loadFeatureBitDeployments + printFeatureBitsTelemetryRows with every assertion intact.

## Invariant
The early config-time mine-address check accepts exactly the inputs node.ParseMineAddress accepts and rejects exactly what it rejects, and every ParseMineAddress-rejected --mine-address (including a 33-byte value with an unsupported suite_id) exits 2 before datadir creation, chainstate load/save, blockstore open, reconcile, or service startup; the parsed result is produced once and reused by the miner and RPC sites.

## Scope
- Changed files: 5
- Surfaces: clients/go/cmd/rubin-node (main.go + tests), clients/go/node (config.go + tests)
- Non-scope: no change to which addresses are valid (node.ParseMineAddress untouched, domain authority); no new public API; no miner/RPC behavior beyond validation ordering and where invalid input is reported; no Rust (go-only slice — the Rust node keeps its late-exit/degradation behavior as a recorded deferred divergence, see the parity exemption below); no consensus, storage schema, or recovery change
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head d7d39f17 (rebased onto 4bf38f76, range-diff identical to the reviewed b6743640-based branch): scripts/dev-env.sh -- bash -lc 'cd clients/go && go build ./... && go vet ./...' — PASS; go test -count=1 ./cmd/rubin-node ./node — PASS (re-run on the rebased head); go test -race -count=1 ./cmd/rubin-node — PASS; go test -race -count=1 ./node — PASS; go test -count=1 ./... — PASS; cd conformance && go test ./... — PASS (separate Go module); gofmt — clean; git diff --check — PASS; executed-binary adversarial matrix (built from HEAD, empty env, absent datadir) — every rejected value exits 2 with the datadir still absent
- Mutation receipts on record: restoring the length-only early check turns the bidirectional domain table red (14 rows) and every hostile startup leg red; removing the early check and restoring per-site late parsing turns the ordering sentinels red ("sync engine constructed despite a rejected --mine-address") on every leg
- Hostile coverage: 9-value matrix (unsupported suites 0x00/0x02/0xff, 0x/0X prefixes, whitespace, odd-length, non-hex, 31/34-byte) x 5 startup legs, each asserting exit 2 and no filesystem side effect; dual-violation row pins invalid mine-address winning over invalid pv-mode; config-file leg verified structurally vacuous (no config-file loader exists in this binary)

## Follow-ups / Waivers
- RUB-877 startup-parity harness leg for this flag is parked with a pointer to RUB-1135 (recorded on the Linear issues)
- Rust sibling divergence (late exit + RPC degradation still present in clients/rust rubin-node) is a recorded deferred divergence of this go-only slice; the Rust-phase mirror materialization owns the closure

### Parity exemption justification
This is a contract-approved Go-only startup-repair slice (RUB-1135: target_repo go-only, forbidden_files_or_surfaces explicitly includes Rust, class_change_stop_rule stops on any Rust work). It changes node CLI startup validation ordering and operator error reporting only — no consensus, wire, serialization, hash, fixture, or shared-vector surface. The Rust node retains the baseline late-validation behavior; the divergence is deliberate, recorded on RUB-1135 and the parked RUB-877 startup-parity harness leg, and its closure is owned by the Rust-phase mirror materialization of the validate-before-storage family.
