### PR TITLE
RUB-1139: isolate p2p_runtime tests with unique temp paths and orphan-accounting serialization

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -5336,8 +5336,12 @@ mod tests {
     #[test]
     fn compact_fallback_read_message_continues_after_expiry_fallback() {
         let (mut session, mut client) = test_peer_session();
+        // RUB-1139: the client's read here (via assert_fallback_getdata) waits on
+        // the peer thread below, whose own budget is 2s; the client deadline must
+        // stay wider than that budget so a starved peer thread can't make this
+        // read time out first under CPU contention.
         client
-            .set_read_timeout(Some(Duration::from_secs(1)))
+            .set_read_timeout(Some(Duration::from_secs(5)))
             .expect("client read timeout");
         let block_hash = [0xcc; 32];
         let mut req = compact_outstanding_test_request(block_hash);
@@ -5448,8 +5452,12 @@ mod tests {
     #[test]
     fn late_blocktxn_fragmented_after_expiry_fallback() {
         let (mut session, mut client) = test_peer_session();
+        // RUB-1139: same deadline-ordering requirement as
+        // compact_fallback_read_message_continues_after_expiry_fallback above -
+        // this client read must outlast the peer thread's 2s budget under
+        // contention (measured red: Os { code: 35, kind: WouldBlock } at 1s).
         client
-            .set_read_timeout(Some(Duration::from_secs(1)))
+            .set_read_timeout(Some(Duration::from_secs(5)))
             .expect("client read timeout");
         let block_hash = [0xe3; 32];
         let mut payload = block_hash.to_vec();

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -376,9 +376,10 @@ fn orphan_pool_metrics_sub(blocks: usize, bytes: usize) {
 pub(crate) fn orphan_pool_metrics_test_guard() -> std::sync::MutexGuard<'static, ()> {
     // Recovery is sound: the lock only serializes access to unit test state, and every
     // guarded test resets that state at entry via `reset_orphan_pool_metrics_for_test`.
-    ORPHAN_POOL_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+    ORPHAN_POOL_TEST_LOCK.lock().unwrap_or_else(|poisoned| {
+        eprintln!("orphan_pool_metrics_test_guard: recovered from a poisoned lock");
+        poisoned.into_inner()
+    })
 }
 
 #[cfg(test)]
@@ -3987,6 +3988,7 @@ mod tests {
     }
 
     fn test_sync_engine_with_genesis() -> SyncEngine {
+        // pid + epoch-nanos + monotonic counter => fresh path by construction; no pre-cleanup needed.
         let root = crate::io_utils::unique_temp_path("rubin-node-p2p-runtime");
         fs::create_dir_all(&root).expect("create temp dir");
         let blockstore_dir = root.join("blockstore");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -374,9 +374,11 @@ fn orphan_pool_metrics_sub(blocks: usize, bytes: usize) {
 
 #[cfg(test)]
 pub(crate) fn orphan_pool_metrics_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    // Recovery is sound: the lock only serializes access to unit test state, and every
+    // guarded test resets that state at entry via `reset_orphan_pool_metrics_for_test`.
     ORPHAN_POOL_TEST_LOCK
         .lock()
-        .expect("lock orphan metrics tests")
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[cfg(test)]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3830,7 +3830,7 @@ mod tests {
     use std::io::Read;
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::Ordering;
     use std::thread;
     use std::time::Duration;
 
@@ -3850,8 +3850,6 @@ mod tests {
         BLOCK_HEADER_BYTES,
     };
     use serde::Deserialize;
-
-    static NEXT_TEST_ROOT_ID: AtomicU64 = AtomicU64::new(1);
 
     #[expect(clippy::type_complexity)]
     #[rustfmt::skip]
@@ -3987,9 +3985,7 @@ mod tests {
     }
 
     fn test_sync_engine_with_genesis() -> SyncEngine {
-        let unique = NEXT_TEST_ROOT_ID.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir().join(format!("rubin-node-p2p-runtime-{unique}"));
-        let _ = fs::remove_dir_all(&root);
+        let root = crate::io_utils::unique_temp_path("rubin-node-p2p-runtime");
         fs::create_dir_all(&root).expect("create temp dir");
         let blockstore_dir = root.join("blockstore");
         let chainstate_path = root.join("chainstate.json");
@@ -7645,6 +7641,14 @@ mod tests {
     #[test]
     fn has_block_local_store_error_propagates_through_p2p_consumers() {
         use crate::sync::{next_candidate_block_for_test, stock_devnet_engine_for_test};
+
+        // Case 6 below inserts into the orphan pool, which mutates the
+        // process-global GLOBAL_ORPHAN_TOTAL_BYTES/GLOBAL_ORPHAN_METRICS
+        // accounting (RUB-1139): serialize with the rest of the
+        // orphan-accounting test group so a sibling's reset/assert cannot
+        // interleave with this insert.
+        let _guard = orphan_pool_metrics_test_guard();
+        reset_orphan_pool_metrics_for_test();
 
         let (mut engine, dir) = stock_devnet_engine_for_test("rubin-b1-consumers", |_| {});
         let block = next_candidate_block_for_test(&engine, POW_LIMIT, engine.tip_timestamp + 1);


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1139
- GitHub Issue mirror (non-authoritative): #2861

Refs: Q-RUST-P2P-RUNTIME-TEST-ISOLATION-01

## Summary
Test-isolation flake fix for the rubin-node p2p_runtime suite, with zero production-code change. (1) test_sync_engine_with_genesis dropped its process-local AtomicU64 counter and fixed temp names (rubin-node-p2p-runtime-N restarted at 1 every process, colliding across interrupted runs and concurrent test binaries, with remove_dir_all able to delete a live sibling's blockstore) in favor of the crate's established unique_temp_path helper (pid+nanos+counter). (2) has_block_local_store_error_propagates_through_p2p_consumers — the one orphan-accounting test mutating the process-global GLOBAL_ORPHAN_TOTAL_BYTES/GLOBAL_ORPHAN_METRICS without the group's serialization guard — now takes orphan_pool_metrics_test_guard with the standard entry reset. (3) The guard itself now recovers from mutex poisoning (mirroring with_orphan_pool_metrics) with an eprintln breadcrumb, so a panicked member no longer aborts the remaining ten members at the guard line before their bodies run. (4) The second flake mechanism (amendment_2026_08_06_second_flake): the two tests built on the asymmetric assert_fallback_getdata construct — a 1s client read deadline racing a spawned peer thread's 2s internal budget — were reproduced 15/15 red under full-suite CPU-contention load and fixed by widening the client deadline to 5s so it strictly outlasts the peer budget; a module-wide sweep of all 42 timeout/clock sites found no third member of the class. The production statics and orphan accounting are byte-identical.

## Invariant
Every p2p_runtime test owns run-isolated state: unique per-run temp paths (no fixed rubin-node-p2p-runtime-N names) and orphan accounting that cannot be perturbed by a concurrent or interrupted sibling test — so the suite is deterministic under CPU contention and after an interrupted run, with zero production-code change.

## Scope
- Changed files: 1
- Surfaces: clients/rust/crates/rubin-node/src/p2p_runtime.rs, #[cfg(test)] code only (the test module plus the ratified #[cfg(test)] guard-helper block)
- Non-scope: no production code path (GLOBAL_ORPHAN_TOTAL_BYTES/GLOBAL_ORPHAN_METRICS and their accounting byte-identical); no orphan-policy or metrics-shape change; temp-dir litter growth (paths not returned to the 18 call sites for cleanup) accepted as the crate norm
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head 46b0df79: cargo fmt --check — PASS; cargo clippy -p rubin-node --all-targets --locked -- -D warnings — PASS; cargo test -p rubin-node --lib — PASS (906 passed, 0 failed); interrupted-run residue test (stale fixed-name and rubin-b1-* dirs pre-created) — PASS with no new fixed-name dirs; contention load (full suite, --test-threads=32, 20-way CPU spin) — clock-flake baseline 15/15 red on late_blocktxn_fragmented_after_expiry_fallback (Os error 35 WouldBlock), post-fix 0/10 red under the same load; git diff --check — PASS
- Falsification receipts: constructed race probe against the exact previously-unguarded interleave — 127/400 red unguarded vs 0/400 guarded; guard-poison probe — sibling dies at the guard line under .expect, runs its body and passes under the recovery; zero non-#[cfg(test)] changed lines verified by reading the full ±line list

## Follow-ups / Waivers
- Rust sibling of the mine-address validate-before-storage family remains separately owned (recorded on the Linear issue); the clock-timeout flake was pinned into this slice by amendment and is fixed here
