### PR TITLE
RUB-1121: reuse the positive SigCache in live Mempool validation

### DIFF
--- a/clients/go/consensus/htlc.go
+++ b/clients/go/consensus/htlc.go
@@ -78,27 +78,63 @@ func ValidateHTLCSpendAtHeight(
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) error {
-	rotation, registry = resolveHTLCSpendProviders(rotation, registry)
+	return validateHTLCSpendAtHeightWithSigCache(htlcSpendCheck{
+		entry:       entry,
+		pathItem:    pathItem,
+		sigItem:     sigItem,
+		tx:          tx,
+		inputIndex:  inputIndex,
+		inputValue:  inputValue,
+		chainID:     chainID,
+		blockHeight: blockHeight,
+		blockMTP:    blockMTP,
+		cache:       cache,
+		rotation:    rotation,
+		registry:    registry,
+	})
+}
 
-	c, err := ParseHTLCCovenantData(entry.CovenantData)
+// htlcSpendCheck carries the CORE_HTLC spend inputs plus the optional
+// caller-owned positive signature cache. sigCache is nil for every path that
+// does not own one, which keeps behavior exactly uncached.
+type htlcSpendCheck struct {
+	tx          *Tx
+	rotation    RotationProvider
+	registry    *SuiteRegistry
+	cache       *SighashV1PrehashCache
+	sigCache    *SigCache
+	entry       UtxoEntry
+	pathItem    WitnessItem
+	sigItem     WitnessItem
+	chainID     [32]byte
+	inputValue  uint64
+	blockHeight uint64
+	blockMTP    uint64
+	inputIndex  uint32
+}
+
+func validateHTLCSpendAtHeightWithSigCache(check htlcSpendCheck) error {
+	rotation, registry := resolveHTLCSpendProviders(check.rotation, check.registry)
+
+	c, err := ParseHTLCCovenantData(check.entry.CovenantData)
 	if err != nil {
 		return err
 	}
 
-	expectedKeyID, err := expectedHTLCSpendKeyID(c, pathItem, blockHeight, blockMTP)
+	expectedKeyID, err := expectedHTLCSpendKeyID(c, check.pathItem, check.blockHeight, check.blockMTP)
 	if err != nil {
 		return err
 	}
 
-	if err := validateHTLCSignaturePrecheck(sigItem, expectedKeyID, blockHeight, rotation, registry); err != nil {
+	if err := validateHTLCSignaturePrecheck(check.sigItem, expectedKeyID, check.blockHeight, rotation, registry); err != nil {
 		return err
 	}
 
-	cryptoSig, digest, err := extractSigAndDigestWithCache(sigItem, tx, inputIndex, inputValue, chainID, cache)
+	cryptoSig, digest, err := extractSigAndDigestWithCache(check.sigItem, check.tx, check.inputIndex, check.inputValue, check.chainID, check.cache)
 	if err != nil {
 		return err
 	}
-	ok, err := verifySigWithRegistry(sigItem.SuiteID, sigItem.Pubkey, cryptoSig, digest, registry)
+	ok, err := verifySigWithRegistryCache(check.sigItem.SuiteID, check.sigItem.Pubkey, cryptoSig, digest, registry, check.sigCache)
 	if err != nil {
 		return err
 	}

--- a/clients/go/consensus/sig_cache.go
+++ b/clients/go/consensus/sig_cache.go
@@ -174,6 +174,12 @@ func (c *SigCache) lookupKey(key [32]byte) bool {
 func (c *SigCache) insertKey(key [32]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// A zero-value SigCache was not built by NewSigCache: it has no map and no
+	// ring. Stay a no-op instead of panicking on a nil-map write or a modulo by
+	// zero — this type is exported and a caller may declare one.
+	if c.capacity <= 0 || len(c.order) != c.capacity || c.entries == nil {
+		return
+	}
 	if _, ok := c.entries[key]; ok {
 		return
 	}

--- a/clients/go/consensus/sig_cache.go
+++ b/clients/go/consensus/sig_cache.go
@@ -12,15 +12,28 @@ import (
 // Design rationale:
 //   - Positive-only: caching negative results would allow cache-poisoning attacks
 //     where an attacker causes valid signatures to be rejected.
-//   - Bounded: the cache has a fixed maximum capacity. When full, new entries are
-//     silently dropped (no eviction). This is simpler than LRU and still correct:
-//     the cache is a pure performance optimization.
+//   - Bounded: the cache has a fixed maximum capacity. At saturation it evicts in
+//     deterministic insertion-order FIFO, so a newly verified tuple always enters
+//     and the oldest inserted tuple leaves. A lookup hit never refreshes an
+//     entry's position: eviction order depends only on insertion order, never on
+//     access order, so it cannot be steered by lookup traffic.
 //   - Thread-safe: concurrent reads and writes are safe via RWMutex.
-//   - Canonical key: SHA3-256(suiteID || len(pubkey) || pubkey || len(sig) || sig || digest).
-//     Length-prefixing prevents ambiguity between different (pubkey, sig) splits.
+//   - Canonical key: see sigCacheKey / sigCacheBoundKey. Two key domains that can
+//     never collide: the legacy suite-only domain (0x00) and the binding-inclusive
+//     domain (0x01) used by live validation.
+//
+// The cache is a pure performance optimization: an entry may only ever let a
+// caller skip a backend verification call that already returned valid=true for
+// the exact same key components. It never carries transaction validity, an
+// admission result, or any failure.
 type SigCache struct {
-	mu       sync.RWMutex
-	entries  map[[32]byte]struct{}
+	mu      sync.RWMutex
+	entries map[[32]byte]struct{}
+	// order is an insertion-order ring of exactly capacity slots. order[next]
+	// holds the oldest live key whenever the cache is full, which makes
+	// eviction deterministic FIFO without tracking access.
+	order    [][32]byte
+	next     int
 	capacity int
 	hits     atomic.Uint64
 	misses   atomic.Uint64
@@ -34,34 +47,116 @@ func NewSigCache(capacity int) *SigCache {
 	}
 	return &SigCache{
 		entries:  make(map[[32]byte]struct{}, capacity),
+		order:    make([][32]byte, capacity),
 		capacity: capacity,
 	}
 }
 
-// sigCacheKey computes the canonical cache key for a verification tuple.
-// The key is SHA3-256(suiteID || le32(len(pubkey)) || pubkey || le32(len(sig)) || sig || digest).
+// Cache-key domains. The first preimage byte separates the legacy suite-only
+// key space from the binding-inclusive key space, so an entry inserted through
+// one API can never be found through the other.
+const (
+	sigCacheKeyDomainLegacy uint8 = 0x00
+	sigCacheKeyDomainBound  uint8 = 0x01
+)
+
+// appendSigCacheLenPrefixed appends le64(len(b)) || b.
+func appendSigCacheLenPrefixed(buf []byte, b []byte) []byte {
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(b)))
+	buf = append(buf, lenBuf[:]...)
+	return append(buf, b...)
+}
+
+// appendSigCacheInt appends an int as le64 two's complement. It is injective on
+// every pointer width because the value is widened to int64 before the cast, so
+// a 32-bit and a 64-bit build encode the same value identically.
+func appendSigCacheInt(buf []byte, v int) []byte {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(int64(v)))
+	return append(buf, b[:]...)
+}
+
+// sigCacheKey computes the legacy suite-only cache key for a verification tuple:
+// SHA3-256(0x00 || suiteID || le64(len(pubkey)) || pubkey || le64(len(sig)) || sig || digest).
+//
+// This key does NOT identify the resolved verifier binding and must not be used
+// by any live validation path; it is retained for the in-package SigCheckQueue
+// fast path and focused tests. Live validation uses sigCacheBoundKey.
 func sigCacheKey(suiteID uint8, pubkey, sig []byte, digest [32]byte) [32]byte {
-	// Pre-allocate: 1 + 4 + len(pubkey) + 4 + len(sig) + 32
-	buf := make([]byte, 0, 1+4+len(pubkey)+4+len(sig)+32)
-	buf = append(buf, suiteID)
-	var lenBuf [4]byte
-	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(pubkey))) // #nosec G115 -- suite-specific pubkey sizes are bounded well below uint32.
-	buf = append(buf, lenBuf[:]...)
-	buf = append(buf, pubkey...)
-	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(sig))) // #nosec G115 -- suite-specific signature sizes are bounded well below uint32.
-	buf = append(buf, lenBuf[:]...)
-	buf = append(buf, sig...)
+	buf := make([]byte, 0, 2+8+len(pubkey)+8+len(sig)+32)
+	buf = append(buf, sigCacheKeyDomainLegacy, suiteID)
+	buf = appendSigCacheLenPrefixed(buf, pubkey)
+	buf = appendSigCacheLenPrefixed(buf, sig)
+	buf = append(buf, digest[:]...)
+	return sha3_256(buf)
+}
+
+// sigCacheBoundKey computes the binding-inclusive cache key:
+// SHA3-256(0x01 || suiteID || le64(len(bindingID)) || bindingID ||
+//
+//	le64(len(pubkey)) || pubkey || le64(len(sig)) || sig || digest).
+//
+// Injectivity: the preimage is self-delimiting. Byte 0 is the domain, byte 1 is
+// the suite ID, every variable-length component is preceded by its exact 8-byte
+// little-endian length, and the fixed 32-byte digest terminates the buffer.
+// A preimage can therefore be parsed back into exactly one component tuple
+// left-to-right, so two DIFFERENT (bindingID, suiteID, pubkey, sig, digest)
+// tuples can never produce the same preimage — in particular two different
+// resolved verifier bindings can never serialize into the same key, and no
+// re-split of the pubkey/signature byte boundary can alias another tuple.
+// Key equality therefore implies component equality under SHA3-256 collision
+// resistance. bindingID must itself be an injective encoding of the resolved
+// binding (see sigCacheVerifierBindingIdentity).
+func sigCacheBoundKey(bindingID []byte, suiteID uint8, pubkey, sig []byte, digest [32]byte) [32]byte {
+	buf := make([]byte, 0, 2+8+len(bindingID)+8+len(pubkey)+8+len(sig)+32)
+	buf = append(buf, sigCacheKeyDomainBound, suiteID)
+	buf = appendSigCacheLenPrefixed(buf, bindingID)
+	buf = appendSigCacheLenPrefixed(buf, pubkey)
+	buf = appendSigCacheLenPrefixed(buf, sig)
 	buf = append(buf, digest[:]...)
 	return sha3_256(buf)
 }
 
 // Lookup checks if a (suiteID, pubkey, sig, digest) tuple has been previously
-// verified as valid. Returns true if found in cache (positive hit).
+// verified as valid under the legacy suite-only key domain. Returns true if
+// found in cache (positive hit). Live validation must use lookupBound.
 func (c *SigCache) Lookup(suiteID uint8, pubkey, sig []byte, digest [32]byte) bool {
 	if c == nil {
 		return false
 	}
-	key := sigCacheKey(suiteID, pubkey, sig, digest)
+	return c.lookupKey(sigCacheKey(suiteID, pubkey, sig, digest))
+}
+
+// Insert records a positive verification result under the legacy suite-only key
+// domain. Live validation must use insertBound.
+func (c *SigCache) Insert(suiteID uint8, pubkey, sig []byte, digest [32]byte) {
+	if c == nil {
+		return
+	}
+	c.insertKey(sigCacheKey(suiteID, pubkey, sig, digest))
+}
+
+// lookupBound reports whether the exact tuple was already verified successfully
+// under this resolved verifier binding identity.
+func (c *SigCache) lookupBound(bindingID []byte, suiteID uint8, pubkey, sig []byte, digest [32]byte) bool {
+	if c == nil {
+		return false
+	}
+	return c.lookupKey(sigCacheBoundKey(bindingID, suiteID, pubkey, sig, digest))
+}
+
+// insertBound records a successful backend verification under this resolved
+// verifier binding identity. Callers must only reach it after the backend
+// returned valid=true with a nil error.
+func (c *SigCache) insertBound(bindingID []byte, suiteID uint8, pubkey, sig []byte, digest [32]byte) {
+	if c == nil {
+		return
+	}
+	c.insertKey(sigCacheBoundKey(bindingID, suiteID, pubkey, sig, digest))
+}
+
+func (c *SigCache) lookupKey(key [32]byte) bool {
 	c.mu.RLock()
 	_, ok := c.entries[key]
 	c.mu.RUnlock()
@@ -73,18 +168,21 @@ func (c *SigCache) Lookup(suiteID uint8, pubkey, sig []byte, digest [32]byte) bo
 	return ok
 }
 
-// Insert records a positive verification result. If the cache is at capacity,
-// the entry is silently dropped (no eviction).
-func (c *SigCache) Insert(suiteID uint8, pubkey, sig []byte, digest [32]byte) {
-	if c == nil {
+// insertKey stores key, evicting the oldest inserted key first when the cache is
+// at capacity. Re-inserting a key already present is a no-op: it neither
+// duplicates a ring slot nor refreshes the key's eviction position.
+func (c *SigCache) insertKey(key [32]byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.entries[key]; ok {
 		return
 	}
-	key := sigCacheKey(suiteID, pubkey, sig, digest)
-	c.mu.Lock()
-	if len(c.entries) < c.capacity {
-		c.entries[key] = struct{}{}
+	if len(c.entries) >= c.capacity {
+		delete(c.entries, c.order[c.next])
 	}
-	c.mu.Unlock()
+	c.order[c.next] = key
+	c.next = (c.next + 1) % c.capacity
+	c.entries[key] = struct{}{}
 }
 
 // Len returns the number of cached entries.
@@ -114,13 +212,16 @@ func (c *SigCache) Misses() uint64 {
 	return c.misses.Load()
 }
 
-// Reset clears all cached entries and resets counters.
+// Reset clears all cached entries, the insertion order, and the counters. It is
+// exact and concurrency-safe; it is not a policy-generation signal.
 func (c *SigCache) Reset() {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	c.entries = make(map[[32]byte]struct{}, c.capacity)
+	c.order = make([][32]byte, c.capacity)
+	c.next = 0
 	c.hits.Store(0)
 	c.misses.Store(0)
 	c.mu.Unlock()

--- a/clients/go/consensus/sig_cache.go
+++ b/clients/go/consensus/sig_cache.go
@@ -159,12 +159,14 @@ func (c *SigCache) insertBound(bindingID []byte, suiteID uint8, pubkey, sig []by
 func (c *SigCache) lookupKey(key [32]byte) bool {
 	c.mu.RLock()
 	_, ok := c.entries[key]
-	c.mu.RUnlock()
+	// Counter bump stays under RLock: Reset zeroes the counters under the write
+	// lock, so no add can land after a completed Reset.
 	if ok {
 		c.hits.Add(1)
 	} else {
 		c.misses.Add(1)
 	}
+	c.mu.RUnlock()
 	return ok
 }
 

--- a/clients/go/consensus/sig_cache_test.go
+++ b/clients/go/consensus/sig_cache_test.go
@@ -235,6 +235,19 @@ func TestSigCache_NilSafe(t *testing.T) {
 	c.Reset() // should not panic
 }
 
+func TestSigCache_ZeroValueIsANoOp(t *testing.T) {
+	var c SigCache // not built by NewSigCache: no map, no ring
+	pk, sig, d := syntheticSigCacheTuple(0x01)
+	c.Insert(SUITE_ID_ML_DSA_87, pk, sig, d)
+	c.insertBound([]byte("binding"), SUITE_ID_ML_DSA_87, pk, sig, d)
+	if c.Lookup(SUITE_ID_ML_DSA_87, pk, sig, d) || c.lookupBound([]byte("binding"), SUITE_ID_ML_DSA_87, pk, sig, d) {
+		t.Fatal("zero-value cache must never report a hit")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("zero-value cache len=%d, want 0", c.Len())
+	}
+}
+
 func TestSigCache_Reset(t *testing.T) {
 	c := NewSigCache(10)
 	kp := mustMLDSA87Keypair(t)

--- a/clients/go/consensus/sig_cache_test.go
+++ b/clients/go/consensus/sig_cache_test.go
@@ -66,16 +66,156 @@ func TestSigCache_BoundedCapacity(t *testing.T) {
 		t.Fatalf("expected len=2 (bounded), got %d", c.Len())
 	}
 
-	// First two should be present.
-	for i := 0; i < 2; i++ {
+	// FIFO at saturation: the OLDEST insertion left, the newest entered.
+	if c.Lookup(SUITE_ID_ML_DSA_87, kp.PubkeyBytes(), entries[0].sig, entries[0].digest) {
+		t.Fatalf("entry 0 should have been evicted (oldest insertion, capacity=2)")
+	}
+	for i := 1; i < 3; i++ {
 		if !c.Lookup(SUITE_ID_ML_DSA_87, kp.PubkeyBytes(), entries[i].sig, entries[i].digest) {
 			t.Fatalf("entry %d should be in cache", i)
 		}
 	}
+}
 
-	// Third should be absent (dropped due to capacity).
-	if c.Lookup(SUITE_ID_ML_DSA_87, kp.PubkeyBytes(), entries[2].sig, entries[2].digest) {
-		t.Fatalf("entry 2 should have been dropped (capacity=2)")
+// syntheticSigCacheTuple builds distinct, cheap (pubkey, sig, digest) bytes for
+// cache-mechanics tests that do not need a real signature.
+func syntheticSigCacheTuple(seed byte) (pubkey, sig []byte, digest [32]byte) {
+	pubkey = []byte{0xa0, seed}
+	sig = []byte{0x50, seed}
+	digest[0] = seed
+	return pubkey, sig, digest
+}
+
+// TestSigCache_FIFOEvictsOldestAndHitsDoNotRefreshOrder pins the deterministic
+// insertion-order FIFO contract: at saturation the oldest INSERTION is evicted
+// so a newly verified tuple always enters, and a lookup hit never moves an
+// entry's eviction position (which would make eviction access-order/LRU and let
+// lookup traffic steer it).
+func TestSigCache_FIFOEvictsOldestAndHitsDoNotRefreshOrder(t *testing.T) {
+	c := NewSigCache(2)
+	pkA, sigA, dA := syntheticSigCacheTuple(0xa1)
+	pkB, sigB, dB := syntheticSigCacheTuple(0xb2)
+	pkC, sigC, dC := syntheticSigCacheTuple(0xc3)
+
+	c.Insert(SUITE_ID_ML_DSA_87, pkA, sigA, dA)
+	c.Insert(SUITE_ID_ML_DSA_87, pkB, sigB, dB)
+
+	// Hit A repeatedly, then re-insert it: neither may refresh its position.
+	for i := 0; i < 3; i++ {
+		if !c.Lookup(SUITE_ID_ML_DSA_87, pkA, sigA, dA) {
+			t.Fatalf("A must be cached before saturation")
+		}
+	}
+	c.Insert(SUITE_ID_ML_DSA_87, pkA, sigA, dA)
+	if c.Len() != 2 {
+		t.Fatalf("re-insert of a present key changed len: got %d, want 2", c.Len())
+	}
+
+	c.Insert(SUITE_ID_ML_DSA_87, pkC, sigC, dC)
+	if c.Len() != 2 {
+		t.Fatalf("len=%d after saturating insert, want 2", c.Len())
+	}
+	if c.Lookup(SUITE_ID_ML_DSA_87, pkA, sigA, dA) {
+		t.Fatal("A (oldest insertion) must be evicted despite its lookup hits")
+	}
+	if !c.Lookup(SUITE_ID_ML_DSA_87, pkB, sigB, dB) {
+		t.Fatal("B must survive: it was inserted after A")
+	}
+	if !c.Lookup(SUITE_ID_ML_DSA_87, pkC, sigC, dC) {
+		t.Fatal("C (newly verified) must be admitted at saturation")
+	}
+
+	// Next insert evicts B, the new oldest — the ring keeps advancing.
+	pkD, sigD, dD := syntheticSigCacheTuple(0xd4)
+	c.Insert(SUITE_ID_ML_DSA_87, pkD, sigD, dD)
+	if c.Lookup(SUITE_ID_ML_DSA_87, pkB, sigB, dB) {
+		t.Fatal("B must be evicted next")
+	}
+	if !c.Lookup(SUITE_ID_ML_DSA_87, pkC, sigC, dC) || !c.Lookup(SUITE_ID_ML_DSA_87, pkD, sigD, dD) {
+		t.Fatal("C and D must both be resident after the second eviction")
+	}
+}
+
+// TestSigCache_BoundKeyIsInjectiveAndDomainSeparated falsifies a cache key that
+// drops the resolved-binding component or that lets two different component
+// tuples alias each other. Every row below differs in exactly one component and
+// must therefore produce a different key.
+func TestSigCache_BoundKeyIsInjectiveAndDomainSeparated(t *testing.T) {
+	base := struct {
+		bindingID []byte
+		suiteID   uint8
+		pubkey    []byte
+		sig       []byte
+		digest    [32]byte
+	}{
+		bindingID: []byte("binding-v1"),
+		suiteID:   SUITE_ID_ML_DSA_87,
+		pubkey:    []byte{0x01, 0x02, 0x03},
+		sig:       []byte{0x04, 0x05},
+		digest:    [32]byte{0xff},
+	}
+	want := sigCacheBoundKey(base.bindingID, base.suiteID, base.pubkey, base.sig, base.digest)
+	if got := sigCacheBoundKey(base.bindingID, base.suiteID, base.pubkey, base.sig, base.digest); got != want {
+		t.Fatal("same components must produce the same key")
+	}
+
+	otherDigest := base.digest
+	otherDigest[31] = 0x01
+	cases := []struct {
+		name string
+		key  [32]byte
+	}{
+		{"different_binding_identity", sigCacheBoundKey([]byte("binding-v2"), base.suiteID, base.pubkey, base.sig, base.digest)},
+		{"binding_identity_absent", sigCacheBoundKey(nil, base.suiteID, base.pubkey, base.sig, base.digest)},
+		{"different_suite_id", sigCacheBoundKey(base.bindingID, 0x02, base.pubkey, base.sig, base.digest)},
+		{"different_pubkey", sigCacheBoundKey(base.bindingID, base.suiteID, []byte{0x01, 0x02, 0x04}, base.sig, base.digest)},
+		{"different_signature", sigCacheBoundKey(base.bindingID, base.suiteID, base.pubkey, []byte{0x04, 0x06}, base.digest)},
+		{"different_digest", sigCacheBoundKey(base.bindingID, base.suiteID, base.pubkey, base.sig, otherDigest)},
+		// Re-split of the same concatenated bytes across the field boundary.
+		{"pubkey_signature_resplit", sigCacheBoundKey(base.bindingID, base.suiteID, []byte{0x01, 0x02}, []byte{0x03, 0x04, 0x05}, base.digest)},
+		// A binding-inclusive key can never equal a legacy suite-only key.
+		{"legacy_domain", sigCacheKey(base.suiteID, base.pubkey, base.sig, base.digest)},
+	}
+	for _, tc := range cases {
+		if tc.key == want {
+			t.Fatalf("%s: key collides with the base tuple key", tc.name)
+		}
+	}
+}
+
+// TestSigCache_ConcurrentInsertLookupEvictReset drives insert, lookup, FIFO
+// eviction, and Reset from concurrent goroutines under -race. The invariant is
+// that the cache never exceeds capacity and never panics; residency is
+// deliberately not asserted because Reset races with insertion by design.
+func TestSigCache_ConcurrentInsertLookupEvictReset(t *testing.T) {
+	const capacity = 8
+	c := NewSigCache(capacity)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				pk, sig, d := syntheticSigCacheTuple(byte(gid*8 + i%8))
+				d[1] = byte(i)
+				c.Insert(SUITE_ID_ML_DSA_87, pk, sig, d)
+				c.lookupBound([]byte("binding"), SUITE_ID_ML_DSA_87, pk, sig, d)
+				c.insertBound([]byte("binding"), SUITE_ID_ML_DSA_87, pk, sig, d)
+				c.Lookup(SUITE_ID_ML_DSA_87, pk, sig, d)
+				if n := c.Len(); n > capacity {
+					t.Errorf("cache len=%d exceeds capacity %d", n, capacity)
+					return
+				}
+				if gid == 0 && i%50 == 0 {
+					c.Reset()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	if n := c.Len(); n > capacity {
+		t.Fatalf("final cache len=%d exceeds capacity %d", n, capacity)
 	}
 }
 

--- a/clients/go/consensus/spend_verify.go
+++ b/clients/go/consensus/spend_verify.go
@@ -59,7 +59,10 @@ type spendSigContext struct {
 	chainID    [32]byte
 	cache      *SighashV1PrehashCache
 	registry   *SuiteRegistry
-	context    string
+	// sigCache is the optional caller-owned positive signature cache. Nil (the
+	// default for every block-validation path) means exact uncached behavior.
+	sigCache *SigCache
+	context  string
 }
 
 // verifyKeyAndSigWithRegistryCache verifies a witness item's key binding and
@@ -74,7 +77,7 @@ func verifyKeyAndSigWithRegistryCache(w WitnessItem, expectedKeyID [32]byte, ctx
 	if err != nil {
 		return err
 	}
-	ok, err := verifySigWithRegistry(w.SuiteID, w.Pubkey, cryptoSig, digest, ctx.registry)
+	ok, err := verifySigWithRegistryCache(w.SuiteID, w.Pubkey, cryptoSig, digest, ctx.registry, ctx.sigCache)
 	if err != nil {
 		return err
 	}

--- a/clients/go/consensus/stealth.go
+++ b/clients/go/consensus/stealth.go
@@ -48,6 +48,7 @@ type coreStealthSpendValidation struct {
 	cache       *SighashV1PrehashCache
 	rotation    RotationProvider
 	registry    *SuiteRegistry
+	sigCache    *SigCache
 }
 
 // validateCoreStealthSpendAtHeight validates a stealth spend using the suite
@@ -86,6 +87,7 @@ func validateCoreStealthSpendAtHeight(input coreStealthSpendValidation) error {
 		chainID:    input.chainID,
 		cache:      input.cache,
 		registry:   input.registry,
+		sigCache:   input.sigCache,
 		context:    "CORE_STEALTH",
 	})
 }

--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -27,9 +27,19 @@ type ParsedTxIDs struct {
 	WTxID [32]byte
 }
 
+// SuiteValidationContext is the suite-aware validation seam for an already
+// parsed transaction.
+//
+// SigCache is the caller-owned positive-only signature cache. It is OPTIONAL:
+// nil means exact uncached validation, which is what every block-validation
+// caller passes. A non-nil cache may only ever let the sequential native
+// signature paths skip a backend verification call for a tuple that already
+// verified successfully under the same resolved verifier binding; it never
+// caches transaction validity, an admission result, or any failure.
 type SuiteValidationContext struct {
 	Rotation RotationProvider
 	Registry *SuiteRegistry
+	SigCache *SigCache
 }
 
 func P2PKCovenantDataForPubkey(pub []byte) []byte {
@@ -142,6 +152,7 @@ func CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		chainID:  chainID,
 		rotation: suite.Rotation,
 		registry: suite.Registry,
+		sigCache: suite.SigCache,
 	})
 	if err != nil {
 		return nil, err

--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -103,6 +103,30 @@ func CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) (*CheckedTransaction, error) {
+	return CheckTransactionWithOwnedUtxoSetAndValidationContext(
+		txBytes,
+		workUtxos,
+		height,
+		blockMTP,
+		chainID,
+		SuiteValidationContext{Rotation: rotation, Registry: registry},
+	)
+}
+
+// CheckTransactionWithOwnedUtxoSetAndValidationContext is the
+// SuiteValidationContext-bearing sibling of
+// CheckTransactionWithOwnedUtxoSetAndSuiteContext: identical parse, validation
+// and error contract, but the caller supplies the whole seam, so a caller that
+// owns a positive signature cache can pass it. The positional wrapper above is
+// exactly this call with SigCache left nil (uncached validation).
+func CheckTransactionWithOwnedUtxoSetAndValidationContext(
+	txBytes []byte,
+	workUtxos map[Outpoint]UtxoEntry,
+	height uint64,
+	blockMTP uint64,
+	chainID [32]byte,
+	suite SuiteValidationContext,
+) (*CheckedTransaction, error) {
 	tx, txid, wtxid, consumed, err := ParseTx(txBytes)
 	if err != nil {
 		return nil, err
@@ -119,7 +143,7 @@ func CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 		height,
 		blockMTP,
 		chainID,
-		SuiteValidationContext{Rotation: rotation, Registry: registry},
+		suite,
 	)
 }
 

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -9,6 +9,10 @@ type nonCoinbaseApplyWorkInput struct {
 	chainID  [32]byte
 	rotation RotationProvider
 	registry *SuiteRegistry
+	// sigCache is the optional caller-owned positive signature cache. Block
+	// validation leaves it nil and keeps exact uncached behavior; only the live
+	// Mempool owner passes one, through SuiteValidationContext.
+	sigCache *SigCache
 }
 
 func applyNonCoinbaseTxBasicWork(input nonCoinbaseApplyWorkInput) (map[Outpoint]UtxoEntry, Uint128, error) {
@@ -21,6 +25,7 @@ func applyNonCoinbaseTxBasicWork(input nonCoinbaseApplyWorkInput) (map[Outpoint]
 		chainID:  input.chainID,
 		rotation: input.rotation,
 		registry: input.registry,
+		sigCache: input.sigCache,
 	}).apply()
 }
 
@@ -287,6 +292,7 @@ func (ctx *nonCoinbaseApplyContext) validateP2PKInput(inputIndex int, entry Utxo
 			chainID:    ctx.chainID,
 			cache:      ctx.sighashCache,
 			registry:   ctx.registry,
+			sigCache:   ctx.sigCache,
 		},
 	})
 }
@@ -309,6 +315,7 @@ func (ctx *nonCoinbaseApplyContext) validateMultisigInput(inputIndex int, entry 
 			chainID:    ctx.chainID,
 			cache:      ctx.sighashCache,
 			registry:   ctx.registry,
+			sigCache:   ctx.sigCache,
 			context:    "CORE_MULTISIG",
 		},
 	})
@@ -334,7 +341,21 @@ func (ctx *nonCoinbaseApplyContext) validateHTLCInput(inputIndex int, entry Utxo
 	if len(assigned) != 2 {
 		return txerr(TX_ERR_PARSE, "CORE_HTLC witness_slots must be 2")
 	}
-	return ValidateHTLCSpendAtHeight(entry, assigned[0], assigned[1], ctx.tx, uint32(inputIndex), entry.Value, ctx.chainID, ctx.height, ctx.blockMTP, ctx.sighashCache, ctx.rotation, ctx.registry)
+	return validateHTLCSpendAtHeightWithSigCache(htlcSpendCheck{
+		entry:       entry,
+		pathItem:    assigned[0],
+		sigItem:     assigned[1],
+		tx:          ctx.tx,
+		inputIndex:  uint32(inputIndex),
+		inputValue:  entry.Value,
+		chainID:     ctx.chainID,
+		blockHeight: ctx.height,
+		blockMTP:    ctx.blockMTP,
+		cache:       ctx.sighashCache,
+		rotation:    ctx.rotation,
+		registry:    ctx.registry,
+		sigCache:    ctx.sigCache,
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) validateCoreStealthInput(inputIndex int, entry UtxoEntry, assigned []WitnessItem) error {
@@ -352,6 +373,7 @@ func (ctx *nonCoinbaseApplyContext) validateCoreStealthInput(inputIndex int, ent
 		cache:       ctx.sighashCache,
 		rotation:    ctx.rotation,
 		registry:    ctx.registry,
+		sigCache:    ctx.sigCache,
 	})
 }
 

--- a/clients/go/consensus/utxo_basic_common.go
+++ b/clients/go/consensus/utxo_basic_common.go
@@ -202,6 +202,7 @@ type nonCoinbaseApplyContext struct {
 	rotation      RotationProvider
 	registry      *SuiteRegistry
 	sighashCache  *SighashV1PrehashCache
+	sigCache      *SigCache
 	resolved      []nonCoinbaseResolvedInput
 	simplicityCtx *SimplicityTxContext
 	spend         nonCoinbaseSpendState

--- a/clients/go/consensus/utxo_basic_vault.go
+++ b/clients/go/consensus/utxo_basic_vault.go
@@ -94,7 +94,10 @@ func (ctx *nonCoinbaseApplyContext) validateVaultSpendSignature() error {
 			chainID:    ctx.chainID,
 			cache:      ctx.sighashCache,
 			registry:   ctx.registry,
-			context:    "CORE_VAULT",
+			// The Vault threshold path shares the one caller-owned positive
+			// signature cache with every other sequential native path.
+			sigCache: ctx.sigCache,
+			context:  "CORE_VAULT",
 		},
 	})
 }

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -176,6 +176,7 @@ static int rubin_verify_sig_oneshot(
 import "C"
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -564,6 +565,56 @@ func runtimeSuiteParamsForVerification(suiteID uint8, registry *SuiteRegistry) (
 // AlgName alone. Runtime verification resolves an explicit v1 binding from
 // the suite parameters so existing suites cannot switch backend silently.
 func verifySigWithRegistry(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, registry *SuiteRegistry) (bool, error) {
+	return verifySigWithRegistryCache(suiteID, pubkey, signature, digest32, registry, nil)
+}
+
+// sigCacheVerifierBindingIdentity encodes the RESOLVED verifier binding as
+// canonical identity bytes for the live signature-cache key.
+//
+// Injectivity: every component is either fixed-width (the binding kind byte, the
+// suite ID byte, the le64 integers) or length-prefixed (the algorithm names), so
+// the buffer parses back into exactly one (binding, params) pair left-to-right.
+// Two different resolved bindings — a different binding kind, a different
+// backend algorithm, different canonical lengths — and two different registry
+// entries behind the same suite ID therefore always produce different identity
+// bytes, and hence different cache keys.
+func sigCacheVerifierBindingIdentity(params SuiteParams, binding suiteVerifierBinding) []byte {
+	buf := make([]byte, 0, 64+len(binding.opensslAlg)+len(params.AlgName))
+	buf = append(buf, byte(binding.kind))
+	buf = appendSigCacheLenPrefixed(buf, []byte(binding.opensslAlg))
+	buf = appendSigCacheInt(buf, binding.pubkeyLen)
+	buf = appendSigCacheInt(buf, binding.sigLen)
+	buf = append(buf, params.SuiteID)
+	buf = appendSigCacheLenPrefixed(buf, []byte(params.AlgName))
+	buf = appendSigCacheInt(buf, params.PubkeyLen)
+	buf = appendSigCacheInt(buf, params.SigLen)
+	var cost [8]byte
+	binary.LittleEndian.PutUint64(cost[:], params.VerifyCost)
+	return append(buf, cost[:]...)
+}
+
+// verifySigWithRegistryCache is verifySigWithRegistry with an optional
+// positive-only signature cache.
+//
+// A nil cache is byte-for-byte the uncached path. With a cache, the ONLY step a
+// hit may skip is the verifySigWithBinding backend call, and only after every
+// authority check of this run already succeeded on this run:
+//
+//	registry lookup and runtime-registry drift check -> OpenSSL consensus init
+//	-> live verifier-binding resolution -> canonical length check
+//	-> binding-inclusive cache lookup -> backend on miss -> insert on success.
+//
+// Nothing else is cached: an invalid result, a backend error, an unknown suite,
+// a registry or binding resolution failure, and a non-canonical length never
+// insert, and none of them can be answered from the cache.
+func verifySigWithRegistryCache(
+	suiteID uint8,
+	pubkey []byte,
+	signature []byte,
+	digest32 [32]byte,
+	registry *SuiteRegistry,
+	cache *SigCache,
+) (bool, error) {
 	params, err := runtimeSuiteParamsForVerification(suiteID, registry)
 	if err != nil {
 		return false, err
@@ -575,5 +626,25 @@ func verifySigWithRegistry(suiteID uint8, pubkey []byte, signature []byte, diges
 	if err != nil {
 		return false, wrapResolveSuiteVerifierBindingError(suiteID, err)
 	}
-	return verifySigWithBinding(binding, pubkey, signature, digest32)
+	if cache == nil {
+		return verifySigWithBinding(binding, pubkey, signature, digest32)
+	}
+	// The canonical length check runs BEFORE the cache is consulted, so a
+	// non-canonical tuple can never be answered from the cache. This mirrors
+	// verifySigWithBinding's own first check, which the miss path repeats.
+	if len(pubkey) != binding.pubkeyLen || len(signature) != binding.sigLen {
+		return false, nil
+	}
+	bindingID := sigCacheVerifierBindingIdentity(params, binding)
+	if cache.lookupBound(bindingID, suiteID, pubkey, signature, digest32) {
+		return true, nil
+	}
+	ok, err := verifySigWithBinding(binding, pubkey, signature, digest32)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		cache.insertBound(bindingID, suiteID, pubkey, signature, digest32)
+	}
+	return ok, nil
 }

--- a/clients/go/consensus/verify_sig_registry_test.go
+++ b/clients/go/consensus/verify_sig_registry_test.go
@@ -3,6 +3,7 @@
 package consensus
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1083,5 +1084,495 @@ func TestVerifyKeyAndSigWithRegistryCache_Success(t *testing.T) {
 	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live positive SigCache (RUB-1121)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// liveSigCacheBackend is the counting backend seam for the live-cache tests. It
+// is the honest way to prove "a hit skips exactly the backend call and nothing
+// else" and "a miss executes it exactly once": every assertion below is against
+// the observed call count, never against an argument about control flow.
+type liveSigCacheBackend struct {
+	calls int
+	ok    bool
+	err   error
+}
+
+func newLiveSigCacheBackend(t *testing.T, ok bool, err error) *liveSigCacheBackend {
+	t.Helper()
+	backend := &liveSigCacheBackend{ok: ok, err: err}
+	orig := opensslVerifySigOneShotFn
+	opensslVerifySigOneShotFn = func(_ string, _, _, _ []byte) (bool, error) {
+		backend.calls++
+		return backend.ok, backend.err
+	}
+	t.Cleanup(func() { opensslVerifySigOneShotFn = orig })
+	return backend
+}
+
+// liveSigCacheTuple returns canonical-length ML-DSA-87 witness bytes plus a
+// digest, all derived from seed so distinct seeds never alias.
+func liveSigCacheTuple(seed byte) (pubkey, sig []byte, digest [32]byte) {
+	pubkey = make([]byte, ML_DSA_87_PUBKEY_BYTES)
+	pubkey[0] = seed
+	sig = make([]byte, ML_DSA_87_SIG_BYTES)
+	sig[0] = seed
+	digest[0] = seed
+	return pubkey, sig, digest
+}
+
+// registryWithAlg returns a registry whose ML-DSA-87 suite ID maps to a
+// different algorithm identity, i.e. a changed registry mapping behind the same
+// suite ID.
+func registryWithAlg(alg string) *SuiteRegistry {
+	params := canonicalDefaultRuntimeSuiteParams()
+	params.AlgName = alg
+	return NewSuiteRegistryFromParams([]SuiteParams{params})
+}
+
+func TestLiveSigCacheHitSkipsOnlyTheBackendCall(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(4)
+	reg := DefaultSuiteRegistry()
+	pub, sig, digest := liveSigCacheTuple(0x11)
+
+	ok, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pub, sig, digest, reg, cache)
+	if err != nil || !ok {
+		t.Fatalf("first verify: ok=%v err=%v", ok, err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("miss must execute the backend exactly once, got %d calls", backend.calls)
+	}
+	if cache.Len() != 1 || cache.Misses() != 1 || cache.Hits() != 0 {
+		t.Fatalf("after miss: len=%d misses=%d hits=%d, want 1/1/0", cache.Len(), cache.Misses(), cache.Hits())
+	}
+
+	ok, err = verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pub, sig, digest, reg, cache)
+	if err != nil || !ok {
+		t.Fatalf("second verify: ok=%v err=%v", ok, err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("hit must skip the backend, got %d calls", backend.calls)
+	}
+	if cache.Hits() != 1 || cache.Len() != 1 {
+		t.Fatalf("after hit: hits=%d len=%d, want 1/1", cache.Hits(), cache.Len())
+	}
+
+	// A different digest, pubkey, signature, or suite is a different tuple.
+	otherPub, otherSig, otherDigest := liveSigCacheTuple(0x22)
+	for _, tc := range []struct {
+		name   string
+		pub    []byte
+		sig    []byte
+		digest [32]byte
+	}{
+		{"different_digest", pub, sig, otherDigest},
+		{"different_pubkey", otherPub, sig, digest},
+		{"different_signature", pub, otherSig, digest},
+	} {
+		before := backend.calls
+		if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, tc.pub, tc.sig, tc.digest, reg, cache); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if backend.calls != before+1 {
+			t.Fatalf("%s must miss and execute the backend once", tc.name)
+		}
+	}
+}
+
+func TestLiveSigCacheNilCacheIsExactBaseline(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	pub, sig, digest := liveSigCacheTuple(0x33)
+
+	for i := 1; i <= 3; i++ {
+		ok, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pub, sig, digest, DefaultSuiteRegistry(), nil)
+		if err != nil || !ok {
+			t.Fatalf("run %d: ok=%v err=%v", i, ok, err)
+		}
+		if backend.calls != i {
+			t.Fatalf("nil cache must execute the backend every run: calls=%d, want %d", backend.calls, i)
+		}
+	}
+}
+
+func TestLiveSigCacheNeverInsertsUnsuccessfulResults(t *testing.T) {
+	backendErr := errors.New("backend exploded")
+	cases := []struct {
+		name     string
+		ok       bool
+		err      error
+		registry *SuiteRegistry
+		suiteID  uint8
+		wantCode ErrorCode
+		wantCall bool
+	}{
+		{name: "invalid_signature", ok: false, registry: DefaultSuiteRegistry(), suiteID: SUITE_ID_ML_DSA_87, wantCall: true},
+		{name: "backend_error", ok: false, err: backendErr, registry: DefaultSuiteRegistry(), suiteID: SUITE_ID_ML_DSA_87, wantCode: TX_ERR_SIG_INVALID, wantCall: true},
+		{name: "unknown_suite", ok: true, registry: DefaultSuiteRegistry(), suiteID: 0x7e, wantCode: TX_ERR_SIG_ALG_INVALID},
+		{name: "registry_mapping_changed", ok: true, registry: registryWithAlg("ML-DSA-44"), suiteID: SUITE_ID_ML_DSA_87, wantCode: TX_ERR_SIG_ALG_INVALID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := newLiveSigCacheBackend(t, tc.ok, tc.err)
+			cache := NewSigCache(4)
+			pub, sig, digest := liveSigCacheTuple(0x44)
+
+			ok, err := verifySigWithRegistryCache(tc.suiteID, pub, sig, digest, tc.registry, cache)
+			if ok {
+				t.Fatal("expected a non-accepting result")
+			}
+			switch {
+			case tc.wantCode == "":
+				if err != nil {
+					t.Fatalf("want (false, nil), got err=%v", err)
+				}
+			default:
+				if got := mustTxErrCode(t, err); got != tc.wantCode {
+					t.Fatalf("code=%s, want %s", got, tc.wantCode)
+				}
+			}
+			if tc.wantCall && backend.calls != 1 {
+				t.Fatalf("backend calls=%d, want 1", backend.calls)
+			}
+			if !tc.wantCall && backend.calls != 0 {
+				t.Fatalf("backend must not run before the failing check: calls=%d", backend.calls)
+			}
+			if cache.Len() != 0 {
+				t.Fatalf("no unsuccessful result may be inserted: len=%d", cache.Len())
+			}
+		})
+	}
+}
+
+// TestLiveSigCacheStaleBindingAndLengthCannotHit pins the two ways a cached
+// tuple must NOT be reusable: after the registry mapping behind the suite ID
+// changed (resolution now fails closed), and for a non-canonical length whose
+// bytes share the cached prefix.
+func TestLiveSigCacheStaleBindingAndLengthCannotHit(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(4)
+	pub, sig, digest := liveSigCacheTuple(0x55)
+
+	if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pub, sig, digest, DefaultSuiteRegistry(), cache); err != nil {
+		t.Fatalf("seed verify: %v", err)
+	}
+	if cache.Len() != 1 || backend.calls != 1 {
+		t.Fatalf("seed state: len=%d calls=%d, want 1/1", cache.Len(), backend.calls)
+	}
+	hitsAfterSeed := cache.Hits()
+
+	// Same suite ID, changed registry mapping: fails closed at resolution, so
+	// the older binding-keyed entry cannot be reached at all.
+	_, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pub, sig, digest, registryWithAlg("ML-DSA-44"), cache)
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_ALG_INVALID)
+	}
+	if cache.Hits() != hitsAfterSeed {
+		t.Fatalf("stale binding produced a hit: hits=%d, want %d", cache.Hits(), hitsAfterSeed)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("resolution failure must not reach the backend: calls=%d", backend.calls)
+	}
+
+	// Non-canonical lengths sharing the cached byte prefix: rejected before the
+	// cache is CONSULTED AT ALL, so neither the hit nor the miss counter moves
+	// and the backend is never reached. The miss counter is the load-bearing
+	// assertion: it is what distinguishes "checked lengths, then looked up"
+	// from "looked up, then checked lengths".
+	missesAfterSeed := cache.Misses()
+	for _, tc := range []struct {
+		name string
+		pub  []byte
+		sig  []byte
+	}{
+		{"short_signature", pub, sig[:len(sig)-1]},
+		{"short_pubkey", pub[:len(pub)-1], sig},
+		{"long_signature", pub, append(append([]byte(nil), sig...), 0x00)},
+	} {
+		ok, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, tc.pub, tc.sig, digest, DefaultSuiteRegistry(), cache)
+		if ok || err != nil {
+			t.Fatalf("%s: ok=%v err=%v, want (false, nil)", tc.name, ok, err)
+		}
+		if cache.Hits() != hitsAfterSeed || cache.Misses() != missesAfterSeed {
+			t.Fatalf("%s consulted the cache: hits=%d misses=%d, want %d/%d",
+				tc.name, cache.Hits(), cache.Misses(), hitsAfterSeed, missesAfterSeed)
+		}
+		if backend.calls != 1 {
+			t.Fatalf("%s reached the backend: calls=%d", tc.name, backend.calls)
+		}
+	}
+}
+
+// TestLiveSigCacheSaturationAdmitsNewestVerifiedTuple covers capacity pressure
+// on the live path: the newest verified tuple always enters and the oldest
+// insertion is the one that has to be re-verified afterwards.
+func TestLiveSigCacheSaturationAdmitsNewestVerifiedTuple(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(1)
+	reg := DefaultSuiteRegistry()
+	pubA, sigA, dA := liveSigCacheTuple(0x66)
+	pubB, sigB, dB := liveSigCacheTuple(0x77)
+
+	if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pubA, sigA, dA, reg, cache); err != nil {
+		t.Fatalf("verify A: %v", err)
+	}
+	if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pubB, sigB, dB, reg, cache); err != nil {
+		t.Fatalf("verify B: %v", err)
+	}
+	if backend.calls != 2 || cache.Len() != 1 {
+		t.Fatalf("calls=%d len=%d, want 2/1", backend.calls, cache.Len())
+	}
+
+	// B (newest) is resident; A was evicted and must be verified again.
+	if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pubB, sigB, dB, reg, cache); err != nil {
+		t.Fatalf("verify B again: %v", err)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("newest tuple must hit: calls=%d, want 2", backend.calls)
+	}
+	if _, err := verifySigWithRegistryCache(SUITE_ID_ML_DSA_87, pubA, sigA, dA, reg, cache); err != nil {
+		t.Fatalf("verify A again: %v", err)
+	}
+	if backend.calls != 3 {
+		t.Fatalf("evicted tuple must re-execute the backend: calls=%d, want 3", backend.calls)
+	}
+}
+
+// TestLiveSigCacheSharedBySequentialSpendPaths proves each supported sequential
+// native signature path consumes the SAME caller-owned cache, and that a
+// key-binding mismatch neither hits nor inserts even when the signature bytes
+// are already cached.
+func TestLiveSigCacheSharedBySequentialSpendPaths(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(16)
+	reg := DefaultSuiteRegistry()
+
+	pub, cryptoSig, _ := liveSigCacheTuple(0x88)
+	keyID := sha3_256(pub)
+	w := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    pub,
+		Signature: append(append([]byte(nil), cryptoSig...), SIGHASH_ALL),
+	}
+	tx := &Tx{
+		Version: TX_WIRE_VERSION,
+		Inputs:  []TxInput{{PrevVout: 0}},
+		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
+	}
+	sigCtx := func() spendSigContext {
+		return spendSigContext{
+			tx:         tx,
+			inputValue: 1000,
+			registry:   reg,
+			sigCache:   cache,
+			context:    "TEST",
+		}
+	}
+
+	// P2PK path.
+	entry := p2pkEntryForPub(t, SUITE_ID_ML_DSA_87, pub)
+	p2pk := p2pkSpendCheck{entry: entry, witness: w, rotation: DefaultRotationProvider{}, sig: sigCtx()}
+	if err := validateP2PKSpendAtHeight(p2pk); err != nil {
+		t.Fatalf("P2PK first: %v", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("P2PK first must execute the backend once: calls=%d", backend.calls)
+	}
+	if err := validateP2PKSpendAtHeight(p2pk); err != nil {
+		t.Fatalf("P2PK repeat: %v", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("P2PK repeat must hit: calls=%d", backend.calls)
+	}
+
+	// Threshold path (CORE_MULTISIG and CORE_VAULT share it) reuses the same
+	// cached tuple: no further backend call.
+	threshold := thresholdSigSpendCheck{
+		keys:      [][32]byte{keyID},
+		threshold: 1,
+		witnesses: []WitnessItem{w},
+		rotation:  DefaultRotationProvider{},
+		sig:       sigCtx(),
+	}
+	if err := validateThresholdSigSpendAtHeight(threshold); err != nil {
+		t.Fatalf("threshold: %v", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("threshold path must share the cache: calls=%d", backend.calls)
+	}
+
+	// CORE_STEALTH path.
+	stealth := coreStealthSpendValidation{
+		entry:      UtxoEntry{Value: 1000, CovenantType: COV_TYPE_CORE_STEALTH, CovenantData: stealthCovenantDataForKeyID(keyID)},
+		w:          w,
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		rotation:   DefaultRotationProvider{},
+		sigCache:   cache,
+	}
+	if err := validateCoreStealthSpendAtHeight(stealth); err != nil {
+		t.Fatalf("stealth: %v", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("stealth path must share the cache: calls=%d", backend.calls)
+	}
+
+	// Key-binding mismatch with otherwise cached signature bytes: rejected
+	// before verification, no hit, nothing inserted.
+	hits, entries := cache.Hits(), cache.Len()
+	otherPub, _, _ := liveSigCacheTuple(0x99)
+	mismatch := p2pkSpendCheck{
+		entry:    p2pkEntryForPub(t, SUITE_ID_ML_DSA_87, otherPub),
+		witness:  w,
+		rotation: DefaultRotationProvider{},
+		sig:      sigCtx(),
+	}
+	err := validateP2PKSpendAtHeight(mismatch)
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+	if cache.Hits() != hits || cache.Len() != entries || backend.calls != 1 {
+		t.Fatalf("key-binding mismatch touched the cache: hits=%d len=%d calls=%d", cache.Hits(), cache.Len(), backend.calls)
+	}
+}
+
+func TestLiveSigCacheHTLCPathSharesTheOwnerCache(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(4)
+
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0xa5)
+	preimage := []byte("live-sig-cache-htlc-preimage-ok!")
+	entry := makeHTLCEntry(sha3_256(preimage), LOCK_MODE_HEIGHT, 100, claimKeyID, refundKeyID)
+	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	check := htlcSpendCheck{
+		entry:       entry,
+		pathItem:    WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: claimKeyID[:], Signature: encodeHTLCClaimPayload(preimage)},
+		sigItem:     WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: claimPub, Signature: dummyMLSignature(SIGHASH_ALL)},
+		tx:          tx,
+		inputIndex:  inputIndex,
+		inputValue:  inputValue,
+		chainID:     chainID,
+		blockHeight: 3,
+		sigCache:    cache,
+	}
+
+	if err := validateHTLCSpendAtHeightWithSigCache(check); err != nil {
+		t.Fatalf("HTLC first: %v", err)
+	}
+	if backend.calls != 1 || cache.Len() != 1 {
+		t.Fatalf("HTLC first: calls=%d len=%d, want 1/1", backend.calls, cache.Len())
+	}
+	if err := validateHTLCSpendAtHeightWithSigCache(check); err != nil {
+		t.Fatalf("HTLC repeat: %v", err)
+	}
+	if backend.calls != 1 || cache.Hits() != 1 {
+		t.Fatalf("HTLC repeat must hit: calls=%d hits=%d", backend.calls, cache.Hits())
+	}
+
+	// The exported wrapper carries no cache and stays exactly uncached.
+	if err := ValidateHTLCSpendAtHeight(check.entry, check.pathItem, check.sigItem, tx, inputIndex, inputValue, chainID, 3, 0, nil, nil, nil); err != nil {
+		t.Fatalf("HTLC uncached wrapper: %v", err)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("uncached wrapper must execute the backend: calls=%d, want 2", backend.calls)
+	}
+}
+
+func TestLiveSigCacheVaultThresholdSiteUsesTheOwnerCache(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+	cache := NewSigCache(4)
+
+	pub, cryptoSig, _ := liveSigCacheTuple(0xb6)
+	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	ctx := &nonCoinbaseApplyContext{
+		tx:       tx,
+		chainID:  chainID,
+		rotation: DefaultRotationProvider{},
+		registry: DefaultSuiteRegistry(),
+		sigCache: cache,
+	}
+	ctx.spend.vaultSigKeys = [][32]byte{sha3_256(pub)}
+	ctx.spend.vaultSigThreshold = 1
+	ctx.spend.vaultSigWitness = []WitnessItem{{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    pub,
+		Signature: append(append([]byte(nil), cryptoSig...), SIGHASH_ALL),
+	}}
+	ctx.spend.vaultSigInputIndex = inputIndex
+	ctx.spend.vaultSigInputValue = inputValue
+
+	if err := ctx.validateVaultSpendSignature(); err != nil {
+		t.Fatalf("vault first: %v", err)
+	}
+	if backend.calls != 1 || cache.Len() != 1 {
+		t.Fatalf("vault first: calls=%d len=%d, want 1/1", backend.calls, cache.Len())
+	}
+	if err := ctx.validateVaultSpendSignature(); err != nil {
+		t.Fatalf("vault repeat: %v", err)
+	}
+	if backend.calls != 1 || cache.Hits() != 1 {
+		t.Fatalf("vault repeat must hit: calls=%d hits=%d", backend.calls, cache.Hits())
+	}
+}
+
+// TestCheckParsedTransactionSuiteContextSigCacheSeam drives the exact seam the
+// live Mempool uses. It also pins that a caller without a cache — the shape
+// every block-validation caller has — never consumes one.
+func TestCheckParsedTransactionSuiteContextSigCacheSeam(t *testing.T) {
+	backend := newLiveSigCacheBackend(t, true, nil)
+
+	var chainID [32]byte
+	var prev [32]byte
+	prev[0] = 0xc7
+	pub, cryptoSig, _ := liveSigCacheTuple(0xc7)
+	witness := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    pub,
+		Signature: append(append([]byte(nil), cryptoSig...), SIGHASH_ALL),
+	}
+	txBytes := txWithOneInputOneOutputWithWitness(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData(), []WitnessItem{witness})
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: p2pkCovenantDataForPubkey(pub),
+		},
+	}
+	check := func(suite SuiteValidationContext) {
+		t.Helper()
+		if _, err := CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
+			txBytes, tx, ParsedTxIDs{TxID: txid}, copyTestUtxoSet(utxos), 0, 0, chainID, suite,
+		); err != nil {
+			t.Fatalf("CheckParsedTransaction...: %v", err)
+		}
+	}
+
+	// No cache (block-validation shape): every run executes the backend.
+	check(SuiteValidationContext{})
+	check(SuiteValidationContext{})
+	if backend.calls != 2 {
+		t.Fatalf("cacheless seam must verify every run: calls=%d, want 2", backend.calls)
+	}
+
+	cache := NewSigCache(4)
+	check(SuiteValidationContext{SigCache: cache})
+	if backend.calls != 3 || cache.Len() != 1 {
+		t.Fatalf("first cached run: calls=%d len=%d, want 3/1", backend.calls, cache.Len())
+	}
+	check(SuiteValidationContext{SigCache: cache})
+	if backend.calls != 3 || cache.Hits() != 1 {
+		t.Fatalf("repeat cached run must hit: calls=%d hits=%d", backend.calls, cache.Hits())
+	}
+
+	// A cache owned by a different caller shares nothing.
+	other := NewSigCache(4)
+	check(SuiteValidationContext{SigCache: other})
+	if backend.calls != 4 || other.Len() != 1 {
+		t.Fatalf("separate owner cache: calls=%d len=%d, want 4/1", backend.calls, other.Len())
 	}
 }

--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -40,7 +40,13 @@ func (m *Mempool) validateTransactionWithConsensus(
 		nextHeight,
 		blockMTP,
 		m.chainID,
-		consensus.SuiteValidationContext{Rotation: policy.RotationProvider, Registry: policy.SuiteRegistry},
+		// The mempool-owned positive signature cache enters consensus only
+		// here, through the existing suite-aware parsed-transaction seam.
+		consensus.SuiteValidationContext{
+			Rotation: policy.RotationProvider,
+			Registry: policy.SuiteRegistry,
+			SigCache: m.sigCache,
+		},
 	)
 	if err != nil {
 		return nil, txAdmitRejected(err.Error())

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -20,6 +20,11 @@ const (
 
 	mempoolLowWaterNumerator   = 9
 	mempoolLowWaterDenominator = 10
+
+	// mempoolSigCacheCapacity is the fixed process-memory capacity of the one
+	// positive signature cache each Mempool owns. It is not configurable: no
+	// CLI, RPC, config, metric, or persistence surface exposes it.
+	mempoolSigCacheCapacity = 50_000
 )
 
 type mempoolTxSource string
@@ -67,6 +72,15 @@ type Mempool struct {
 	// the former spenders index: outpoint ownership now lives with the claim
 	// and its token, so no second spender map can drift from the records.
 	pendingOutpoints *PendingOutpointOwner
+	// sigCache is the one positive-only signature cache this Mempool owns. It
+	// is constructed empty, lives in process memory only, is never persisted,
+	// and is shared by every sequential native signature path of live
+	// admission validation. A hit lets consensus skip ONLY a previously
+	// successful backend verification call for the exact same tuple under the
+	// same resolved verifier binding — never an admission, duplicate,
+	// conflict, floor, or capacity decision. Block validation and the deferred
+	// SigCheckQueue never see it.
+	sigCache *consensus.SigCache
 	// Admission counters are bumped exactly once for each AddTx call on a
 	// non-nil Mempool that reaches the final outcome accounting path.
 	// Nil-receiver calls return before that defer is registered and are

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -74,10 +74,13 @@ type Mempool struct {
 	pendingOutpoints *PendingOutpointOwner
 	// sigCache is the one positive-only signature cache this Mempool owns. It
 	// is constructed empty, lives in process memory only, and is never
-	// persisted. It reaches consensus through exactly one call site —
-	// validateTransactionWithConsensus, the suite-aware parsed-transaction
-	// seam — where every sequential native signature path (P2PK, multisig,
-	// Vault threshold, HTLC, CORE_STEALTH) shares it. A hit lets consensus
+	// persisted. It reaches consensus through exactly two ratified call sites,
+	// both landing in the suite-aware validation seam every sequential native
+	// signature path (P2PK, multisig, Vault threshold, HTLC, CORE_STEALTH)
+	// shares: validateTransactionWithConsensus (mempolicy_helpers.go), the
+	// parsed-transaction seam used for relay metadata, and
+	// checkTransactionWithSnapshot (mempool_precheck.go), the live AddTx path,
+	// which enters through the raw-bytes helper. A hit lets consensus
 	// skip ONLY a previously successful backend verification call for the
 	// exact same tuple under the same resolved verifier binding — never an
 	// admission, duplicate, conflict, floor, or capacity decision. Block

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -73,13 +73,15 @@ type Mempool struct {
 	// and its token, so no second spender map can drift from the records.
 	pendingOutpoints *PendingOutpointOwner
 	// sigCache is the one positive-only signature cache this Mempool owns. It
-	// is constructed empty, lives in process memory only, is never persisted,
-	// and is shared by every sequential native signature path of live
-	// admission validation. A hit lets consensus skip ONLY a previously
-	// successful backend verification call for the exact same tuple under the
-	// same resolved verifier binding — never an admission, duplicate,
-	// conflict, floor, or capacity decision. Block validation and the deferred
-	// SigCheckQueue never see it.
+	// is constructed empty, lives in process memory only, and is never
+	// persisted. It reaches consensus through exactly one call site —
+	// validateTransactionWithConsensus, the suite-aware parsed-transaction
+	// seam — where every sequential native signature path (P2PK, multisig,
+	// Vault threshold, HTLC, CORE_STEALTH) shares it. A hit lets consensus
+	// skip ONLY a previously successful backend verification call for the
+	// exact same tuple under the same resolved verifier binding — never an
+	// admission, duplicate, conflict, floor, or capacity decision. Block
+	// validation, the miner, and the deferred SigCheckQueue never see it.
 	sigCache *consensus.SigCache
 	// Admission counters are bumped exactly once for each AddTx call on a
 	// non-nil Mempool that reaches the final outcome accounting path.

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -99,14 +99,20 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 			return nil, nil, txAdmitRejected(reason)
 		}
 	}
-	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndSuiteContext(
+	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndValidationContext(
 		txBytes,
 		snapshot.utxos,
 		nextHeight,
 		blockMTP,
 		m.chainID,
-		policy.RotationProvider,
-		policy.SuiteRegistry,
+		// Same validation, same order, same errors: the only difference from
+		// the positional wrapper is that the live AddTx path carries this
+		// Mempool's positive signature cache into the suite-aware seam.
+		consensus.SuiteValidationContext{
+			Rotation: policy.RotationProvider,
+			Registry: policy.SuiteRegistry,
+			SigCache: m.sigCache,
+		},
 	)
 	if err != nil {
 		return nil, nil, txAdmitRejected(err.Error())

--- a/clients/go/node/mempool_stats.go
+++ b/clients/go/node/mempool_stats.go
@@ -137,6 +137,9 @@ func NewMempoolWithConfig(chainState *ChainState, blockStore *BlockStore, chainI
 		// Exactly one owner per mempool, initialized from the bound
 		// ChainState stable tip. Nothing else constructs one.
 		pendingOutpoints: newPendingOutpointOwner(pendingOutpointTipOf(chainState)),
+		// Exactly one positive signature cache per mempool, empty at
+		// construction and never persisted.
+		sigCache: consensus.NewSigCache(mempoolSigCacheCapacity),
 	}, nil
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5836,3 +5836,98 @@ func TestMempoolSigCacheNilCacheAddTxMatchesBaseline(t *testing.T) {
 			uncachedErr, cachedErr, uncachedLen, cachedLen, uncachedTxid, cachedTxid)
 	}
 }
+
+// TestMempoolSigCacheWarmCacheNeverBuysAdmission pins the hostile admission
+// rows on the LIVE AddTx path: a positive cache hit is never an admission-result
+// hit. Each row warms the owner cache through the validation-only relay seam
+// (which claims no outpoint), then proves the conflict and capacity authorities
+// fire exactly as they would with a cold cache.
+func TestMempoolSigCacheWarmCacheNeverBuysAdmission(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	newPool := func(t *testing.T) (*Mempool, *ChainState, []consensus.Outpoint) {
+		t.Helper()
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+		mp, err := NewMempool(st, nil, devnetGenesisChainID)
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		return mp, st, outpoints
+	}
+
+	// The cache is warmed with the CONFLICTING transaction's own signature, so
+	// its verification is a genuine hit — admission is still refused by the
+	// pending-outpoint authority with its exact existing message.
+	t.Run("conflict", func(t *testing.T) {
+		mp, st, ops := newPool(t)
+		txA := mustBuildSignedTransferTx(t, st.Utxos, ops[:1], 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+		txB := mustBuildSignedTransferTx(t, st.Utxos, ops[:1], 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+		txidA, txidB := txID(t, txA), txID(t, txB)
+		if txidA == txidB {
+			t.Fatalf("conflict row needs distinct txids, got %x twice", txidA)
+		}
+		if _, err := mp.RelayMetadata(txB); err != nil {
+			t.Fatalf("RelayMetadata(txB): %v", err)
+		}
+		if err := mp.AddTx(txA); err != nil {
+			t.Fatalf("AddTx(txA): %v", err)
+		}
+		if mp.sigCache.Len() != 2 || mp.sigCache.Hits() != 0 || mp.sigCache.Misses() != 2 {
+			t.Fatalf("warm state: len=%d hits=%d misses=%d, want 2/0/2",
+				mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses())
+		}
+		var txErr *TxAdmitError
+		if err := mp.AddTx(txB); !errors.As(err, &txErr) || txErr.Kind != TxAdmitConflict {
+			t.Fatalf("AddTx(txB) err=%T %v, want TxAdmitConflict", err, err)
+		}
+		if want := fmt.Sprintf("mempool double-spend conflict with %x", txidA); txErr.Message != want {
+			t.Fatalf("conflict message %q, want %q", txErr.Message, want)
+		}
+		if mp.Len() != 1 || mp.txs[txidA] == nil || mp.txs[txidB] != nil {
+			t.Fatalf("conflicting tx changed the resident set: len=%d", mp.Len())
+		}
+		if got := mp.AdmissionCounts(); got != (MempoolAdmissionCounts{Accepted: 1, Conflict: 1}) {
+			t.Fatalf("admission counts=%+v, want accepted=1 conflict=1", got)
+		}
+		// B's signature WAS answered from cache (hit, no backend call) and the
+		// rejected admission inserted nothing.
+		if mp.sigCache.Hits() != 1 || mp.sigCache.Misses() != 2 || mp.sigCache.Len() != 2 {
+			t.Fatalf("after conflict: hits=%d misses=%d len=%d, want 1/2/2",
+				mp.sigCache.Hits(), mp.sigCache.Misses(), mp.sigCache.Len())
+		}
+	})
+
+	// Saturation at the production capacity constant is a performance state,
+	// never a verdict. The fill uses the exported legacy-domain API: those keys
+	// only occupy capacity, they live in a different key domain than the live
+	// seam's binding-inclusive keys and can never be mistaken for a result.
+	t.Run("saturation", func(t *testing.T) {
+		mp, st, ops := newPool(t)
+		var digest [32]byte
+		for i := 0; i < mempoolSigCacheCapacity; i++ {
+			digest[0], digest[1], digest[2] = byte(i), byte(i>>8), byte(i>>16)
+			mp.sigCache.Insert(0x01, []byte("saturation-pubkey"), []byte("saturation-sig"), digest)
+		}
+		if mp.sigCache.Len() != mempoolSigCacheCapacity {
+			t.Fatalf("cache not saturated: len=%d, want %d", mp.sigCache.Len(), mempoolSigCacheCapacity)
+		}
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, ops[:1], 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("saturated cache must never reject admission: %v", err)
+		}
+		if mp.Len() != 1 || mp.txs[txID(t, txBytes)] == nil {
+			t.Fatalf("tx not resident after admission: len=%d", mp.Len())
+		}
+		// FIFO evicted exactly one older entry, and the newest entry survived:
+		// revalidating the same transaction hits with no new backend call.
+		if _, err := mp.RelayMetadata(txBytes); err != nil {
+			t.Fatalf("RelayMetadata(repeat): %v", err)
+		}
+		if mp.sigCache.Len() != mempoolSigCacheCapacity || mp.sigCache.Hits() != 1 || mp.sigCache.Misses() != 1 {
+			t.Fatalf("under saturation: len=%d hits=%d misses=%d, want %d/1/1",
+				mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses(), mempoolSigCacheCapacity)
+		}
+	})
+}

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5750,3 +5750,89 @@ func TestMempoolSigCacheAlternateWitnessWithSameTxidCannotHit(t *testing.T) {
 			mp.sigCache.Misses(), mp.sigCache.Len())
 	}
 }
+
+// TestMempoolSigCacheAddTxPathReusesPositiveResults pins the LIVE admission
+// path (AddTx -> addTxWithSource -> checkTransactionWithSnapshot) on the one
+// mempool-owned cache. Backend executions are counted by Misses(): the live
+// seam calls the backend exactly once per miss and never on a hit, which
+// clients/go/consensus/verify_sig_registry_test.go pins directly against the
+// backend call counter. So a second admission of the same signed transaction
+// that adds a hit and no miss added zero backend calls.
+//
+// The repeat is rejected as a duplicate, which is the point: a positive cache
+// hit is not an admission-result hit — every non-backend check still runs.
+func TestMempoolSigCacheAddTxPathReusesPositiveResults(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	if mp.sigCache.Misses() != 1 || mp.sigCache.Hits() != 0 || mp.sigCache.Len() != 1 {
+		t.Fatalf("first AddTx must miss and insert once: misses=%d hits=%d len=%d, want 1/0/1",
+			mp.sigCache.Misses(), mp.sigCache.Hits(), mp.sigCache.Len())
+	}
+
+	if err := mp.AddTx(txBytes); err == nil {
+		t.Fatal("duplicate AddTx unexpectedly accepted")
+	}
+	if mp.sigCache.Hits() != 1 {
+		t.Fatalf("repeat admission must hit the owner cache: hits=%d, want 1", mp.sigCache.Hits())
+	}
+	if mp.sigCache.Misses() != 1 {
+		t.Fatalf("repeat admission must add zero backend calls: misses=%d, want 1", mp.sigCache.Misses())
+	}
+	if mp.sigCache.Len() != 1 {
+		t.Fatalf("a hit must not insert: len=%d, want 1", mp.sigCache.Len())
+	}
+	if mp.Len() != 1 {
+		t.Fatalf("duplicate must not be admitted twice: len=%d, want 1", mp.Len())
+	}
+}
+
+// TestMempoolSigCacheNilCacheAddTxMatchesBaseline proves the nil-cache AddTx
+// path is exact uncached behavior: same accept, same duplicate rejection text,
+// same resident set as the cache-owning mempool over identical state.
+func TestMempoolSigCacheNilCacheAddTxMatchesBaseline(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+
+	admit := func(t *testing.T, nilCache bool) (string, int, [32]byte) {
+		t.Helper()
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+		mp, err := NewMempool(st, nil, devnetGenesisChainID)
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		if nilCache {
+			mp.sigCache = nil
+		}
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx (nilCache=%v): %v", nilCache, err)
+		}
+		dupErr := mp.AddTx(txBytes)
+		if dupErr == nil {
+			t.Fatalf("duplicate AddTx unexpectedly accepted (nilCache=%v)", nilCache)
+		}
+		return dupErr.Error(), mp.Len(), txID(t, txBytes)
+	}
+
+	cachedErr, cachedLen, cachedTxid := admit(t, false)
+	uncachedErr, uncachedLen, uncachedTxid := admit(t, true)
+	if cachedErr != uncachedErr || cachedLen != uncachedLen || cachedTxid != uncachedTxid {
+		t.Fatalf("nil cache diverged from baseline: err %q vs %q, len %d vs %d, txid %x vs %x",
+			uncachedErr, cachedErr, uncachedLen, cachedLen, uncachedTxid, cachedTxid)
+	}
+}

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5647,3 +5647,106 @@ func TestValidateChainSnapshotRejectsNil(t *testing.T) {
 		t.Fatalf("expected TxAdmitUnavailable, got %T %v", err, err)
 	}
 }
+
+// TestMempoolSigCacheOwnerReusesPositiveResultsAcrossValidations pins the one
+// mempool-owned positive signature cache on the live validation seam that
+// currently routes through it (RelayMetadata -> validateTransactionWithConsensus):
+// empty at construction, populated by a successful validation, reused by a later
+// validation of the exact same tuple, per-mempool (never shared), and never an
+// admission-result cache — a hit publishes no entry and claims no outpoint.
+func TestMempoolSigCacheOwnerReusesPositiveResultsAcrossValidations(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if mp.sigCache == nil {
+		t.Fatal("mempool must own a signature cache")
+	}
+	if mp.sigCache.Len() != 0 || mp.sigCache.Hits() != 0 || mp.sigCache.Misses() != 0 {
+		t.Fatalf("cache must be empty at construction: len=%d hits=%d misses=%d",
+			mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses())
+	}
+
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	if _, err := mp.RelayMetadata(txBytes); err != nil {
+		t.Fatalf("RelayMetadata: %v", err)
+	}
+	if mp.sigCache.Len() != 1 || mp.sigCache.Misses() != 1 || mp.sigCache.Hits() != 0 {
+		t.Fatalf("after first validation: len=%d misses=%d hits=%d, want 1/1/0",
+			mp.sigCache.Len(), mp.sigCache.Misses(), mp.sigCache.Hits())
+	}
+
+	// A second mempool owns a separate, empty cache.
+	other, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool (other): %v", err)
+	}
+	if other.sigCache == mp.sigCache || other.sigCache.Len() != 0 {
+		t.Fatalf("each mempool must own exactly one fresh cache: len=%d", other.sigCache.Len())
+	}
+
+	if _, err := mp.RelayMetadata(txBytes); err != nil {
+		t.Fatalf("RelayMetadata (repeat): %v", err)
+	}
+	if mp.sigCache.Hits() != 1 {
+		t.Fatalf("repeated validation must hit the cache: hits=%d", mp.sigCache.Hits())
+	}
+	if mp.sigCache.Len() != 1 {
+		t.Fatalf("a hit must not insert: len=%d", mp.sigCache.Len())
+	}
+	if mp.Len() != 0 || mp.AdmissionCounts() != (MempoolAdmissionCounts{}) {
+		t.Fatalf("a cache hit is not an admission: len=%d counts=%+v", mp.Len(), mp.AdmissionCounts())
+	}
+}
+
+// TestMempoolSigCacheAlternateWitnessWithSameTxidCannotHit covers the hostile
+// row: a re-signed transaction has the same txid but different signature bytes,
+// so it must MISS and verify on its own.
+func TestMempoolSigCacheAlternateWitnessWithSameTxidCannotHit(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	first := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	second := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	if bytes.Equal(first, second) {
+		t.Skip("signature backend is deterministic: no alternate witness representation available")
+	}
+	_, firstTxid, _, _, err := consensus.ParseTx(first)
+	if err != nil {
+		t.Fatalf("ParseTx(first): %v", err)
+	}
+	_, secondTxid, _, _, err := consensus.ParseTx(second)
+	if err != nil {
+		t.Fatalf("ParseTx(second): %v", err)
+	}
+	if firstTxid != secondTxid {
+		t.Fatalf("txid mismatch: %x vs %x", firstTxid, secondTxid)
+	}
+
+	if _, err := mp.RelayMetadata(first); err != nil {
+		t.Fatalf("RelayMetadata(first): %v", err)
+	}
+	if _, err := mp.RelayMetadata(second); err != nil {
+		t.Fatalf("RelayMetadata(second): %v", err)
+	}
+	if mp.sigCache.Hits() != 0 {
+		t.Fatalf("alternate witness bytes must not hit: hits=%d", mp.sigCache.Hits())
+	}
+	if mp.sigCache.Misses() != 2 || mp.sigCache.Len() != 2 {
+		t.Fatalf("alternate witness must verify on its own: misses=%d len=%d, want 2/2",
+			mp.sigCache.Misses(), mp.sigCache.Len())
+	}
+}


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1121
- GitHub Issue mirror (non-authoritative): #2835

Refs: Q-GO-MEMPOOL-SIGCACHE-OWNER-01

## Summary
The existing positive-only consensus.SigCache gains a binding-inclusive injective key (SHA3-256 over a self-delimiting, length-prefixed preimage; domain byte 0x01 keeps the space disjoint from the legacy 0x00 SigCheckQueue keys) and deterministic insertion-order FIFO where hits never refresh order. Each Go Mempool owns exactly one 50,000-entry cache constructed empty in NewMempoolWithConfig, never persisted, with no public knob. The cache travels through SuiteValidationContext into the sequential spend-verify seam and is consulted strictly after registry lookup/drift check, OpenSSL consensus init, live verifier-binding resolution, and the canonical length check — a hit skips only the verifySigWithBinding backend call; insert happens only on (true, nil). Both live paths are wired: relay metadata (validateTransactionWithConsensus) and AddTx admission (checkTransactionWithSnapshot routes through the new CheckTransactionWithOwnedUtxoSetAndValidationContext; the pre-existing positional helper became a wrapper passing a nil cache so block validation, the miner, the CLI, and every other caller stay byte-identical and uncached). All five sequential native signature paths — P2PK, multisig, Vault threshold, HTLC, CORE_STEALTH — share the one owner cache. A warm cache never buys an admission: the conflict row measures a real cache hit still rejected by the pending-outpoint authority, and a saturated cache still admits the newest valid transaction.

## Invariant
Live Go Mempool validation may skip only the expensive signature-backend call for a previously successful exact tuple after current rotation admission, registry parameters, canonical lengths, covenant and key binding, sighash derivation, and live verifier-binding resolution all succeed; invalid, unresolved, stale-binding, and failed verification results are never cached.

## Scope
- Changed files: 16
- Surfaces: clients/go/consensus (sig_cache, verify_sig_openssl, spend_verify, tx_helpers, utxo_basic family incl. the ratified one-field vault pass-through, htlc, stealth, tests), clients/go/node (mempool owner field + constructor, the ratified AddTx call-site argument change in mempool_precheck, mempolicy_helpers, mempool_stats, tests)
- Non-scope: no consensus rule, error identity, or first-error-order change; no second or negative cache; no worker/queue activation (sig_verify_batch.go and tx_validate_worker.go untouched); no CLI/RPC/config/metrics-schema/persistence field; no P2P, Rust, conformance, rubin-formal, or spec change (Rust owns a dormant SigCache — its production ownership is a separate post-Go parity contract per parity_status GO_REFERENCE_ONLY)
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head 01d9ec44 (df6e487e plus one lock-scope fix keeping the lookup counter bump inside the read section so Reset linearizes against the whole lookup; targeted TestSigCache + race suites re-run green on the new head): gofmt — clean; go test -count=1 ./consensus -run "^(TestSigCache|TestLiveSigCache|TestCheckParsedTransaction.*SigCache)" — PASS; go test -count=1 ./node -run "^TestMempool.*SigCache" — PASS (7 tests); go test -race -count=1 ./consensus ./node — PASS; go test -count=1 ./... — PASS; go vet ./... — PASS; cd conformance && go test ./... — PASS (separate Go module, NO_CHANGE disposition respected); git diff --check — PASS
- Mutation receipts on record: key without the binding component -> injectivity row red; insert before the backend verdict -> never-insert rows red; cache lookup before the canonical length check -> non-canonical rows red (hits and misses both pinned unmoved); LRU-style refresh on hit -> FIFO row red; block path consuming the cache -> containment row red; AddTx seam reverted to the positional wrapper -> miss-then-hit row red (misses=0, want 1); conflict authority short-circuited -> warm-cache conflict row red (nil error, want TxAdmitConflict)
- Backend-call counter receipts: miss -> exactly one backend call; repeat -> zero additional calls; nil cache -> one call per run; resolution failure and non-canonical length -> zero calls
- Warm-cache floor row: implemented and green in an earlier iteration, dropped solely for the LOC hard cap; the floor decision is fee arithmetic carrying no cache-derived data on either the precheck or locked-admission side

## Follow-ups / Waivers
- Rust SigCache production ownership is the separate post-Go parity contract (parity_status GO_REFERENCE_ONLY on the Linear issue)
- RUB-1115 (relay representation cache) consumes this merged reference: https://linear.app/rubinp/issue/RUB-1115

### Parity exemption justification
This is a contract-approved Go-only policy-layer slice (RUB-1121: parity_status GO_REFERENCE_ONLY; forbidden_files_or_surfaces includes clients/rust). It changes no consensus rule, error identity, first-error order, serialization, hash, or shared-fixture surface — a positive-only signature-verification cache inside Go Mempool admission, invisible to block validation. The Rust TxPool retains its dormant SigCache; Rust production ownership is the separate registered post-Go parity contract that must consume this merged Go reference (recorded on the Linear issue), and the future Rust relay-cache mirror depends on it.
