### PR TITLE
RUB-1144: add warm-cache capacity and floor AddTx admission rows

### DIFF
--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5839,9 +5839,11 @@ func TestMempoolSigCacheNilCacheAddTxMatchesBaseline(t *testing.T) {
 
 // TestMempoolSigCacheWarmCacheNeverBuysAdmission pins the hostile admission
 // rows on the LIVE AddTx path: a positive cache hit is never an admission-result
-// hit. Each row warms the owner cache through the validation-only relay seam
-// (which claims no outpoint), then proves the conflict and capacity authorities
-// fire exactly as they would with a cold cache.
+// hit. The conflict, capacity, and fee-floor rows warm the owner cache through
+// the validation-only relay seam (which claims no outpoint); the saturation row
+// fills the cache directly via the legacy Insert API. All four rows prove the
+// conflict, saturation/FIFO, capacity, and fee-floor authorities fire exactly
+// as they would with a cold cache.
 func TestMempoolSigCacheWarmCacheNeverBuysAdmission(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -5928,6 +5930,132 @@ func TestMempoolSigCacheWarmCacheNeverBuysAdmission(t *testing.T) {
 		if mp.sigCache.Len() != mempoolSigCacheCapacity || mp.sigCache.Hits() != 1 || mp.sigCache.Misses() != 1 {
 			t.Fatalf("under saturation: len=%d hits=%d misses=%d, want %d/1/1",
 				mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses(), mempoolSigCacheCapacity)
+		}
+	})
+
+	// The candidate's own signature is warmed through the validation-only
+	// relay seam (a genuine hit target, mirroring "conflict" above), then the
+	// mempool is filled so the candidate is the worst-ranked entry by
+	// fee/weight. The capacity authority must reject it with its exact
+	// existing message and leave the resident set untouched, exactly as it
+	// would for a cold candidate.
+	t.Run("capacity", func(t *testing.T) {
+		st, ops := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{ops[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{ops[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
+		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+			MaxTransactions: 10,
+			MaxBytes:        len(tx1) + len(tx2) - 1,
+		})
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		if err := mp.AddTx(tx1); err != nil {
+			t.Fatalf("AddTx(tx1): %v", err)
+		}
+		if _, err := mp.RelayMetadata(tx2); err != nil {
+			t.Fatalf("RelayMetadata(tx2): %v", err)
+		}
+		if mp.sigCache.Len() != 2 || mp.sigCache.Hits() != 0 || mp.sigCache.Misses() != 2 {
+			t.Fatalf("warm state: len=%d hits=%d misses=%d, want 2/0/2",
+				mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses())
+		}
+		before, err := snapshotMempool(mp)
+		if err != nil {
+			t.Fatalf("snapshot before warm-capacity: %v", err)
+		}
+		usedBytes := mp.usedBytes
+		addErr := mp.AddTx(tx2)
+		if addErr == nil {
+			t.Fatalf("expected candidate-worst rejection, got nil")
+		}
+		var txErr *TxAdmitError
+		if !errors.As(addErr, &txErr) || txErr.Kind != TxAdmitUnavailable {
+			t.Fatalf("warm-capacity err=%v, want TxAdmitUnavailable", addErr)
+		}
+		if want := "mempool capacity candidate rejected by eviction ordering"; txErr.Message != want {
+			t.Fatalf("warm-capacity message %q, want %q", txErr.Message, want)
+		}
+		after, err := snapshotMempool(mp)
+		if err != nil {
+			t.Fatalf("snapshot after warm-capacity: %v", err)
+		}
+		// The capacity reject fires after the conflict slot already reserved
+		// (and released) a token for the candidate, exactly like the cold
+		// candidate-worst row in TestMempoolCandidateWorstRejectsWithoutMutation.
+		assertPostSlotRejectionSnapshot(t, before, after)
+		if mp.Len() != 1 || mp.txs[txID(t, tx1)] == nil || mp.txs[txID(t, tx2)] != nil {
+			t.Fatalf("warm-capacity candidate changed resident set: len=%d", mp.Len())
+		}
+		if mp.usedBytes != usedBytes {
+			t.Fatalf("warm-capacity usedBytes=%d, want %d", mp.usedBytes, usedBytes)
+		}
+		// The warm hit answered tx2's signature from cache: one additional
+		// hit, zero additional backend executions (misses unchanged), and
+		// the hit itself inserted nothing new.
+		if mp.sigCache.Hits() != 1 || mp.sigCache.Misses() != 2 || mp.sigCache.Len() != 2 {
+			t.Fatalf("after warm-capacity: hits=%d misses=%d len=%d, want 1/2/2",
+				mp.sigCache.Hits(), mp.sigCache.Misses(), mp.sigCache.Len())
+		}
+	})
+
+	// The floor authority has two enforcement points: a cheap pre-signature
+	// fast-reject (single-input plain P2PK only, see cheapFeeFloorPrecheck)
+	// and the locked post-validation check (validateFeeFloorLockedWithFloor)
+	// that runs after every witness is verified. A single-input candidate
+	// never reaches the cache on this row: the fast path intercepts it
+	// before verification (feePrecheckP2PKInputValue requires
+	// len(tx.Inputs)==1 && len(tx.Witness)==1). To exercise a GENUINE warm
+	// hit on the floor authority, the candidate spends two outpoints (two
+	// witness items), which is outside the fast path's single-witness
+	// eligibility and always defers to the full validation + locked floor
+	// check below.
+	t.Run("floor", func(t *testing.T) {
+		st, ops := testSpendableChainState(fromAddress, []uint64{600_000, 600_000})
+		txBelowFloor := mustBuildSignedTransferTx(t, st.Utxos, ops, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+		mp, err := NewMempool(st, nil, devnetGenesisChainID)
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		// RelayMetadata runs full validation (warming the cache for both
+		// witness items) BEFORE its own read-only floor check, so it also
+		// rejects below-floor — proving the read-only relay seam never
+		// buys admission either, exactly like the AddTx path below.
+		if _, relayErr := mp.RelayMetadata(txBelowFloor); relayErr == nil || !strings.Contains(relayErr.Error(), "mempool fee below rolling minimum") {
+			t.Fatalf("RelayMetadata(txBelowFloor) = %v, want below-floor rejection", relayErr)
+		}
+		if mp.sigCache.Len() != 2 || mp.sigCache.Hits() != 0 || mp.sigCache.Misses() != 2 {
+			t.Fatalf("warm state: len=%d hits=%d misses=%d, want 2/0/2",
+				mp.sigCache.Len(), mp.sigCache.Hits(), mp.sigCache.Misses())
+		}
+		before, err := snapshotMempool(mp)
+		if err != nil {
+			t.Fatalf("snapshot before warm-floor: %v", err)
+		}
+		addErr := mp.AddTx(txBelowFloor)
+		if addErr == nil || !strings.Contains(addErr.Error(), "mempool fee below rolling minimum") {
+			t.Fatalf("expected below-floor rejection, got %v", addErr)
+		}
+		var txErr *TxAdmitError
+		if !errors.As(addErr, &txErr) || txErr.Kind != TxAdmitUnavailable {
+			t.Fatalf("warm-floor err=%v, want TxAdmitUnavailable", addErr)
+		}
+		after, err := snapshotMempool(mp)
+		if err != nil {
+			t.Fatalf("snapshot after warm-floor: %v", err)
+		}
+		// The locked floor check runs after reserveEntryInputsLocked already
+		// reserved (and released) a token for the two-input candidate.
+		assertPostSlotRejectionSnapshot(t, before, after)
+		if mp.Len() != 0 || mp.txs[txID(t, txBelowFloor)] != nil {
+			t.Fatalf("warm-floor candidate entered resident set: len=%d", mp.Len())
+		}
+		// Both of the candidate's witness items were answered from cache
+		// (two additional hits, the tx's two witness tuples), zero
+		// additional backend executions, and no new insertion.
+		if mp.sigCache.Hits() != 2 || mp.sigCache.Misses() != 2 || mp.sigCache.Len() != 2 {
+			t.Fatalf("after warm-floor: hits=%d misses=%d len=%d, want 2/2/2",
+				mp.sigCache.Hits(), mp.sigCache.Misses(), mp.sigCache.Len())
 		}
 	})
 }

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -6017,12 +6017,27 @@ func TestMempoolSigCacheWarmCacheNeverBuysAdmission(t *testing.T) {
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
 		}
+		// The below-floor rejection message is deterministic here: the tx is
+		// built above with a fixed fee, ML-DSA-87 witnesses are fixed-length
+		// so the weight is stable, and a fresh mempool's rolling floor is
+		// DefaultMempoolMinFeeRate. Compute it once via the same parse/weight
+		// helpers the production floor checks use, and pin the exact string.
+		parsedFloorTx, _, _, _, err := consensus.ParseTx(txBelowFloor)
+		if err != nil {
+			t.Fatalf("ParseTx(txBelowFloor): %v", err)
+		}
+		floorWeight, _, _, err := consensus.TxWeightAndStats(parsedFloorTx)
+		if err != nil {
+			t.Fatalf("TxWeightAndStats(txBelowFloor): %v", err)
+		}
+		wantFloorMsg := fmt.Sprintf("mempool fee below rolling minimum: fee=%s weight=%d min_fee_rate=%d",
+			consensus.Uint128FromU64(1).String(), floorWeight, DefaultMempoolMinFeeRate)
 		// RelayMetadata runs full validation (warming the cache for both
 		// witness items) BEFORE its own read-only floor check, so it also
 		// rejects below-floor — proving the read-only relay seam never
 		// buys admission either, exactly like the AddTx path below.
-		if _, relayErr := mp.RelayMetadata(txBelowFloor); relayErr == nil || !strings.Contains(relayErr.Error(), "mempool fee below rolling minimum") {
-			t.Fatalf("RelayMetadata(txBelowFloor) = %v, want below-floor rejection", relayErr)
+		if _, relayErr := mp.RelayMetadata(txBelowFloor); relayErr == nil || relayErr.Error() != wantFloorMsg {
+			t.Fatalf("RelayMetadata(txBelowFloor) = %v, want %q", relayErr, wantFloorMsg)
 		}
 		if mp.sigCache.Len() != 2 || mp.sigCache.Hits() != 0 || mp.sigCache.Misses() != 2 {
 			t.Fatalf("warm state: len=%d hits=%d misses=%d, want 2/0/2",
@@ -6033,12 +6048,15 @@ func TestMempoolSigCacheWarmCacheNeverBuysAdmission(t *testing.T) {
 			t.Fatalf("snapshot before warm-floor: %v", err)
 		}
 		addErr := mp.AddTx(txBelowFloor)
-		if addErr == nil || !strings.Contains(addErr.Error(), "mempool fee below rolling minimum") {
-			t.Fatalf("expected below-floor rejection, got %v", addErr)
+		if addErr == nil {
+			t.Fatalf("expected below-floor rejection, got nil")
 		}
 		var txErr *TxAdmitError
 		if !errors.As(addErr, &txErr) || txErr.Kind != TxAdmitUnavailable {
 			t.Fatalf("warm-floor err=%v, want TxAdmitUnavailable", addErr)
+		}
+		if txErr.Message != wantFloorMsg {
+			t.Fatalf("warm-floor message = %q, want %q", txErr.Message, wantFloorMsg)
 		}
 		after, err := snapshotMempool(mp)
 		if err != nil {


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1144
- GitHub Issue mirror (non-authoritative): #2870

Refs: Q-GO-MEMPOOL-SIGCACHE-WARM-ADMISSION-ROWS-01

## Summary
Restores the warm-cache admission coverage dropped at the RUB-1121 LOC cap (flagged pre-merge by the contract lens, re-found post-merge by Copilot on PR 2869). Adds two subtests to TestMempoolSigCacheWarmCacheNeverBuysAdmission: (1) capacity — the candidate is warmed via RelayMetadata so its AddTx verification is a genuine cache hit, the mempool is arranged full with the candidate ranked worst, and AddTx must still return the exact capacity rejection with the resident set, pending-outpoint token discipline, and usedBytes unchanged; (2) floor — a two-input candidate (the single-input shape is intercepted by cheapFeeFloorPrecheck before signature validation and never consults the cache, per amendment_2026_08_07_floor_row_two_input_shape on the Linear issue), warmed for both witness tuples by RelayMetadata (which itself rejects below-floor read-only after fully validating), then AddTx records two cache hits and must still return the locked floor rejection. A temporary short-circuit of the locked authorities on a warm hit turns both rows red (reverted); the stale parent-test header comment was corrected in the same pass.

## Invariant
A warm SigCache hit on the AddTx path never buys admission past any policy authority: with the candidate's exact verification tuple already cached, AddTx still returns the same floor and capacity rejections (same error, unchanged resident set) that a cold candidate receives, and the cache records a hit rather than re-running the backend.

## Scope
- Changed files: 1
- Surfaces: clients/go/node/mempool_test.go (two appended subtests + a corrected header comment in the existing warm-admission test family)
- Non-scope: no production code path; no consensus file; no existing test row modified (pure append + comment); Rust mirror rows owned by RUB-1125
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- Dynamic checks at head 45fd92f2: gofmt -l clients/go/node — PASS (clean); go vet ./node/... — PASS; go test -count=1 ./node/ (full package) — PASS (375s); go test -race -count=1 -run 'TestMempoolSigCacheWarm' ./node/ — PASS; go test -count=1 -run 'TestMempoolSigCacheWarm' ./node/ — PASS (all four subtests); git diff --check — PASS
- Falsification receipt: temporary short-circuit of the locked floor/capacity authorities on a positive cache hit — capacity and floor rows red, conflict and saturation rows green as predicted; mutation reverted, final diff touches only mempool_test.go

## Follow-ups / Waivers
- A warm candidate rejected by a policy lane (applyPolicyAgainstState) is structurally unobservable for plain P2PK candidates and outside this contract's accepted_cases; recorded on RUB-1144 in Linear
- Rust sibling rows are owned by RUB-1125 from the start
