### PR TITLE
RUB-1120: publish closed relay admission dispositions with exact-context evidence

### DIFF
--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -128,14 +128,40 @@ func applyPolicyAgainstStateCoreExtUnsupported(checked *consensus.CheckedTransac
 	return nil
 }
 
+// simplicityPreActivationRetryableError marks a CORE_SIMPLICITY pre-activation
+// policy outcome DECIDED FROM a deployment provider, which the published
+// admission context cannot pin. Error() returns the wrapped message
+// verbatim, so every caller that renders, wraps or compares this error stays
+// byte-identical to baseline; the wrapper is a TYPE signal read only by the
+// relay classifier, never parsed from text.
+type simplicityPreActivationRetryableError struct{ err error }
+
+func (e *simplicityPreActivationRetryableError) Error() string { return e.err.Error() }
+
+func (e *simplicityPreActivationRetryableError) Unwrap() error { return e.err }
+
+// markSimplicityPreActivation wraps err ONLY when this outcome is the retryable
+// provider-decided one. reject is the SAME tuple-shape discriminator the
+// precheck call site applies (relayDispositionForSimplicityPreActivationOutcome):
+// reject == true is the half a deployment provider governs, while the
+// reject == false error is the covenant well-formedness verdict, which reads no
+// deployment set and is context-complete. The no-provider verdict rests on the
+// constructor-frozen configuration. Both stay unwrapped, hence stable terminal.
+func markSimplicityPreActivation(err error, reject bool, rotation consensus.RotationProvider) error {
+	if relayDispositionForSimplicityPreActivationOutcome(reject, rotation) != RelayAdmissionUnavailable {
+		return err
+	}
+	return &simplicityPreActivationRetryableError{err: err}
+}
+
 func applyPolicyAgainstStateSimplicity(checked *consensus.CheckedTransaction, utxos map[consensus.Outpoint]consensus.UtxoEntry, chainID [32]byte, nextHeight uint64, policy MempoolConfig) error {
 	if policy.PolicyRejectSimplicityPreActivation {
 		reject, reason, err := rejectCoreSimplicityPreActivation(checked.Tx, utxos, chainID, nextHeight, policy.RotationProvider)
 		if err != nil {
-			return err
+			return markSimplicityPreActivation(err, reject, policy.RotationProvider)
 		}
 		if reject {
-			return errors.New(reason)
+			return markSimplicityPreActivation(errors.New(reason), true, policy.RotationProvider)
 		}
 	}
 	return nil

--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -128,6 +128,19 @@ func applyPolicyAgainstStateCoreExtUnsupported(checked *consensus.CheckedTransac
 	return nil
 }
 
+// policyImpossibleInvariantError marks an applyPolicyAgainstState outcome that
+// no candidate property can produce — a record shape the live admission path
+// never builds. Error() returns the wrapped message verbatim, so every caller
+// that renders, wraps or compares this error stays byte-identical to baseline;
+// the wrapper is a TYPE signal read only by the relay classifier, never parsed
+// from text. It is the policy fan-out's form of the impossible-invariant tagging
+// the locked admission helpers do inline with selectRelayDisposition.
+type policyImpossibleInvariantError struct{ err error }
+
+func (e *policyImpossibleInvariantError) Error() string { return e.err.Error() }
+
+func (e *policyImpossibleInvariantError) Unwrap() error { return e.err }
+
 // simplicityPreActivationRetryableError marks a CORE_SIMPLICITY pre-activation
 // policy outcome DECIDED FROM a deployment provider, which the published
 // admission context cannot pin. Error() returns the wrapped message

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -236,19 +236,23 @@ func (m *Mempool) Contains(txid [32]byte) bool {
 }
 
 func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
-	return m.addTxWithSource(txBytes, mempoolTxSourceLocal)
+	return m.addTxWithSource(txBytes, mempoolTxSourceLocal, nil)
 }
 
 // AddRemoteTx admits a transaction received from a peer while preserving the
 // same validation and admission policy as AddTx. The source is metadata only.
+//
+// It is the compatibility wrapper over the SAME implementation
+// AddRemoteTxForRelay drives: a nil relay probe is the only difference, and it
+// changes no validation order, no mutation, no error, and no counter.
 func (m *Mempool) AddRemoteTx(txBytes []byte) (retErr error) {
-	return m.addTxWithSource(txBytes, mempoolTxSourceRemote)
+	return m.addTxWithSource(txBytes, mempoolTxSourceRemote, nil)
 }
 
 // AddReorgTx admits a transaction requeued from a disconnected canonical block
 // while preserving the same validation and admission policy as AddTx.
 func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
-	return m.addTxWithSource(txBytes, mempoolTxSourceReorg)
+	return m.addTxWithSource(txBytes, mempoolTxSourceReorg, nil)
 }
 
 // addTxWithSource validates and admits a transaction while recording the
@@ -258,9 +262,14 @@ func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
 // Its ChainState.admissionMu.RLock below BLOCKS INDEFINITELY, by design, once a
 // canonical transition has entered the fail-closed terminal state described on
 // canonicalTransition.end: waiting for the required restart is the contract.
-func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retErr error) {
+//
+// probe is the per-call relay sink AddRemoteTxForRelay supplies and every
+// legacy entry point leaves nil. It carries identity, the proven admission
+// context and the success selection only; a failed admission's disposition
+// rides on the admission error itself, selected at its originating branch.
+func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource, probe *relayAdmissionProbe) (retErr error) {
 	if m == nil {
-		return txAdmitUnavailable("nil mempool")
+		return selectRelayDisposition(txAdmitUnavailable("nil mempool"), RelayAdmissionUnavailable)
 	}
 	// Exactly one admission counter increment per non-nil-receiver call, and
 	// NEVER outside the admission guard. Only the nil-ChainState guard can
@@ -268,7 +277,7 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 	// at its own return site through the same noteAdmissionResult mapping. A nil
 	// receiver counts nothing.
 	if m.chainState == nil {
-		err := txAdmitUnavailable("nil chainstate")
+		err := selectRelayDisposition(txAdmitUnavailable("nil chainstate"), RelayAdmissionUnavailable)
 		m.noteAdmissionResult(err)
 		return err
 	}
@@ -281,11 +290,19 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 	// acquisition must be able to exclude.
 	defer func() { m.noteAdmissionResult(retErr) }()
 
+	// Pure read, inside the guard that pins both the owner context and the
+	// chainstate tip for this whole call. It decides nothing and mutates
+	// nothing; a context it cannot prove simply stays unproven.
+	m.bindRelayAdmissionContext(probe)
+
 	// Inside the guard, so its rejection and count belong to that contained
 	// lifecycle and it waits on a terminally latched engine like every other
 	// admission: caller metadata never reports an outcome the binding cannot see.
+	//
+	// Every entry point pins the source constant itself, so an invalid source is
+	// an impossible invariant rather than a candidate property.
 	if !validMempoolTxSource(source) {
-		return txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source))
+		return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source)), RelayAdmissionInternal)
 	}
 
 	snapshot := m.chainState.admissionSnapshot()
@@ -306,7 +323,7 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 	// Wave-7's snap-once-pass-through fixed only the decay direction
 	// and reopened the opposite race; wave-8 closes both.
 	snappedFloor := m.CurrentMinFeeRateSnapshot()
-	checked, inputs, err := m.checkTransactionWithSnapshot(txBytes, snapshot, policy, snappedFloor)
+	checked, inputs, err := m.checkTransactionWithSnapshot(txBytes, snapshot, policy, snappedFloor, probe)
 	if err != nil {
 		return err
 	}
@@ -315,7 +332,11 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 	defer m.mu.Unlock()
 
 	entry := newMempoolEntry(checked, inputs, source)
-	return m.addEntryLockedWithFloor(entry, snappedFloor)
+	if err := m.addEntryLockedProbed(entry, snappedFloor, probe); err != nil {
+		return err
+	}
+	m.noteRetainedLocked(entry, probe)
+	return nil
 }
 
 // RelayMetadata returns the metadata a relay peer needs to forward the

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -106,7 +106,8 @@ type Mempool struct {
 	// evictedResidentTotal counts cumulative resident-entry capacity
 	// evictions since process start. It is bumped exactly once per
 	// already-admitted entry that is removed by capacity pressure
-	// (the per-victim counter loop in addEntryLockedWithFloor, after
+	// (the per-victim counter loop in addEntryLockedProbed, the one
+	// implementation of the locked admission path, after
 	// validateCapacityAdmissionLocked classifies the candidate as
 	// admitted-and-evicting and commitStandardDeltaLocked removes the
 	// victims with their exact tokens). Candidate-worst rejection —
@@ -348,7 +349,7 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource, probe 
 //
 // RelayMetadata is not full mempool admission: it does not insert, does not
 // record source/admission_seq, and does not check duplicate, conflict, or
-// capacity state. Those remain owned by addTxWithSource/addEntryLockedWithFloor.
+// capacity state. Those remain owned by addTxWithSource/addEntryLockedProbed.
 func (m *Mempool) RelayMetadata(txBytes []byte) (RelayTxMetadata, error) {
 	if m == nil {
 		return RelayTxMetadata{}, txAdmitUnavailable("nil mempool")
@@ -434,7 +435,13 @@ func (m *Mempool) checkParsedTransactionWithSnapshot(
 
 func (m *Mempool) applyPolicyAgainstState(checked *consensus.CheckedTransaction, nextHeight uint64, utxos map[consensus.Outpoint]consensus.UtxoEntry, policy MempoolConfig) error {
 	if checked == nil || checked.Tx == nil {
-		return errors.New("nil checked transaction")
+		// Both call sites reach here only with the CheckedTransaction a completed
+		// consensus validation returned, so this is an impossible invariant and
+		// never a candidate property. It is TYPED — never message-matched — so the
+		// relay classifier publishes INTERNAL for it instead of the
+		// cache-authorizing stable terminal rejection its default would give. The
+		// message is unchanged, so every public error built from it is unchanged.
+		return &policyImpossibleInvariantError{err: errors.New("nil checked transaction")}
 	}
 	// Apply non-coinbase anchor output policy
 	if err := applyPolicyAgainstStateAnchor(checked, policy); err != nil {

--- a/clients/go/node/mempool_capacity.go
+++ b/clients/go/node/mempool_capacity.go
@@ -42,14 +42,14 @@ func (m *Mempool) validateCapacityAdmissionLocked(entry *mempoolEntry, snappedFl
 		return nil, err
 	}
 	if candidateEvicted {
-		return nil, txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
+		return nil, selectRelayDisposition(txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering"), RelayAdmissionCapacity)
 	}
 	return evictedEntries, nil
 }
 
 func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoolEntry, bool, error) {
 	if candidate == nil {
-		return nil, false, txAdmitRejected("nil mempool entry")
+		return nil, false, selectRelayDisposition(txAdmitRejected("nil mempool entry"), RelayAdmissionInternal)
 	}
 	state, err := m.capacityStateLocked(candidate)
 	if err != nil {
@@ -71,7 +71,10 @@ func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityS
 		return mempoolCapacityState{}, err
 	}
 	if m.maxTxs <= 0 || maxBytes == 0 {
-		return mempoolCapacityState{}, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
+		// Construction normalizes both limits to a positive default, so a
+		// non-positive limit here is corrupted accounting, not capacity
+		// pressure the candidate could ever retry past.
+		return mempoolCapacityState{}, selectRelayDisposition(txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes)), RelayAdmissionInternal)
 	}
 	candidateSize, err := nonNegativeMempoolIntToUint64("candidate_size", candidate.size)
 	if err != nil {
@@ -82,7 +85,7 @@ func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityS
 		return mempoolCapacityState{}, err
 	}
 	if candidateSize > maxBytes {
-		return mempoolCapacityState{}, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
+		return mempoolCapacityState{}, selectRelayDisposition(txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes)), RelayAdmissionCapacity)
 	}
 	countPressure := len(m.txs) >= m.maxTxs
 	bytePressure := usedBytes > maxBytes-candidateSize
@@ -121,7 +124,9 @@ func (m *Mempool) evictionPlanPoolLocked(candidate *mempoolEntry) ([]mempoolEvic
 			return nil, err
 		}
 		if existing, exists := admissionSeqs[entry.admissionSeq]; exists {
-			return nil, txAdmitRejected(fmt.Sprintf("duplicate mempool entry admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid))
+			// Two RESIDENT records sharing a sequence is corrupted accounting,
+			// not the candidate's own sequence outcome.
+			return nil, selectRelayDisposition(txAdmitRejected(fmt.Sprintf("duplicate mempool entry admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid)), RelayAdmissionInternal)
 		}
 		admissionSeqs[entry.admissionSeq] = entry.txid
 		planPool = append(planPool, mempoolEvictionPlanEntry{entry: entry})
@@ -145,7 +150,7 @@ func dryRunCapacityEvictions(planPool []mempoolEvictionPlanEntry, state mempoolC
 		planPool = append(planPool[:worstIndex], planPool[worstIndex+1:]...)
 	}
 	if state.exceedsHardCapacity(maxTxs) {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", state.totalCount, maxTxs, state.totalBytes, state.maxBytes))
+		return nil, false, selectRelayDisposition(txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", state.totalCount, maxTxs, state.totalBytes, state.maxBytes)), RelayAdmissionCapacity)
 	}
 	return evictedEntries, false, nil
 }
@@ -161,7 +166,7 @@ func (state mempoolCapacityState) exceedsHardCapacity(maxTxs int) bool {
 func (state *mempoolCapacityState) applyDryRunEviction(entry *mempoolEntry) error {
 	worstSize := uint64(entry.size) // #nosec G115 -- validateEvictionMetadata rejects non-positive entry sizes before this helper.
 	if state.totalBytes < worstSize {
-		return txAdmitUnavailable("mempool eviction byte accounting underflow")
+		return selectRelayDisposition(txAdmitUnavailable("mempool eviction byte accounting underflow"), RelayAdmissionInternal)
 	}
 	state.totalBytes -= worstSize
 	state.totalCount--
@@ -178,28 +183,33 @@ func worstEvictionPlanIndex(planPool []mempoolEvictionPlanEntry) int {
 	return worstIndex
 }
 
+// nonNegativeMempoolIntToUint64 guards a capacity accounting field. A negative
+// byte or size count is corrupted accounting, never capacity pressure.
 func nonNegativeMempoolIntToUint64(label string, value int) (uint64, error) {
 	if value < 0 {
-		return 0, txAdmitUnavailable(fmt.Sprintf("invalid mempool %s: %d", label, value))
+		return 0, selectRelayDisposition(txAdmitUnavailable(fmt.Sprintf("invalid mempool %s: %d", label, value)), RelayAdmissionInternal)
 	}
 	return uint64(value), nil
 }
 
+// validateEvictionMetadata checks an ALREADY-ADMITTED resident record before it
+// enters the eviction plan. Every failure describes corrupted resident
+// accounting, never a property of the incoming candidate.
 func validateEvictionMetadata(entry *mempoolEntry) error {
 	if entry == nil {
-		return txAdmitRejected("nil mempool entry")
+		return selectRelayDisposition(txAdmitRejected("nil mempool entry"), RelayAdmissionInternal)
 	}
 	if entry.txid == ([32]byte{}) {
-		return txAdmitRejected("invalid mempool entry txid")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry txid"), RelayAdmissionInternal)
 	}
 	if entry.size <= 0 {
-		return txAdmitRejected("invalid mempool entry size")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry size"), RelayAdmissionInternal)
 	}
 	if entry.weight == 0 {
-		return txAdmitRejected("invalid mempool entry weight")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry weight"), RelayAdmissionInternal)
 	}
 	if entry.admissionSeq == 0 {
-		return txAdmitRejected(fmt.Sprintf("invalid mempool entry admission_seq for txid %x", entry.txid))
+		return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("invalid mempool entry admission_seq for txid %x", entry.txid)), RelayAdmissionInternal)
 	}
 	return nil
 }

--- a/clients/go/node/mempool_fee_floor.go
+++ b/clients/go/node/mempool_fee_floor.go
@@ -39,14 +39,14 @@ func (m *Mempool) validateFeeFloorLocked(entry *mempoolEntry) error {
 // max-of-(snap, live) closes both sides.
 func (m *Mempool) validateFeeFloorLockedWithFloor(entry *mempoolEntry, snappedFloor uint64) error {
 	if entry == nil {
-		return txAdmitRejected("nil mempool entry")
+		return selectRelayDisposition(txAdmitRejected("nil mempool entry"), RelayAdmissionInternal)
 	}
 	floor := snappedFloor
 	if live := m.currentMinFeeRateLocked(); live > floor {
 		floor = live
 	}
 	if feeRateBelowFloor(entry.fee, entry.weight, floor) {
-		return txAdmitUnavailable(fmt.Sprintf("mempool fee below rolling minimum: fee=%s weight=%d min_fee_rate=%d", entry.fee.String(), entry.weight, floor))
+		return selectRelayDisposition(txAdmitUnavailable(fmt.Sprintf("mempool fee below rolling minimum: fee=%s weight=%d min_fee_rate=%d", entry.fee.String(), entry.weight, floor)), RelayAdmissionRollingFloor)
 	}
 	return nil
 }

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -211,8 +211,9 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 }
 
 // validateNonCapacityAdmissionLockedProbed is the one implementation. The probe
-// only reaches the owner seam, where a caller-supplied expected admission
-// context is validated; every check, its order and its error are unchanged.
+// reaches the owner seam, where a caller-supplied expected admission context is
+// validated, and the post-decision release seam, which records a cleanup fault
+// on it; every check, its order and its error are unchanged.
 func (m *Mempool) validateNonCapacityAdmissionLockedProbed(entry *mempoolEntry, probe *relayAdmissionProbe) error {
 	if err := validateBasicMempoolEntry(entry); err != nil {
 		return err
@@ -227,7 +228,7 @@ func (m *Mempool) validateNonCapacityAdmissionLockedProbed(entry *mempoolEntry, 
 		return err
 	}
 	if err := m.validateAdmissionSeqLocked(entry); err != nil {
-		return m.releaseCandidateLocked(entry, err)
+		return m.releaseCandidateLocked(entry, err, probe)
 	}
 	return nil
 }
@@ -318,8 +319,8 @@ func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry, probe *relayAdmi
 		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip"), RelayAdmissionUnavailable)
 	}
 	requested := admission
-	if probe != nil && probe.expected != nil {
-		requested = *probe.expected
+	if probe != nil && probe.hasExpected {
+		requested = probe.expected
 	}
 	token, err := owner.Reserve(requested, PendingOutpointStandardMempool, entry.txid, entry.inputs)
 	if err != nil {
@@ -332,15 +333,28 @@ func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry, probe *relayAdmi
 // releaseCandidateLocked releases a reservation the conflict slot issued for a
 // candidate that a LATER admission check rejected, and returns cause unchanged
 // so the public error order is preserved. The issued sequence stays consumed;
-// high-waters never decrease. Release cannot fail for a claim this call just
-// installed, and reporting a release fault in place of cause would rewrite the
-// contractual admission error, so the release result is deliberately dropped.
-func (m *Mempool) releaseCandidateLocked(entry *mempoolEntry, cause error) error {
+// high-waters never decrease.
+//
+// Release cannot fail for a claim this call just installed, so every failure it
+// can report — a nil owner, a token this owner never issued, a by-outpoint row
+// that disagrees with the token — is owner-accounting corruption. Reporting it
+// in place of cause would rewrite the contractual admission error, so cause is
+// still returned byte-identically; the fault is recorded on the relay probe
+// instead, which publishes it as the fail-closed INTERNAL disposition the
+// already-tagged cause can no longer carry (selectRelayDisposition is
+// first-selection-wins and the deciding branch tagged cause before this ran).
+//
+// probe is nil on the legacy AddTx / AddRemoteTx / AddReorgTx path, where
+// noteCleanupFailure is a no-op and the behavior is exactly as before.
+func (m *Mempool) releaseCandidateLocked(entry *mempoolEntry, cause error, probe *relayAdmissionProbe) error {
 	var zero PendingOutpointToken
 	if entry == nil || entry.token == zero {
 		return cause
 	}
-	_ = m.pendingOutpoints.Release(entry.token)
+	probe.noteCleanupFailure(m.pendingOutpoints.Release(entry.token))
+	// The token is zeroed unconditionally, exactly as before: the entry is
+	// discarded on every path that reaches here, and a failed release leaves no
+	// claim this record may keep pointing at.
 	entry.token = zero
 	return cause
 }
@@ -410,8 +424,9 @@ func (m *Mempool) addEntryLockedWithFloor(entry *mempoolEntry, snappedFloor uint
 }
 
 // addEntryLockedProbed is the one implementation of the locked admission path.
-// The probe reaches only the owner seam inside the non-capacity chain; it
-// changes no check, no order, no error and no mutation.
+// The probe reaches the owner seam inside the non-capacity chain and the
+// post-decision release seam; it changes no check, no order, no error and no
+// mutation.
 func (m *Mempool) addEntryLockedProbed(entry *mempoolEntry, snappedFloor uint64, probe *relayAdmissionProbe) error {
 	normalizeMempoolEntryDefaults(entry)
 	if err := m.validateNonCapacityAdmissionLockedProbed(entry, probe); err != nil {
@@ -419,7 +434,7 @@ func (m *Mempool) addEntryLockedProbed(entry *mempoolEntry, snappedFloor uint64,
 	}
 	evictedEntries, err := m.validateCapacityAdmissionLocked(entry, snappedFloor)
 	if err != nil {
-		return m.releaseCandidateLocked(entry, err)
+		return m.releaseCandidateLocked(entry, err, probe)
 	}
 	m.ensureMinFeeRateLocked()
 	// One typed delta: every exact victim token is released and the candidate
@@ -432,7 +447,7 @@ func (m *Mempool) addEntryLockedProbed(entry *mempoolEntry, snappedFloor uint64,
 	// is possible: every remaining failure is an accounting or claim
 	// inconsistency, which is an impossible invariant.
 	if err := m.commitStandardDeltaLocked(standardMempoolDelta{candidate: entry, removals: evictedEntries}); err != nil {
-		return m.releaseCandidateLocked(entry, selectRelayDisposition(err, RelayAdmissionInternal))
+		return m.releaseCandidateLocked(entry, selectRelayDisposition(err, RelayAdmissionInternal), probe)
 	}
 	for range evictedEntries {
 		// Bump the resident-eviction counter exactly once per

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -361,9 +361,17 @@ func (m *Mempool) releaseCandidateLocked(entry *mempoolEntry, cause error, probe
 
 func (m *Mempool) validateAdmissionSeqLocked(entry *mempoolEntry) error {
 	if entry.admissionSeq != 0 {
+		// A NEW candidate never carries a sequence: newMempoolEntry leaves the
+		// field zero, normalizeMempoolEntryDefaults does not touch it, and
+		// assignAdmissionSeqLocked issues one only at commit time. A non-zero
+		// sequence on an entry still being validated is therefore corrupted
+		// accounting — the same fault the resident-side duplicate-sequence guard
+		// in evictionPlanPoolLocked reports, and classified the same INTERNAL way
+		// — not the candidate's own admission-sequence outcome. The error, its
+		// message and its kind are unchanged.
 		for existingTxid, existing := range m.txs {
 			if existing != nil && existing.admissionSeq == entry.admissionSeq {
-				return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid)), RelayAdmissionAdmissionSequence)
+				return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid)), RelayAdmissionInternal)
 			}
 		}
 	}
@@ -400,7 +408,7 @@ func normalizeMempoolEntryDefaults(entry *mempoolEntry) {
 
 // addEntryLocked admits `entry` under `m.mu`, using the live
 // `m.currentMinFeeRate` value for the fee-floor check. Production
-// callers SHOULD use `addEntryLockedWithFloor` (see wave-6 race fix
+// admission goes through `addEntryLockedProbed` (see wave-6 race fix
 // in addTxWithSource); this wrapper exists for test callers that
 // drive the locked admission path in isolation and accept whatever
 // floor is in effect at call time.

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -203,7 +203,17 @@ func (m *Mempool) removeTxLocked(txid [32]byte) error {
 	return m.commitStandardDeltaLocked(standardMempoolDelta{removals: []*mempoolEntry{entry}})
 }
 
+// validateNonCapacityAdmissionLocked runs the non-capacity admission chain with
+// no relay observer. It is the unprobed form the package's own locked-path tests
+// drive; production admission uses validateNonCapacityAdmissionLockedProbed.
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {
+	return m.validateNonCapacityAdmissionLockedProbed(entry, nil)
+}
+
+// validateNonCapacityAdmissionLockedProbed is the one implementation. The probe
+// only reaches the owner seam, where a caller-supplied expected admission
+// context is validated; every check, its order and its error are unchanged.
+func (m *Mempool) validateNonCapacityAdmissionLockedProbed(entry *mempoolEntry, probe *relayAdmissionProbe) error {
 	if err := validateBasicMempoolEntry(entry); err != nil {
 		return err
 	}
@@ -213,7 +223,7 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	if err := validateMempoolEntrySource(entry.source); err != nil {
 		return err
 	}
-	if err := m.reserveEntryInputsLocked(entry); err != nil {
+	if err := m.reserveEntryInputsLocked(entry, probe); err != nil {
 		return err
 	}
 	if err := m.validateAdmissionSeqLocked(entry); err != nil {
@@ -222,33 +232,40 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	return nil
 }
 
+// validateBasicMempoolEntry checks the record shape a completed consensus
+// validation always produces. Every failure here is an impossible invariant of
+// the live admission path, never a property of the candidate bytes.
 func validateBasicMempoolEntry(entry *mempoolEntry) error {
 	if entry == nil {
-		return txAdmitRejected("nil mempool entry")
+		return selectRelayDisposition(txAdmitRejected("nil mempool entry"), RelayAdmissionInternal)
 	}
 	if entry.size <= 0 {
-		return txAdmitRejected("invalid mempool entry size")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry size"), RelayAdmissionInternal)
 	}
 	if entry.weight == 0 {
-		return txAdmitRejected("invalid mempool entry weight")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry weight"), RelayAdmissionInternal)
 	}
 	return nil
 }
 
+// validateEntryIdentityLocked is the resident-duplicate slot. Both duplicate
+// branches keep the existing TxAdmitConflict kind for compatibility, which is
+// exactly why a relay consumer must read the disposition instead: the same
+// public kind also carries the pending-outpoint double-spend conflict.
 func (m *Mempool) validateEntryIdentityLocked(entry *mempoolEntry) error {
 	txid := entry.txid
 	if txid == ([32]byte{}) {
-		return txAdmitRejected("invalid mempool entry txid")
+		return selectRelayDisposition(txAdmitRejected("invalid mempool entry txid"), RelayAdmissionInternal)
 	}
 	if _, exists := m.txs[txid]; exists {
-		return txAdmitConflict("tx already in mempool")
+		return selectRelayDisposition(txAdmitConflict("tx already in mempool"), RelayAdmissionDuplicate)
 	}
 	wtxid := entry.wtxid
 	if wtxid == ([32]byte{}) {
 		wtxid = entry.txid
 	}
 	if existing, exists := m.wtxids[wtxid]; exists {
-		return txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing))
+		return selectRelayDisposition(txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing)), RelayAdmissionDuplicate)
 	}
 	return nil
 }
@@ -258,7 +275,9 @@ func validateMempoolEntrySource(source mempoolTxSource) error {
 		source = mempoolTxSourceLocal
 	}
 	if !validMempoolTxSource(source) {
-		return txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source))
+		// The entry points pin the source constant; a record can only carry an
+		// invalid one through an impossible invariant.
+		return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source)), RelayAdmissionInternal)
 	}
 	return nil
 }
@@ -277,21 +296,34 @@ func validateMempoolEntrySource(source mempoolTxSource) error {
 // TxAdmitUnavailable, so no new public TxAdmit kind appears here. A candidate
 // with no inputs claims nothing and takes no token, exactly as the replaced loop
 // was a no-op over an empty input slice.
-func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry) error {
+//
+// This slot is ALSO the seam at which a relay caller's supplied expected
+// admission context is validated: the supplied context replaces the observed one
+// as Reserve's binding, so the owner's own availability check refuses a stale
+// tip or a superseded generation before it scans for a conflict and before it
+// consumes a sequence. A nil probe or a nil expected context leaves the baseline
+// binding, and therefore the baseline behavior, untouched.
+func (m *Mempool) reserveEntryInputsLocked(entry *mempoolEntry, probe *relayAdmissionProbe) error {
 	if len(entry.inputs) == 0 {
-		return nil
+		// Pure read of the already-bound owner: the lazy owner constructor is
+		// deliberately NOT called here, because classifying must never mutate.
+		return probe.checkExpectedContext(m.pendingOutpoints, pendingOutpointTipOf(m.chainState))
 	}
 	owner := m.pendingOutpointOwnerLocked()
 	admission, ok := owner.AdmissionContext()
 	if !ok {
-		return txAdmitUnavailable("pending-outpoint owner admission context unavailable")
+		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner admission context unavailable"), RelayAdmissionUnavailable)
 	}
 	if admission.StableTip != pendingOutpointTipOf(m.chainState) {
-		return txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip")
+		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip"), RelayAdmissionUnavailable)
 	}
-	token, err := owner.Reserve(admission, PendingOutpointStandardMempool, entry.txid, entry.inputs)
+	requested := admission
+	if probe != nil && probe.expected != nil {
+		requested = *probe.expected
+	}
+	token, err := owner.Reserve(requested, PendingOutpointStandardMempool, entry.txid, entry.inputs)
 	if err != nil {
-		return txAdmitFromPendingOutpointError(err)
+		return selectRelayDisposition(txAdmitFromPendingOutpointError(err), relayDispositionForOwnerError(err))
 	}
 	entry.token = token
 	return nil
@@ -317,12 +349,12 @@ func (m *Mempool) validateAdmissionSeqLocked(entry *mempoolEntry) error {
 	if entry.admissionSeq != 0 {
 		for existingTxid, existing := range m.txs {
 			if existing != nil && existing.admissionSeq == entry.admissionSeq {
-				return txAdmitRejected(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid))
+				return selectRelayDisposition(txAdmitRejected(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid)), RelayAdmissionAdmissionSequence)
 			}
 		}
 	}
 	if m.lastAdmissionSeq == ^uint64(0) {
-		return txAdmitUnavailable("mempool admission sequence exhausted")
+		return selectRelayDisposition(txAdmitUnavailable("mempool admission sequence exhausted"), RelayAdmissionAdmissionSequence)
 	}
 	return nil
 }
@@ -374,8 +406,15 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 // and a stale-lower snap would otherwise admit a transaction below
 // the current rolling floor.
 func (m *Mempool) addEntryLockedWithFloor(entry *mempoolEntry, snappedFloor uint64) error {
+	return m.addEntryLockedProbed(entry, snappedFloor, nil)
+}
+
+// addEntryLockedProbed is the one implementation of the locked admission path.
+// The probe reaches only the owner seam inside the non-capacity chain; it
+// changes no check, no order, no error and no mutation.
+func (m *Mempool) addEntryLockedProbed(entry *mempoolEntry, snappedFloor uint64, probe *relayAdmissionProbe) error {
 	normalizeMempoolEntryDefaults(entry)
-	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
+	if err := m.validateNonCapacityAdmissionLockedProbed(entry, probe); err != nil {
 		return err
 	}
 	evictedEntries, err := m.validateCapacityAdmissionLocked(entry, snappedFloor)
@@ -386,8 +425,14 @@ func (m *Mempool) addEntryLockedWithFloor(entry *mempoolEntry, snappedFloor uint
 	// One typed delta: every exact victim token is released and the candidate
 	// record plus its token finalization are installed together. A failure here
 	// publishes no entry and exactly releases the candidate reservation.
+	//
+	// The commit validated its whole delta before writing anything, and the
+	// live admission path reaches it holding the ChainState admission read
+	// guard plus m.mu, so no transition, generation move or concurrent removal
+	// is possible: every remaining failure is an accounting or claim
+	// inconsistency, which is an impossible invariant.
 	if err := m.commitStandardDeltaLocked(standardMempoolDelta{candidate: entry, removals: evictedEntries}); err != nil {
-		return m.releaseCandidateLocked(entry, err)
+		return m.releaseCandidateLocked(entry, selectRelayDisposition(err, RelayAdmissionInternal))
 	}
 	for range evictedEntries {
 		// Bump the resident-eviction counter exactly once per

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -11,14 +11,18 @@ import (
 func buildPolicyInputSnapshotIfNeeded(parsedTx *consensus.Tx, snapshot *chainStateAdmissionSnapshot, policy MempoolConfig) (map[consensus.Outpoint]consensus.UtxoEntry, error) {
 	needs, err := policyNeedsInputSnapshotForTx(parsedTx, policy)
 	if err != nil {
-		return nil, txAdmitRejected(err.Error())
+		// Only a nil parsed transaction reaches here, which the callers cannot
+		// produce: an impossible invariant, never a candidate property.
+		return nil, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionInternal)
 	}
 	if !needs {
 		return nil, nil
 	}
 	policyUtxos, err := policyInputSnapshot(parsedTx, snapshot.utxos)
 	if err != nil {
-		return nil, txAdmitRejected(err.Error())
+		// An input the snapshot does not carry is a retryable dependency gap;
+		// the remaining shapes (nil tx, nil utxo set) are impossible invariants.
+		return nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForInputError(err, RelayAdmissionInternal))
 	}
 	return policyUtxos, nil
 }
@@ -31,25 +35,28 @@ func buildPolicyInputSnapshotIfNeeded(parsedTx *consensus.Tx, snapshot *chainSta
 // height, next-block MTP, or a typed admission error if any step
 // fails (Unavailable for chain-context failure, Rejected for parse
 // failure / trailing bytes).
-func (m *Mempool) checkTxParseAndContext(txBytes []byte, snapshot *chainStateAdmissionSnapshot) (*consensus.Tx, uint64, uint64, error) {
+func (m *Mempool) checkTxParseAndContext(txBytes []byte, snapshot *chainStateAdmissionSnapshot, probe *relayAdmissionProbe) (*consensus.Tx, uint64, uint64, error) {
 	if snapshot == nil {
-		return nil, 0, 0, txAdmitUnavailable("nil chainstate")
+		return nil, 0, 0, selectRelayDisposition(txAdmitUnavailable("nil chainstate"), RelayAdmissionUnavailable)
 	}
 	nextHeight, _, err := nextBlockContextFromFields(snapshot.hasTip, snapshot.height, snapshot.tipHash)
 	if err != nil {
-		return nil, 0, 0, txAdmitUnavailable(err.Error())
+		return nil, 0, 0, selectRelayDisposition(txAdmitUnavailable(err.Error()), RelayAdmissionUnavailable)
 	}
 	blockMTP, err := m.nextBlockMTP(nextHeight)
 	if err != nil {
-		return nil, 0, 0, txAdmitUnavailable(err.Error())
+		return nil, 0, 0, selectRelayDisposition(txAdmitUnavailable(err.Error()), RelayAdmissionUnavailable)
 	}
-	parsedTx, _, _, consumed, err := consensus.ParseTx(txBytes)
+	parsedTx, txid, wtxid, consumed, err := consensus.ParseTx(txBytes)
 	if err != nil {
-		return nil, 0, 0, txAdmitRejected(err.Error())
+		return nil, 0, 0, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionStableTerminalReject)
 	}
 	if consumed != len(txBytes) {
-		return nil, 0, 0, txAdmitRejected("trailing bytes after canonical tx")
+		return nil, 0, 0, selectRelayDisposition(txAdmitRejected("trailing bytes after canonical tx"), RelayAdmissionStableTerminalReject)
 	}
+	// The canonical identity exists from here on, so every later outcome
+	// reports the real candidate and an unparseable candidate reports none.
+	probe.noteIdentity(txid, wtxid)
 	return parsedTx, nextHeight, blockMTP, nil
 }
 
@@ -65,8 +72,8 @@ func (m *Mempool) checkTxParseAndContext(txBytes []byte, snapshot *chainStateAdm
 // while spurious-reject under `decayMinFeeRateAfterConnectedBlockLocked`
 // remains the lesser evil (caller can retry against the fresher
 // snapshot). Bidirectional race protection biased toward strict.
-func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainStateAdmissionSnapshot, policy MempoolConfig, snappedFloor uint64) (*consensus.CheckedTransaction, []consensus.Outpoint, error) {
-	parsedTx, nextHeight, blockMTP, err := m.checkTxParseAndContext(txBytes, snapshot)
+func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainStateAdmissionSnapshot, policy MempoolConfig, snappedFloor uint64, probe *relayAdmissionProbe) (*consensus.CheckedTransaction, []consensus.Outpoint, error) {
+	parsedTx, nextHeight, blockMTP, err := m.checkTxParseAndContext(txBytes, snapshot, probe)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,22 +88,24 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 	// would be misclassified as transient Unavailable instead of
 	// Rejected (terminal).
 	if err := cheapFeeFloorPrecheck(parsedTx, snapshot, snappedFloor, nextHeight, policy.RotationProvider, policy.SuiteRegistry); err != nil {
-		return nil, nil, err
+		// The cheap precheck produces exactly one failure: below the rolling
+		// floor. Every shape it cannot decide defers to the slow path above.
+		return nil, nil, selectRelayDisposition(err, RelayAdmissionRollingFloor)
 	}
 	policyUtxos, err := buildPolicyInputSnapshotIfNeeded(parsedTx, snapshot, policy)
 	if err != nil {
 		return nil, nil, err
 	}
 	if reject, reason := rejectUnsupportedCoreExtNodeRuntime(parsedTx, policyUtxos); reject {
-		return nil, nil, txAdmitRejected(reason)
+		return nil, nil, selectRelayDisposition(txAdmitRejected(reason), RelayAdmissionStableTerminalReject)
 	}
 	if policy.PolicyRejectSimplicityPreActivation {
 		reject, reason, err := rejectCoreSimplicityPreActivation(parsedTx, policyUtxos, m.chainID, nextHeight, policy.RotationProvider)
 		if err != nil {
-			return nil, nil, txAdmitRejected(err.Error())
+			return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionStableTerminalReject)
 		}
 		if reject {
-			return nil, nil, txAdmitRejected(reason)
+			return nil, nil, selectRelayDisposition(txAdmitRejected(reason), RelayAdmissionStableTerminalReject)
 		}
 	}
 	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndValidationContext(
@@ -115,10 +124,17 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 		},
 	)
 	if err != nil {
-		return nil, nil, txAdmitRejected(err.Error())
+		// An input that is absent, still immature, or not yet unlocked becomes
+		// spendable at a later height and stays retryable; every other
+		// consensus failure is stable terminal invalidity of these exact bytes
+		// against the exact stable context this call is bound to.
+		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForInputError(err, RelayAdmissionStableTerminalReject))
 	}
 	if err := m.applyPolicyAgainstState(checked, nextHeight, policyUtxos, policy); err != nil {
-		return nil, nil, txAdmitRejected(err.Error())
+		// Constructor-frozen, context-bound static policy: anchor outputs, the
+		// DA fee/budget terms, the retired CORE_EXT surface, and Simplicity
+		// pre-activation.
+		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionStableTerminalReject)
 	}
 	inputs := extractTxInputs(checked)
 	return checked, inputs, nil

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -100,12 +100,30 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 		return nil, nil, selectRelayDisposition(txAdmitRejected(reason), RelayAdmissionStableTerminalReject)
 	}
 	if policy.PolicyRejectSimplicityPreActivation {
+		// This lane has TWO error exits and they are discriminated by the SHAPE of
+		// the tuple the helper already returns, never by its message text.
+		//
+		// reject == true (with or without err) is the deployment-set-dependent
+		// half: the lookup failure and the pre-ACTIVE verdict alike are decided
+		// from what a provider published, and a {StableTip, Generation} context
+		// does not pin that set — so with a provider present they are UNAVAILABLE,
+		// never cache-authorizing, and with no provider they rest on the
+		// constructor-frozen configuration and stay stable terminal.
+		//
+		// reject == false with a non-nil err is the covenant well-formedness
+		// rejection, evaluated against a rotation shim that forces Simplicity
+		// active: it consults no deployment set at all, only the candidate, the
+		// chain id, the pinned height and the frozen live artifact hashes. Its
+		// context is complete, so it stays stable terminal even with a provider
+		// configured.
+		//
+		// The returned error, its message and its kind are unchanged in every case.
 		reject, reason, err := rejectCoreSimplicityPreActivation(parsedTx, policyUtxos, m.chainID, nextHeight, policy.RotationProvider)
 		if err != nil {
-			return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionStableTerminalReject)
+			return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForSimplicityPreActivationOutcome(reject, policy.RotationProvider))
 		}
 		if reject {
-			return nil, nil, selectRelayDisposition(txAdmitRejected(reason), RelayAdmissionStableTerminalReject)
+			return nil, nil, selectRelayDisposition(txAdmitRejected(reason), relayDispositionForSimplicityPreActivationOutcome(true, policy.RotationProvider))
 		}
 	}
 	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndValidationContext(
@@ -133,8 +151,10 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 	if err := m.applyPolicyAgainstState(checked, nextHeight, policyUtxos, policy); err != nil {
 		// Constructor-frozen, context-bound static policy: anchor outputs, the
 		// DA fee/budget terms, the retired CORE_EXT surface, and Simplicity
-		// pre-activation.
-		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), RelayAdmissionStableTerminalReject)
+		// pre-activation. The one state-availability outcome this fan-out can
+		// produce — an undetermined CORE_SIMPLICITY deployment state — is typed,
+		// and is UNAVAILABLE rather than stable terminal.
+		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForPolicyError(err))
 	}
 	inputs := extractTxInputs(checked)
 	return checked, inputs, nil

--- a/clients/go/node/mempool_stats.go
+++ b/clients/go/node/mempool_stats.go
@@ -85,6 +85,13 @@ const (
 type TxAdmitError struct {
 	Kind    TxAdmitErrorKind
 	Message string
+	// disposition is the closed relay classification that the branch which
+	// BUILT this error selected for it (see selectRelayDisposition). It is
+	// unexported and deliberately outside every public mapping: Error(), the
+	// TxAdmitErrorKind buckets, noteAdmissionResult and the HTTP status mapping
+	// neither read it nor change with it. Its zero value means "no branch
+	// selected", which relayDispositionOf reports as INTERNAL, fail closed.
+	disposition RelayAdmissionDisposition
 }
 
 func (e *TxAdmitError) Error() string { return e.Message }

--- a/clients/go/node/mempool_stats.go
+++ b/clients/go/node/mempool_stats.go
@@ -215,8 +215,9 @@ func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
 // adjustments performed by raiseMinFeeRateAfterEvictionLocked and
 // decayMinFeeRateAfterConnectedBlockLocked. EvictedResidentTotal is
 // loaded INSIDE the read-lock window. Writers bump that counter
-// under m.mu.Lock in addEntryLockedWithFloor's per-victim counter
-// loop, so the reader's m.mu.RLock pairs with the writer's m.mu.Lock and
+// under m.mu.Lock in the per-victim counter loop of
+// addEntryLockedProbed — the one implementation of the locked
+// admission path — so the reader's m.mu.RLock pairs with the writer's m.mu.Lock and
 // the atomic.Load observes the same critical section as the gauge
 // fields read on the surrounding lines. Covered by
 // TestMempoolStatsScrapePurity and the

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -73,7 +73,7 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 		t.Fatalf("TxWeightAndStats: %v", err)
 	}
 
-	if err := mp.addTxWithSource(txBytes, mempoolTxSourceRemote); err != nil {
+	if err := mp.addTxWithSource(txBytes, mempoolTxSourceRemote, nil); err != nil {
 		t.Fatalf("addTxWithSource: %v", err)
 	}
 
@@ -187,7 +187,7 @@ func TestMempoolRejectsInvalidEntrySource(t *testing.T) {
 		t.Fatalf("new mempool: %v", err)
 	}
 	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
-	err = mp.addTxWithSource(txBytes, "sidecar")
+	err = mp.addTxWithSource(txBytes, "sidecar", nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool tx source") {
 		t.Fatalf("expected invalid source rejection, got %v", err)
 	}

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -92,16 +92,32 @@ func (p *CanonicalMempoolTxPool) AddRemoteTxForRelay(txid [32]byte, raw []byte, 
 			Err:         &node.TxAdmitError{Kind: node.TxAdmitUnavailable, Message: "nil canonical mempool tx pool"},
 		}
 	}
-	if rawTxid, err := canonicalTxID(raw); err == nil && rawTxid != txid {
+	if rawTxid, rawWTxID, ok := canonicalRelayIdentity(raw); ok && rawTxid != txid {
 		return node.RelayAdmissionResult{
 			Disposition: node.RelayAdmissionInternal,
-			TxID:        rawTxid,
+			// The bytes parsed CANONICALLY to reach this branch, so BOTH identities
+			// are known and both are published: the result doc states TxID and
+			// WTxID are zero only when the candidate never parsed canonically.
+			TxID:  rawTxid,
+			WTxID: rawWTxID,
 			// An impossible-invariant admission failure keeps the producer's own
 			// compatibility kind for this class: TxAdmitRejected.
 			Err: &node.TxAdmitError{Kind: node.TxAdmitRejected, Message: fmt.Sprintf("relay adapter identity mismatch: announced %x, canonical %x", txid, rawTxid)},
 		}
 	}
 	return p.mempool.AddRemoteTxForRelay(raw, expected)
+}
+
+// canonicalRelayIdentity returns BOTH identities of canonically encoded tx
+// bytes. It applies exactly the canonical-parse test canonicalTxID applies —
+// consensus.ParseTx plus the full-consumption check — and differs from it only
+// by also yielding the wtxid the same parse already produced.
+func canonicalRelayIdentity(raw []byte) (txid [32]byte, wtxid [32]byte, ok bool) {
+	_, parsedTxid, parsedWTxID, consumed, err := consensus.ParseTx(raw)
+	if err != nil || consumed != len(raw) {
+		return [32]byte{}, [32]byte{}, false
+	}
+	return parsedTxid, parsedWTxID, true
 }
 
 func (p *CanonicalMempoolTxPool) Put(txid [32]byte, raw []byte, _ consensus.Uint128, _ int) bool {

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -61,6 +62,46 @@ func (p *CanonicalMempoolTxPool) Has(txid [32]byte) bool {
 		return false
 	}
 	return p.mempool.Contains(txid)
+}
+
+// AddRemoteTxForRelay admits a peer transaction through the canonical mempool
+// and returns the producer's result UNCHANGED: the same disposition, the
+// producer's own TxID and WTxID, the same admission-context evidence, and the
+// same error. The adapter classifies nothing itself.
+//
+// It first validates its OWN identity contract — the announced txid must be the
+// txid of the supplied canonical bytes. A mismatch is an adapter contract
+// violation, reported INTERNAL, and the mempool is never called. Bytes that do
+// not parse carry no identity to mismatch, so they are handed to the producer,
+// which owns the parse classification.
+//
+// A nil adapter returns RelayAdmissionUnavailable without reaching a mempool. A
+// nil-backed adapter is NOT special-cased here: the nil *node.Mempool receiver
+// already publishes the legacy "nil mempool" TxAdmitUnavailable result itself.
+//
+// Both adapter-local exits carry a *node.TxAdmitError, exactly like every result
+// the producer returns, so a consumer's errors.As over the Err field always
+// resolves.
+//
+// Deliberately NOT part of the generic TxPool interface: the interface stays the
+// narrow relay contract and only this concrete adapter exposes relay dispositions.
+func (p *CanonicalMempoolTxPool) AddRemoteTxForRelay(txid [32]byte, raw []byte, expected *node.PendingOutpointAdmissionContext) node.RelayAdmissionResult {
+	if p == nil {
+		return node.RelayAdmissionResult{
+			Disposition: node.RelayAdmissionUnavailable,
+			Err:         &node.TxAdmitError{Kind: node.TxAdmitUnavailable, Message: "nil canonical mempool tx pool"},
+		}
+	}
+	if rawTxid, err := canonicalTxID(raw); err == nil && rawTxid != txid {
+		return node.RelayAdmissionResult{
+			Disposition: node.RelayAdmissionInternal,
+			TxID:        rawTxid,
+			// An impossible-invariant admission failure keeps the producer's own
+			// compatibility kind for this class: TxAdmitRejected.
+			Err: &node.TxAdmitError{Kind: node.TxAdmitRejected, Message: fmt.Sprintf("relay adapter identity mismatch: announced %x, canonical %x", txid, rawTxid)},
+		}
+	}
+	return p.mempool.AddRemoteTxForRelay(raw, expected)
 }
 
 func (p *CanonicalMempoolTxPool) Put(txid [32]byte, raw []byte, _ consensus.Uint128, _ int) bool {

--- a/clients/go/node/p2p/mempool_test.go
+++ b/clients/go/node/p2p/mempool_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -332,5 +333,162 @@ func TestMemoryTxPoolEvictsByRateNotProduct(t *testing.T) {
 	}
 	if !pool.Has(dense) || pool.Has(bulky) {
 		t.Fatal("pool should still hold only the higher-rate entry")
+	}
+}
+
+// TestCanonicalMempoolTxPoolRelayAdmissionPreservesProducerResult proves the
+// adapter classifies NOTHING itself: for every candidate whose announced txid
+// matches its canonical bytes — including bytes that do not parse at all, which
+// carry no identity to match — the adapter's result is field-for-field the
+// producer's own.
+func TestCanonicalMempoolTxPoolRelayAdmissionPreservesProducerResult(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "unparseable bytes reach the producer", raw: []byte{0xFF, 0x00, 0x13, 0x37}},
+		{name: "minimal canonical tx", raw: minimalValidTxBytes(t)},
+		{name: "distinct canonical tx", raw: distinctTxBytes(t, 7)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mempool, err := node.NewMempool(node.NewChainState(), nil, [32]byte{})
+			if err != nil {
+				t.Fatalf("NewMempool: %v", err)
+			}
+			// A rejected candidate leaves no state behind, so the producer's own
+			// call and the adapter's call observe the identical mempool.
+			direct := mempool.AddRemoteTxForRelay(tc.raw, nil)
+			if direct.Err == nil {
+				t.Fatalf("fixture admitted; this comparison needs a rejected candidate")
+			}
+			announced, err := canonicalTxID(tc.raw)
+			if err != nil {
+				announced = [32]byte{}
+			}
+
+			got := NewCanonicalMempoolTxPool(mempool).AddRemoteTxForRelay(announced, tc.raw, nil)
+			if got.Disposition != direct.Disposition {
+				t.Fatalf("disposition=%v, want the producer's %v", got.Disposition, direct.Disposition)
+			}
+			if got.TxID != direct.TxID || got.WTxID != direct.WTxID {
+				t.Fatalf("identity=(%x,%x), want the producer's (%x,%x)", got.TxID, got.WTxID, direct.TxID, direct.WTxID)
+			}
+			if got.HasAdmissionContext != direct.HasAdmissionContext || got.AdmissionContext != direct.AdmissionContext {
+				t.Fatalf("context=(%v,%+v), want the producer's (%v,%+v)", got.HasAdmissionContext, got.AdmissionContext, direct.HasAdmissionContext, direct.AdmissionContext)
+			}
+			if got.Err == nil || got.Err.Error() != direct.Err.Error() {
+				t.Fatalf("err=%v, want the producer's %v", got.Err, direct.Err)
+			}
+			if got.Disposition == node.RelayAdmissionInternal {
+				t.Fatal("the adapter must not reclassify a delegated candidate as INTERNAL")
+			}
+		})
+	}
+}
+
+// TestCanonicalMempoolTxPoolRelayAdmissionRetainsAdmittedCandidate proves the
+// adapter's SUCCESS pass-through: a candidate that really admits comes back
+// RETAINED, with the producer's own identities and no error.
+func TestCanonicalMempoolTxPoolRelayAdmissionRetainsAdmittedCandidate(t *testing.T) {
+	chainState := node.NewChainState()
+	raw, txid, utxos := signedCanonicalP2PTxWithoutSeeding(t, 1)
+	for op, entry := range utxos {
+		chainState.Utxos[op] = entry
+	}
+	mempool, err := node.NewMempool(chainState, nil, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+
+	got := NewCanonicalMempoolTxPool(mempool).AddRemoteTxForRelay(txid, raw, nil)
+	if got.Disposition != node.RelayAdmissionRetained {
+		t.Fatalf("disposition=%v, want RETAINED (err=%v)", got.Disposition, got.Err)
+	}
+	if got.Err != nil {
+		t.Fatalf("err=%v, want nil", got.Err)
+	}
+	if got.TxID != txid {
+		t.Fatalf("TxID=%x, want the canonical %x", got.TxID, txid)
+	}
+	if got.WTxID == ([32]byte{}) {
+		t.Fatal("WTxID is zero for an admitted candidate")
+	}
+	if got.HasAdmissionContext {
+		t.Fatal("a nil expected context must never authorize caching")
+	}
+	if !mempool.Contains(txid) {
+		t.Fatal("RETAINED was published for a candidate that is not resident")
+	}
+}
+
+// TestCanonicalMempoolTxPoolRelayAdmissionIdentityMismatchIsInternal pins the
+// adapter's OWN contract: an announced txid that is not the txid of the supplied
+// canonical bytes is an adapter contract violation, and the mempool is never
+// reached.
+func TestCanonicalMempoolTxPoolRelayAdmissionIdentityMismatchIsInternal(t *testing.T) {
+	mempool, err := node.NewMempool(node.NewChainState(), nil, [32]byte{})
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	raw := distinctTxBytes(t, 11)
+	canonical, err := canonicalTxID(raw)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	var announced [32]byte
+	announced[0] = ^canonical[0]
+
+	got := NewCanonicalMempoolTxPool(mempool).AddRemoteTxForRelay(announced, raw, nil)
+	if got.Disposition != node.RelayAdmissionInternal {
+		t.Fatalf("disposition=%v, want INTERNAL", got.Disposition)
+	}
+	if got.TxID != canonical {
+		t.Fatalf("TxID=%x, want the canonical %x", got.TxID, canonical)
+	}
+	var admitErr *node.TxAdmitError
+	if !errors.As(got.Err, &admitErr) {
+		t.Fatalf("err=%v (%T), want a *node.TxAdmitError", got.Err, got.Err)
+	}
+	if got.HasAdmissionContext {
+		t.Fatal("an adapter contract violation must never authorize caching")
+	}
+	if mempool.AdmissionCounts() != (node.MempoolAdmissionCounts{}) {
+		t.Fatalf("the mempool was reached despite the identity mismatch: %+v", mempool.AdmissionCounts())
+	}
+}
+
+// TestCanonicalMempoolTxPoolRelayAdmissionNilSafeAndOffTheGenericInterface pins
+// the nil-receiver contract shared with the adapter's other methods, and that
+// the relay-admission method did NOT widen the generic TxPool contract.
+func TestCanonicalMempoolTxPoolRelayAdmissionNilSafeAndOffTheGenericInterface(t *testing.T) {
+	var nilAdapter *CanonicalMempoolTxPool
+	for name, adapter := range map[string]*CanonicalMempoolTxPool{
+		"nil adapter":        nilAdapter,
+		"nil-backed adapter": NewCanonicalMempoolTxPool(nil),
+	} {
+		got := adapter.AddRemoteTxForRelay([32]byte{}, []byte{0x01}, nil)
+		if got.Disposition != node.RelayAdmissionUnavailable {
+			t.Fatalf("%s: disposition=%v, want UNAVAILABLE", name, got.Disposition)
+		}
+		// The adapter's own exits carry the same typed error every producer
+		// result carries, so a consumer's errors.As always resolves.
+		var admitErr *node.TxAdmitError
+		if !errors.As(got.Err, &admitErr) {
+			t.Fatalf("%s: err=%v (%T), want a *node.TxAdmitError", name, got.Err, got.Err)
+		}
+		if admitErr.Kind != node.TxAdmitUnavailable {
+			t.Fatalf("%s: kind=%q, want %q", name, admitErr.Kind, node.TxAdmitUnavailable)
+		}
+		if got.HasAdmissionContext || got.TxID != ([32]byte{}) {
+			t.Fatalf("%s: published identity or context: %+v", name, got)
+		}
+	}
+
+	var generic TxPool = NewMemoryTxPool()
+	if _, widened := generic.(interface {
+		AddRemoteTxForRelay([32]byte, []byte, *node.PendingOutpointAdmissionContext) node.RelayAdmissionResult
+	}); widened {
+		t.Fatal("the generic TxPool surface was widened with relay admission")
 	}
 }

--- a/clients/go/node/p2p/mempool_test.go
+++ b/clients/go/node/p2p/mempool_test.go
@@ -432,9 +432,12 @@ func TestCanonicalMempoolTxPoolRelayAdmissionIdentityMismatchIsInternal(t *testi
 		t.Fatalf("NewMempool: %v", err)
 	}
 	raw := distinctTxBytes(t, 11)
-	canonical, err := canonicalTxID(raw)
-	if err != nil {
-		t.Fatalf("canonicalTxID: %v", err)
+	canonical, canonicalWTxID, ok := canonicalRelayIdentity(raw)
+	if !ok {
+		t.Fatal("canonicalRelayIdentity: the fixture must parse canonically")
+	}
+	if canonicalWTxID == ([32]byte{}) {
+		t.Fatal("the fixture's wtxid must be non-zero for this row to be meaningful")
 	}
 	var announced [32]byte
 	announced[0] = ^canonical[0]
@@ -445,6 +448,12 @@ func TestCanonicalMempoolTxPoolRelayAdmissionIdentityMismatchIsInternal(t *testi
 	}
 	if got.TxID != canonical {
 		t.Fatalf("TxID=%x, want the canonical %x", got.TxID, canonical)
+	}
+	// The branch is entered only because the bytes parsed canonically, so the
+	// published identity must be WHOLE: a zero wtxid here would contradict the
+	// RelayAdmissionResult contract that zero means "never parsed canonically".
+	if got.WTxID != canonicalWTxID {
+		t.Fatalf("WTxID=%x, want the parsed %x", got.WTxID, canonicalWTxID)
 	}
 	var admitErr *node.TxAdmitError
 	if !errors.As(got.Err, &admitErr) {

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -258,12 +258,29 @@ func (p *relayAdmissionProbe) noteIdentity(txid, wtxid [32]byte) {
 // other mutation. It exists for the candidate shape that claims no outpoint and
 // therefore never reaches Reserve, so no candidate shape can bypass the check.
 //
-// tip is the ChainState tip the caller's admission read guard is pinning. The
-// availability and tip-agreement checks are the SAME two the input-bearing
-// sibling runs before Reserve (reserveEntryInputsLocked), with the same messages
-// and the same order, and the equality check below stands in for the generation
-// refusal Reserve would perform — so this seam enforces exactly what the sibling
-// enforces, never less.
+// tip is the ChainState tip the caller's admission read guard is pinning. It
+// performs three checks, in this order, each of them UNAVAILABLE:
+//
+//  1. the owner publishes a complete admission context at all;
+//  2. that context's stable tip equals tip;
+//  3. that context equals the caller's expected context.
+//
+// Checks 1 and 2 are the SAME two the input-bearing sibling
+// (reserveEntryInputsLocked) runs before Reserve, with the same messages in the
+// same order. Check 3 stands in for the two refusals Reserve would raise from
+// the supplied context — "pending-outpoint expected tip mismatch" and
+// "pending-outpoint expected generation mismatch" — but reports both through ONE
+// combined message, so a consumer cannot tell those two apart here.
+//
+// Reserve's remaining refusals do not apply to a candidate that claims no
+// outpoint: it reserves nothing and takes no token, so the token-sequence
+// exhaustion refusal cannot bear on its outcome; the conflict scan has no
+// outpoint of its own to find a live claim for; and Reserve's empty-input-set
+// rejection describes exactly this candidate shape, which is why it must not be
+// routed through Reserve at all. A transition in progress is not missing either:
+// check 1 already reports unavailable while one is active, and the whole
+// admission call holds the ChainState admission read guard a transition needs
+// for write, so none can begin between this seam and the decision it feeds.
 //
 // It is a no-op for the legacy path (nil probe) and for a nil expected context,
 // so an input-less candidate keeps its exact baseline behavior there.
@@ -481,15 +498,34 @@ func relayDispositionForSimplicityPreActivationOutcome(reject bool, rotation con
 // relayDispositionForPolicyError classifies the static-policy fan-out
 // (applyPolicyAgainstState). Every term it applies is a constructor-frozen
 // decision over pinned inputs — anchor outputs, the DA fee/budget terms, the
-// retired CORE_EXT surface — EXCEPT the CORE_SIMPLICITY pre-activation lane,
-// whose provider-DECIDED outcomes arrive as a typed wrapper because the
-// published context does not pin the deployment set they depend on. That lane's
-// well-formedness rejection depends on no such set and arrives unwrapped, so it
-// classifies here with the pinned-input terms. It reads a type, never a message.
+// retired CORE_EXT surface — EXCEPT two outcomes that arrive as typed wrappers
+// and are read by TYPE, never by message:
+//
+//   - the CORE_SIMPLICITY pre-activation lane's provider-DECIDED outcomes, which
+//     are UNAVAILABLE because the published context does not pin the deployment
+//     set they depend on. That lane's well-formedness rejection depends on no
+//     such set, arrives unwrapped, and classifies with the pinned-input terms.
+//   - the fan-out's own impossible invariant, the nil checked transaction no
+//     caller can produce, which is INTERNAL and so never cache-authorizing.
+//
+// The CORE_EXT term (applyPolicyAgainstStateCoreExtUnsupported) has a second
+// branch, "input snapshot unavailable for CORE_EXT unsupported policy", which
+// would be a state-availability outcome rather than static policy. It is
+// deliberately left unwrapped because it is UNREACHABLE from this fan-out: it
+// fires only for a candidate that HAS inputs and whose policy utxo snapshot is
+// nil, and policyNeedsInputSnapshotForTx returns true whenever the candidate has
+// inputs, so buildPolicyInputSnapshotIfNeeded either hands the fan-out a non-nil
+// snapshot for such a candidate or fails before the fan-out runs. A candidate
+// that reaches the fan-out with a nil snapshot therefore has no inputs, and the
+// branch requires len(Inputs) > 0.
 func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 	var retryable *simplicityPreActivationRetryableError
 	if errors.As(err, &retryable) {
 		return RelayAdmissionUnavailable
+	}
+	var impossible *policyImpossibleInvariantError
+	if errors.As(err, &impossible) {
+		return RelayAdmissionInternal
 	}
 	return RelayAdmissionStableTerminalReject
 }

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -10,7 +10,9 @@ import (
 // admission outcome, published for relay-side download and representation
 // state. The enum is exactly the eleven values below, and every production exit
 // of Mempool.AddRemoteTxForRelay selects one of them AT the branch that decided
-// the outcome, before any compatibility mapping onto TxAdmitErrorKind.
+// the outcome, before any compatibility mapping onto TxAdmitErrorKind — except
+// for the fail-closed RelayAdmissionInternal override a failed REQUIRED
+// post-decision cleanup applies over that selection (see RelayAdmissionInternal).
 //
 // A consumer MUST NOT infer a disposition from TxAdmitError.Kind, from Error(),
 // from message text, from the HTTP status mapping, or from a fallback default:
@@ -30,6 +32,15 @@ const (
 	// consensus, or constructor-frozen context-bound static-policy rejection.
 	// It is the ONLY disposition that may carry cache-authorizing context
 	// evidence, and only when that exact context was proven for this call.
+	//
+	// A policy lane OUTCOME whose verdict depends on state the published context
+	// does NOT pin is therefore not one of these, however static its
+	// configuration looks: a CORE_SIMPLICITY pre-activation outcome decided from
+	// a deployment provider reads a published deployment set that a
+	// {StableTip, Generation} context does not bind, so it is UNAVAILABLE. The
+	// classification is per outcome, not per lane — the same lane's
+	// well-formedness rejection reads no deployment set and stays here
+	// (see relayDispositionForSimplicityPreActivationOutcome).
 	RelayAdmissionStableTerminalReject
 	// RelayAdmissionDuplicate means a resident txid or wtxid duplicate.
 	RelayAdmissionDuplicate
@@ -45,8 +56,7 @@ const (
 	RelayAdmissionRollingFloor
 	// RelayAdmissionCapacity is the retryable capacity outcome.
 	RelayAdmissionCapacity
-	// RelayAdmissionAdmissionSequence is the retryable admission-sequence
-	// outcome.
+	// RelayAdmissionAdmissionSequence is the admission-sequence outcome.
 	RelayAdmissionAdmissionSequence
 	// RelayAdmissionUnavailable covers an absent chain, owner or admission
 	// context, an active canonical transition, a stale expected context, and
@@ -55,6 +65,14 @@ const (
 	// RelayAdmissionInternal covers an impossible invariant, a retained
 	// identity mismatch, accounting corruption, and an adapter contract
 	// violation.
+	//
+	// It is also the ONE disposition a branch does not have to select: a
+	// REQUIRED post-decision cleanup step that reports a fault — pending-outpoint
+	// owner accounting corruption, a claim inconsistency — publishes INTERNAL and
+	// OUTRANKS the disposition the deciding branch already selected, because that
+	// branch's verdict is no longer the whole truth about the call. The public
+	// error still reports the branch's outcome unchanged, so a consumer that
+	// wants the corruption signal MUST read the disposition.
 	RelayAdmissionInternal
 	// RelayAdmissionCancelled is a closed enum value ONLY. This surface
 	// implements no cancellation framework and no production branch selects it.
@@ -99,6 +117,12 @@ func (d RelayAdmissionDisposition) String() string {
 // context this call validated against. Nothing else authorizes a relay
 // representation cache.
 //
+// Disposition is the deciding branch's own selection, EXCEPT when a REQUIRED
+// post-decision cleanup step reported a fault: that publishes
+// RelayAdmissionInternal and outranks the branch's selection, while Err keeps
+// reporting the branch's outcome byte-identically. Disposition is therefore the
+// only field that can report an accounting corruption the cleanup layer found.
+//
 // Err is the unchanged public admission error the equivalent AddRemoteTx call
 // returns: same type, same TxAdmitErrorKind, same message. It is nil exactly on
 // the success exit, whose disposition is RelayAdmissionRetained — or, if the
@@ -123,10 +147,17 @@ type RelayAdmissionResult struct {
 // expected is the caller's own observed pending-outpoint admission context. A
 // nil expected context admits exactly as AddRemoteTx does, never sets
 // HasAdmissionContext, and never authorizes caching. A NON-nil expected context
-// is validated at the existing owner seam (PendingOutpointOwner.Reserve), after
-// the baseline parse, consensus, policy, cheap-floor and duplicate precedence: a
-// stale, superseded or mismatched context is UNAVAILABLE there, before the
-// owner scans for a conflict and before it consumes a sequence.
+// is COPIED BY VALUE at this boundary and never dereferenced again: this call
+// compares against, and publishes evidence for, the snapshot taken here, so a
+// caller that mutates the pointee afterwards — from this goroutine or any
+// other — can change neither this call's admission behavior nor its published
+// evidence. The pointer is a presence flag only; the memory stays the caller's.
+//
+// The snapshot is validated at the existing owner seam
+// (PendingOutpointOwner.Reserve), after the baseline parse, consensus, policy,
+// cheap-floor and duplicate precedence: a stale, superseded or mismatched
+// context is UNAVAILABLE there, before the owner scans for a conflict and
+// before it consumes a sequence.
 //
 // It classifies without mutating: every classification input is either the
 // producing branch's own decision or a pure read. Public errors, messages,
@@ -136,9 +167,23 @@ type RelayAdmissionResult struct {
 // RelayAdmissionUnavailable carrying the legacy "nil mempool" TxAdmitUnavailable
 // error, publishes no identity and no context, and moves no counter.
 func (m *Mempool) AddRemoteTxForRelay(txBytes []byte, expected *PendingOutpointAdmissionContext) RelayAdmissionResult {
-	probe := &relayAdmissionProbe{expected: expected}
+	probe := newRelayAdmissionProbe(expected)
 	err := m.addTxWithSource(txBytes, mempoolTxSourceRemote, probe)
 	return probe.result(err)
+}
+
+// newRelayAdmissionProbe is the ONLY constructor of a probe carrying an expected
+// context. It copies the caller-owned context by value, so the pointer never
+// escapes this function and no later read of the probe can observe a mutation
+// the caller made after entry. A nil expected context leaves hasExpected false,
+// which is the legacy binding every seam already keys off.
+func newRelayAdmissionProbe(expected *PendingOutpointAdmissionContext) *relayAdmissionProbe {
+	probe := &relayAdmissionProbe{}
+	if expected != nil {
+		probe.expected = *expected
+		probe.hasExpected = true
+	}
+	return probe
 }
 
 // relayAdmissionProbe is the per-call producer sink for the relay evidence a
@@ -153,14 +198,47 @@ func (m *Mempool) AddRemoteTxForRelay(txBytes []byte, expected *PendingOutpointA
 // selected at its originating branch and carried by the admission error itself
 // (selectRelayDisposition), so no helper signature, error, message, counter or
 // ordering had to change to make a branch classifiable.
+//
+// internalFailure is the ONE exception, and it is not a branch selection: a
+// REQUIRED post-decision cleanup step ran AFTER its branch already tagged the
+// error, so first-selection-wins leaves the cleanup layer no way to reclassify.
+// It records the fault here instead and result() applies it as a fail-closed
+// override.
+//
+// expected is a VALUE snapshot taken once by newRelayAdmissionProbe, never a
+// caller-owned pointer: every seam below reads memory this call owns, so the
+// context proven, compared and published stays the one supplied at entry.
+// hasExpected — not a sentinel value — distinguishes "no expected context"
+// from a legitimately zero one.
 type relayAdmissionProbe struct {
-	expected      *PendingOutpointAdmissionContext
+	expected      PendingOutpointAdmissionContext
+	hasExpected   bool
 	observed      PendingOutpointAdmissionContext
 	contextProven bool
 	// success is the disposition of the nil-error exit only.
 	success RelayAdmissionDisposition
 	txid    [32]byte
 	wtxid   [32]byte
+	// internalFailure records that a REQUIRED post-decision cleanup step
+	// reported a fault. It is never a branch selection; result() turns it into
+	// the fail-closed INTERNAL override.
+	internalFailure bool
+}
+
+// noteCleanupFailure records a REQUIRED post-decision cleanup fault — an owner
+// accounting inconsistency, a claim inconsistency, or an impossible invariant
+// that only the cleanup step can observe. err is the cleanup step's own result:
+// a nil err records nothing, so the ordinary successful-cleanup path is
+// untouched and keeps the disposition its branch selected.
+//
+// It changes no error, message, kind, counter, ordering or mutation: the caller
+// still returns its unchanged admission cause. A nil probe is the legacy
+// AddTx / AddRemoteTx / AddReorgTx path and this is a no-op there.
+func (p *relayAdmissionProbe) noteCleanupFailure(err error) {
+	if p == nil || err == nil {
+		return
+	}
+	p.internalFailure = true
 }
 
 // noteIdentity records the identity the producer parsed from the candidate
@@ -190,7 +268,7 @@ func (p *relayAdmissionProbe) noteIdentity(txid, wtxid [32]byte) {
 // It is a no-op for the legacy path (nil probe) and for a nil expected context,
 // so an input-less candidate keeps its exact baseline behavior there.
 func (p *relayAdmissionProbe) checkExpectedContext(owner *PendingOutpointOwner, tip PendingOutpointTip) error {
-	if p == nil || p.expected == nil {
+	if p == nil || !p.hasExpected {
 		return nil
 	}
 	observed, ok := owner.AdmissionContext()
@@ -200,7 +278,7 @@ func (p *relayAdmissionProbe) checkExpectedContext(owner *PendingOutpointOwner, 
 	if observed.StableTip != tip {
 		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip"), RelayAdmissionUnavailable)
 	}
-	if observed != *p.expected {
+	if observed != p.expected {
 		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint expected admission context mismatch"), RelayAdmissionUnavailable)
 	}
 	return nil
@@ -208,6 +286,12 @@ func (p *relayAdmissionProbe) checkExpectedContext(owner *PendingOutpointOwner, 
 
 // result assembles the immutable published result from the producer's own
 // selections. It reads no error message and no error kind.
+//
+// A recorded REQUIRED-cleanup fault OUTRANKS the branch-selected disposition:
+// the branch decided the outcome before the cleanup ran, and first-selection-wins
+// keeps it from reclassifying, so the override lives here. It publishes INTERNAL
+// and, since INTERNAL is not a stable terminal rejection, no cache-authorizing
+// context.
 func (p *relayAdmissionProbe) result(err error) RelayAdmissionResult {
 	if p == nil {
 		// The legacy path allocates no probe. It publishes no identity and no
@@ -224,6 +308,11 @@ func (p *relayAdmissionProbe) result(err error) RelayAdmissionResult {
 	default:
 		// Unreachable: the success exit always selects. Fail closed rather than
 		// publish an unselected value as a classification.
+		out.Disposition = RelayAdmissionInternal
+	}
+	if p.internalFailure {
+		// Fail-closed override, applied AFTER the selection it outranks: the
+		// branch's verdict is no longer the whole truth about this call.
 		out.Disposition = RelayAdmissionInternal
 	}
 	// Only an explicit stable terminal rejection carries cache-authorizing
@@ -251,14 +340,14 @@ func (p *relayAdmissionProbe) result(err error) RelayAdmissionResult {
 // therefore the exact one every later decision of this call runs against,
 // including the decisions that return before the owner seam.
 func (m *Mempool) bindRelayAdmissionContext(probe *relayAdmissionProbe) {
-	if probe == nil || probe.expected == nil {
+	if probe == nil || !probe.hasExpected {
 		return
 	}
 	m.mu.RLock()
 	owner := m.pendingOutpoints
 	m.mu.RUnlock()
 	observed, ok := owner.AdmissionContext()
-	if !ok || observed.StableTip != pendingOutpointTipOf(m.chainState) || observed != *probe.expected {
+	if !ok || observed.StableTip != pendingOutpointTipOf(m.chainState) || observed != probe.expected {
 		return
 	}
 	probe.observed = observed
@@ -328,6 +417,81 @@ func relayDispositionForOwnerError(err error) RelayAdmissionDisposition {
 	default:
 		return RelayAdmissionInternal
 	}
+}
+
+// relayDispositionForSimplicityPreActivation selects the CORE_SIMPLICITY
+// pre-activation disposition from the ONE thing that decides whether the
+// published admission context is complete for this lane: whether a deployment
+// provider governs the verdict at all.
+//
+// With a provider present EVERY outcome — the lookup failure, an unobtainable
+// or only partially known set, and an inactive one alike — is UNAVAILABLE and
+// never cache-authorizing. consensus.SimplicityActiveAtHeight reads the
+// provider by documented pure I/O, and consensus.SimplicityDeploymentSetAnchor
+// binds that set to (chain_id, descriptors) and to no block or tip, while a
+// PendingOutpointAdmissionContext pins only {StableTip, Generation}. The set can
+// therefore differ at the same tip and generation, so the context is not
+// complete with respect to this decision. A descriptor's ActivationHeight makes
+// a pre-ACTIVE rejection flip to valid by advancing height anyway — the same
+// property for which TX_ERR_TIMELOCK_NOT_MET and TX_ERR_COINBASE_IMMATURE are
+// classified retryable rather than stable terminal.
+//
+// With no provider the rotation implements no deployment surface: the lane does
+// no I/O and reads no descriptor set, so the verdict rests entirely on the
+// constructor-frozen configuration the context does pin, and stays stable
+// terminal. That is the default node wiring, which publishes no provider.
+func relayDispositionForSimplicityPreActivation(rotation consensus.RotationProvider) RelayAdmissionDisposition {
+	if _, ok := rotation.(consensus.SimplicityDeploymentProvider); ok {
+		return RelayAdmissionUnavailable
+	}
+	return RelayAdmissionStableTerminalReject
+}
+
+// relayDispositionForSimplicityPreActivationOutcome narrows the lane-wide rule
+// above to the ONE outcome that actually consulted the deployment set, using the
+// (reject, err) tuple rejectCoreSimplicityPreActivation already returns as the
+// discriminator — never its message text, and never a second probe of the
+// provider.
+//
+// reject == true is the deployment-set-dependent half of the lane, and it is
+// exactly the half the provider governs: the lookup failure returns
+// (true, reason, err) and the pre-ACTIVE verdict returns (true, reason, nil).
+// Both are decided from what the provider published — or, with no provider,
+// from the constructor-frozen configuration — so they take the lane-wide rule.
+//
+// reject == false with a non-nil err is the covenant well-formedness rejection
+// consensus.ValidateTxCovenantsGenesis returned against a rotation shim that
+// FORCES Simplicity active. That verdict never reads the provider's set: it is a
+// function of the candidate bytes, the chain id, the pinned next-block height
+// and the frozen live artifact hashes — every one of which the published
+// {StableTip, Generation} context does pin or the candidate itself carries. It
+// is therefore context-complete and stays stable terminal whether or not a
+// provider is configured, so the same malformed bytes are cacheable exactly as
+// they are on the default no-provider wiring.
+//
+// The remaining tuple, (false, "", nil), is the accept exit and reaches no
+// caller of this function.
+func relayDispositionForSimplicityPreActivationOutcome(reject bool, rotation consensus.RotationProvider) RelayAdmissionDisposition {
+	if !reject {
+		return RelayAdmissionStableTerminalReject
+	}
+	return relayDispositionForSimplicityPreActivation(rotation)
+}
+
+// relayDispositionForPolicyError classifies the static-policy fan-out
+// (applyPolicyAgainstState). Every term it applies is a constructor-frozen
+// decision over pinned inputs — anchor outputs, the DA fee/budget terms, the
+// retired CORE_EXT surface — EXCEPT the CORE_SIMPLICITY pre-activation lane,
+// whose provider-DECIDED outcomes arrive as a typed wrapper because the
+// published context does not pin the deployment set they depend on. That lane's
+// well-formedness rejection depends on no such set and arrives unwrapped, so it
+// classifies here with the pinned-input terms. It reads a type, never a message.
+func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
+	var retryable *simplicityPreActivationRetryableError
+	if errors.As(err, &retryable) {
+		return RelayAdmissionUnavailable
+	}
+	return RelayAdmissionStableTerminalReject
 }
 
 // relayDispositionForInputError separates the RETRYABLE input-dependency class

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -1,0 +1,351 @@
+package node
+
+import (
+	"errors"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// RelayAdmissionDisposition is the closed classification of ONE remote-mempool
+// admission outcome, published for relay-side download and representation
+// state. The enum is exactly the eleven values below, and every production exit
+// of Mempool.AddRemoteTxForRelay selects one of them AT the branch that decided
+// the outcome, before any compatibility mapping onto TxAdmitErrorKind.
+//
+// A consumer MUST NOT infer a disposition from TxAdmitError.Kind, from Error(),
+// from message text, from the HTTP status mapping, or from a fallback default:
+// those are lossy compatibility views. TxAdmitConflict alone carries both the
+// DUPLICATE and the CONFLICT branch, and TxAdmitUnavailable carries the floor,
+// capacity, sequence, dependency-free unavailability and internal branches.
+//
+// The zero value is deliberately NOT a member of the enum, so a value that no
+// branch selected can never be mistaken for a classification.
+type RelayAdmissionDisposition uint8
+
+const (
+	// RelayAdmissionRetained means the exact candidate representation is
+	// resident in the mempool after the call.
+	RelayAdmissionRetained RelayAdmissionDisposition = iota + 1
+	// RelayAdmissionStableTerminalReject is an explicit canonical, structural,
+	// consensus, or constructor-frozen context-bound static-policy rejection.
+	// It is the ONLY disposition that may carry cache-authorizing context
+	// evidence, and only when that exact context was proven for this call.
+	RelayAdmissionStableTerminalReject
+	// RelayAdmissionDuplicate means a resident txid or wtxid duplicate.
+	RelayAdmissionDuplicate
+	// RelayAdmissionConflict means an exact existing pending-outpoint owner
+	// conflict.
+	RelayAdmissionConflict
+	// RelayAdmissionMissingDependency means a referenced input is absent or not
+	// spendable yet. It is retryable and is never stable-terminal: the same
+	// bytes can admit at a later height.
+	RelayAdmissionMissingDependency
+	// RelayAdmissionRollingFloor is the retryable rolling-relay-fee-floor
+	// outcome.
+	RelayAdmissionRollingFloor
+	// RelayAdmissionCapacity is the retryable capacity outcome.
+	RelayAdmissionCapacity
+	// RelayAdmissionAdmissionSequence is the retryable admission-sequence
+	// outcome.
+	RelayAdmissionAdmissionSequence
+	// RelayAdmissionUnavailable covers an absent chain, owner or admission
+	// context, an active canonical transition, a stale expected context, and
+	// retryable runtime unavailability.
+	RelayAdmissionUnavailable
+	// RelayAdmissionInternal covers an impossible invariant, a retained
+	// identity mismatch, accounting corruption, and an adapter contract
+	// violation.
+	RelayAdmissionInternal
+	// RelayAdmissionCancelled is a closed enum value ONLY. This surface
+	// implements no cancellation framework and no production branch selects it.
+	RelayAdmissionCancelled
+)
+
+var relayAdmissionDispositionNames = [...]string{
+	RelayAdmissionRetained:             "RETAINED",
+	RelayAdmissionStableTerminalReject: "STABLE_TERMINAL_REJECT",
+	RelayAdmissionDuplicate:            "DUPLICATE",
+	RelayAdmissionConflict:             "CONFLICT",
+	RelayAdmissionMissingDependency:    "MISSING_DEPENDENCY",
+	RelayAdmissionRollingFloor:         "ROLLING_FLOOR",
+	RelayAdmissionCapacity:             "CAPACITY",
+	RelayAdmissionAdmissionSequence:    "ADMISSION_SEQUENCE",
+	RelayAdmissionUnavailable:          "UNAVAILABLE",
+	RelayAdmissionInternal:             "INTERNAL",
+	RelayAdmissionCancelled:            "CANCELLED",
+}
+
+// String renders the closed enum name. A value outside the enum — including the
+// zero value that means "no branch selected" — renders as UNSELECTED and is
+// never a classification.
+func (d RelayAdmissionDisposition) String() string {
+	if int(d) < len(relayAdmissionDispositionNames) && relayAdmissionDispositionNames[d] != "" {
+		return relayAdmissionDispositionNames[d]
+	}
+	return "UNSELECTED"
+}
+
+// RelayAdmissionResult is the immutable result of one relay admission. It is
+// returned by value and holds no reference the caller can mutate back into the
+// mempool.
+//
+// TxID and WTxID are the identities the producer PARSED from the candidate
+// bytes; they are the zero hash when the candidate never parsed canonically.
+//
+// AdmissionContext is meaningful ONLY when HasAdmissionContext is true, and is
+// the zero context otherwise. HasAdmissionContext is set only for
+// RelayAdmissionStableTerminalReject, and only when the caller-supplied
+// expected context was proven equal to the exact complete stable admission
+// context this call validated against. Nothing else authorizes a relay
+// representation cache.
+//
+// Err is the unchanged public admission error the equivalent AddRemoteTx call
+// returns: same type, same TxAdmitErrorKind, same message. It is nil exactly on
+// the success exit, whose disposition is RelayAdmissionRetained — or, if the
+// published record somehow failed to be the exact candidate, the
+// retained-identity-mismatch RelayAdmissionInternal that a nil error can also
+// carry.
+type RelayAdmissionResult struct {
+	Disposition         RelayAdmissionDisposition
+	TxID                [32]byte
+	WTxID               [32]byte
+	AdmissionContext    PendingOutpointAdmissionContext
+	HasAdmissionContext bool
+	Err                 error
+}
+
+// AddRemoteTxForRelay admits a transaction received from a peer through EXACTLY
+// the AddRemoteTx implementation, and additionally publishes the
+// producer-selected relay disposition, the parsed candidate identity, and — for
+// a proven stable terminal rejection only — the exact stable admission context
+// a relay representation cache needs.
+//
+// expected is the caller's own observed pending-outpoint admission context. A
+// nil expected context admits exactly as AddRemoteTx does, never sets
+// HasAdmissionContext, and never authorizes caching. A NON-nil expected context
+// is validated at the existing owner seam (PendingOutpointOwner.Reserve), after
+// the baseline parse, consensus, policy, cheap-floor and duplicate precedence: a
+// stale, superseded or mismatched context is UNAVAILABLE there, before the
+// owner scans for a conflict and before it consumes a sequence.
+//
+// It classifies without mutating: every classification input is either the
+// producing branch's own decision or a pure read. Public errors, messages,
+// admission counters, validation order and mutation order are untouched.
+//
+// Nil-safe like every other exported Mempool accessor: a nil receiver returns
+// RelayAdmissionUnavailable carrying the legacy "nil mempool" TxAdmitUnavailable
+// error, publishes no identity and no context, and moves no counter.
+func (m *Mempool) AddRemoteTxForRelay(txBytes []byte, expected *PendingOutpointAdmissionContext) RelayAdmissionResult {
+	probe := &relayAdmissionProbe{expected: expected}
+	err := m.addTxWithSource(txBytes, mempoolTxSourceRemote, probe)
+	return probe.result(err)
+}
+
+// relayAdmissionProbe is the per-call producer sink for the relay evidence a
+// plain error cannot carry: the candidate identity the producer parsed, the
+// exact stable admission context this call ran against, and the selection made
+// on the success exit. Exactly one admission call owns one probe.
+//
+// A nil probe is the legacy AddTx / AddRemoteTx / AddReorgTx path: every method
+// here is nil-safe, so that path allocates nothing and does nothing extra.
+//
+// The disposition of a FAILED admission deliberately does not travel here. It is
+// selected at its originating branch and carried by the admission error itself
+// (selectRelayDisposition), so no helper signature, error, message, counter or
+// ordering had to change to make a branch classifiable.
+type relayAdmissionProbe struct {
+	expected      *PendingOutpointAdmissionContext
+	observed      PendingOutpointAdmissionContext
+	contextProven bool
+	// success is the disposition of the nil-error exit only.
+	success RelayAdmissionDisposition
+	txid    [32]byte
+	wtxid   [32]byte
+}
+
+// noteIdentity records the identity the producer parsed from the candidate
+// bytes. It is called once, immediately after the canonical parse succeeds, so
+// every outcome decided from that point on reports the real candidate identity
+// and an unparseable candidate reports none.
+func (p *relayAdmissionProbe) noteIdentity(txid, wtxid [32]byte) {
+	if p == nil {
+		return
+	}
+	p.txid = txid
+	p.wtxid = wtxid
+}
+
+// checkExpectedContext validates a caller-supplied expected admission context
+// against the owner AT the seam, without creating an owner and without any
+// other mutation. It exists for the candidate shape that claims no outpoint and
+// therefore never reaches Reserve, so no candidate shape can bypass the check.
+//
+// tip is the ChainState tip the caller's admission read guard is pinning. The
+// availability and tip-agreement checks are the SAME two the input-bearing
+// sibling runs before Reserve (reserveEntryInputsLocked), with the same messages
+// and the same order, and the equality check below stands in for the generation
+// refusal Reserve would perform — so this seam enforces exactly what the sibling
+// enforces, never less.
+//
+// It is a no-op for the legacy path (nil probe) and for a nil expected context,
+// so an input-less candidate keeps its exact baseline behavior there.
+func (p *relayAdmissionProbe) checkExpectedContext(owner *PendingOutpointOwner, tip PendingOutpointTip) error {
+	if p == nil || p.expected == nil {
+		return nil
+	}
+	observed, ok := owner.AdmissionContext()
+	if !ok {
+		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner admission context unavailable"), RelayAdmissionUnavailable)
+	}
+	if observed.StableTip != tip {
+		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint owner tip does not match the guarded chainstate tip"), RelayAdmissionUnavailable)
+	}
+	if observed != *p.expected {
+		return selectRelayDisposition(txAdmitUnavailable("pending-outpoint expected admission context mismatch"), RelayAdmissionUnavailable)
+	}
+	return nil
+}
+
+// result assembles the immutable published result from the producer's own
+// selections. It reads no error message and no error kind.
+func (p *relayAdmissionProbe) result(err error) RelayAdmissionResult {
+	if p == nil {
+		// The legacy path allocates no probe. It publishes no identity and no
+		// context, and a nil error there is an unselected outcome, which
+		// relayDispositionOf reports as INTERNAL, fail closed.
+		return RelayAdmissionResult{Disposition: relayDispositionOf(err), Err: err}
+	}
+	out := RelayAdmissionResult{TxID: p.txid, WTxID: p.wtxid, Err: err}
+	switch {
+	case err != nil:
+		out.Disposition = relayDispositionOf(err)
+	case p.success != 0:
+		out.Disposition = p.success
+	default:
+		// Unreachable: the success exit always selects. Fail closed rather than
+		// publish an unselected value as a classification.
+		out.Disposition = RelayAdmissionInternal
+	}
+	// Only an explicit stable terminal rejection carries cache-authorizing
+	// context, and only when that exact context was proven for this call.
+	if out.Disposition == RelayAdmissionStableTerminalReject && p.contextProven {
+		out.AdmissionContext = p.observed
+		out.HasAdmissionContext = true
+	}
+	return out
+}
+
+// bindRelayAdmissionContext proves ONCE per relay call that the owner's exact
+// complete admission context is available, agrees with the guarded chainstate
+// tip, and equals the caller-supplied expected context.
+//
+// It is a pure read: it returns no error, decides no admission outcome, and
+// mutates nothing — in particular it never creates an owner. A context it
+// cannot prove simply leaves contextProven false, so no branch's error, message
+// or ordering can depend on it.
+//
+// The caller holds ChainState.admissionMu for read. Every owner generation and
+// stable-tip move happens inside a canonical transition that holds the SAME
+// guard for write (beginCanonicalTransition through finish/abort), and the
+// chainstate tip only moves under that guard too. The context proven here is
+// therefore the exact one every later decision of this call runs against,
+// including the decisions that return before the owner seam.
+func (m *Mempool) bindRelayAdmissionContext(probe *relayAdmissionProbe) {
+	if probe == nil || probe.expected == nil {
+		return
+	}
+	m.mu.RLock()
+	owner := m.pendingOutpoints
+	m.mu.RUnlock()
+	observed, ok := owner.AdmissionContext()
+	if !ok || observed.StableTip != pendingOutpointTipOf(m.chainState) || observed != *probe.expected {
+		return
+	}
+	probe.observed = observed
+	probe.contextProven = true
+}
+
+// noteRetainedLocked selects the success-exit disposition. RETAINED is the
+// contract's exact statement — the exact candidate representation is resident
+// after the call — so the residency is READ from the live index rather than
+// assumed from a nil error. A mismatch is the retained-identity-mismatch
+// invariant and is INTERNAL. The read mutates nothing; the caller holds m.mu.
+func (m *Mempool) noteRetainedLocked(entry *mempoolEntry, probe *relayAdmissionProbe) {
+	if probe == nil {
+		return
+	}
+	probe.noteIdentity(entry.txid, entry.wtxid)
+	if resident, ok := m.txs[entry.txid]; ok && resident == entry {
+		probe.success = RelayAdmissionRetained
+		return
+	}
+	probe.success = RelayAdmissionInternal
+}
+
+// selectRelayDisposition records, ON the admission error the branch just built,
+// the relay disposition that SAME branch selected for it. It changes no error
+// type, kind, message, HTTP mapping or counter behavior: the field is
+// unexported and no public mapping reads it.
+//
+// The FIRST selection wins, so an outer caller that classifies a whole failure
+// class cannot overwrite the more precise disposition an inner branch already
+// selected. err is returned unchanged — including nil and non-TxAdmitError
+// values — so a branch wraps its existing return expression in place.
+func selectRelayDisposition(err error, disposition RelayAdmissionDisposition) error {
+	var admitErr *TxAdmitError
+	if errors.As(err, &admitErr) && admitErr.disposition == 0 {
+		admitErr.disposition = disposition
+	}
+	return err
+}
+
+// relayDispositionOf reads the disposition the PRODUCING branch stored on err.
+// It never inspects Kind, Error(), message text or an HTTP mapping. An
+// admission error no branch classified is an impossible invariant and is
+// reported INTERNAL, fail closed — never as a stable terminal rejection.
+func relayDispositionOf(err error) RelayAdmissionDisposition {
+	var admitErr *TxAdmitError
+	if errors.As(err, &admitErr) && admitErr.disposition != 0 {
+		return admitErr.disposition
+	}
+	return RelayAdmissionInternal
+}
+
+// relayDispositionForOwnerError selects the disposition of a pending-outpoint
+// owner failure from the OWNER's own typed kind, not from the compatibility
+// TxAdmitErrorKind that txAdmitFromPendingOutpointError folds the owner's
+// Unavailable and Internal kinds together into.
+func relayDispositionForOwnerError(err error) RelayAdmissionDisposition {
+	var ownerErr *PendingOutpointError
+	if !errors.As(err, &ownerErr) {
+		return RelayAdmissionInternal
+	}
+	switch ownerErr.Kind {
+	case PendingOutpointConflict:
+		return RelayAdmissionConflict
+	case PendingOutpointUnavailable:
+		return RelayAdmissionUnavailable
+	default:
+		return RelayAdmissionInternal
+	}
+}
+
+// relayDispositionForInputError separates the RETRYABLE input-dependency class
+// from the branch's own non-dependency selection, discriminating on the typed
+// consensus error CODE rather than on its rendered text. An input that is
+// absent, still immature, or not yet unlocked becomes spendable at a later
+// height, so it must never be published as a stable terminal rejection.
+//
+// nonDependency is the disposition the calling branch selects for everything
+// else it can produce: stable terminal invalidity for the consensus validation
+// seam, an impossible invariant for the policy input-snapshot seam.
+func relayDispositionForInputError(err error, nonDependency RelayAdmissionDisposition) RelayAdmissionDisposition {
+	var txErr *consensus.TxError
+	if errors.As(err, &txErr) {
+		switch txErr.Code {
+		case consensus.TX_ERR_MISSING_UTXO, consensus.TX_ERR_COINBASE_IMMATURE, consensus.TX_ERR_TIMELOCK_NOT_MET:
+			return RelayAdmissionMissingDependency
+		}
+	}
+	return nonDependency
+}

--- a/clients/go/node/relay_admission_test.go
+++ b/clients/go/node/relay_admission_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -887,7 +888,7 @@ func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T)
 		h.advanceOwnerGeneration()
 
 		entry := &mempoolEntry{txid: [32]byte{0x71}, wtxid: [32]byte{0x72}, weight: 1, size: 1}
-		probe := &relayAdmissionProbe{expected: stale}
+		probe := newRelayAdmissionProbe(stale)
 		h.mp.mu.Lock()
 		err := h.mp.reserveEntryInputsLocked(entry, probe)
 		h.mp.mu.Unlock()
@@ -902,7 +903,7 @@ func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T)
 		}
 
 		// The current context passes, and a nil probe keeps the baseline no-op.
-		probe = &relayAdmissionProbe{expected: h.context()}
+		probe = newRelayAdmissionProbe(h.context())
 		h.mp.mu.Lock()
 		err = h.mp.reserveEntryInputsLocked(entry, probe)
 		if err == nil {
@@ -922,7 +923,7 @@ func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T)
 		expected := h.context()
 		bare := &Mempool{}
 		entry := &mempoolEntry{txid: [32]byte{0x81}, wtxid: [32]byte{0x82}, weight: 1, size: 1}
-		probe := &relayAdmissionProbe{expected: expected}
+		probe := newRelayAdmissionProbe(expected)
 		bare.mu.Lock()
 		err := bare.reserveEntryInputsLocked(entry, probe)
 		bare.mu.Unlock()
@@ -950,7 +951,7 @@ func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T)
 		h.st.Height = 101
 
 		entry := &mempoolEntry{txid: [32]byte{0x91}, wtxid: [32]byte{0x92}, weight: 1, size: 1}
-		probe := &relayAdmissionProbe{expected: expected}
+		probe := newRelayAdmissionProbe(expected)
 		h.mp.mu.Lock()
 		err := h.mp.reserveEntryInputsLocked(entry, probe)
 		h.mp.mu.Unlock()
@@ -962,6 +963,89 @@ func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T)
 		}
 		if got, want := err.Error(), "pending-outpoint owner tip does not match the guarded chainstate tip"; got != want {
 			t.Fatalf("message=%q, want the sibling's %q", got, want)
+		}
+	})
+}
+
+// TestAddRemoteTxForRelaySnapshotsExpectedContextAtEntry pins the API-boundary
+// contract: the caller-supplied expected context is COPIED once at entry, and no
+// later seam reads the caller's memory again. Every row takes the snapshot, then
+// mutates the caller's variable to a context the owner never issued, and asserts
+// the call still behaves as the entry-time value — each row fails if the probe
+// goes back to holding the caller's pointer, because it would then read the
+// mutated value and refuse.
+func TestAddRemoteTxForRelaySnapshotsExpectedContextAtEntry(t *testing.T) {
+	// superseded is the same stable tip with a generation the owner has never
+	// issued: it compares unequal to the current context at every seam.
+	superseded := func(current PendingOutpointAdmissionContext) PendingOutpointAdmissionContext {
+		return PendingOutpointAdmissionContext{StableTip: current.StableTip, Generation: current.Generation + 1}
+	}
+
+	t.Run("the proving read binds the entry-time context", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		entryTime := *expected
+		probe := newRelayAdmissionProbe(expected)
+		*expected = superseded(entryTime)
+
+		h.mp.chainState.admissionMu.RLock()
+		h.mp.bindRelayAdmissionContext(probe)
+		h.mp.chainState.admissionMu.RUnlock()
+		if !probe.contextProven || probe.observed != entryTime {
+			t.Fatalf("proven=%v observed=%+v, want the entry-time %+v proven", probe.contextProven, probe.observed, entryTime)
+		}
+	})
+
+	t.Run("the input-less seam checks the entry-time context", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		probe := newRelayAdmissionProbe(expected)
+		*expected = superseded(*expected)
+
+		entry := &mempoolEntry{txid: [32]byte{0xA1}, wtxid: [32]byte{0xA2}, weight: 1, size: 1}
+		h.mp.mu.Lock()
+		err := h.mp.reserveEntryInputsLocked(entry, probe)
+		h.mp.mu.Unlock()
+		if err != nil {
+			t.Fatalf("input-less seam refused the entry-time context: %v", err)
+		}
+	})
+
+	t.Run("the owner seam reserves against the entry-time context", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		probe := newRelayAdmissionProbe(expected)
+		*expected = superseded(*expected)
+
+		entry := &mempoolEntry{
+			txid: [32]byte{0xB1}, wtxid: [32]byte{0xB2}, weight: 1, size: 1,
+			inputs: []consensus.Outpoint{h.outpoints[0]},
+		}
+		h.mp.mu.Lock()
+		err := h.mp.reserveEntryInputsLocked(entry, probe)
+		h.mp.mu.Unlock()
+		if err != nil {
+			t.Fatalf("owner seam refused the entry-time context: %v", err)
+		}
+		if entry.token == (PendingOutpointToken{}) {
+			t.Fatal("owner seam issued no token for the entry-time context")
+		}
+	})
+
+	t.Run("the published evidence is the entry-time context", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		entryTime := *expected
+
+		got := h.mp.AddRemoteTxForRelay([]byte{0xFF, 0x00, 0x13, 0x37}, expected)
+		*expected = superseded(entryTime)
+
+		if got.Disposition != RelayAdmissionStableTerminalReject || !got.HasAdmissionContext {
+			t.Fatalf("disposition=%v hasContext=%v, want a STABLE_TERMINAL_REJECT carrying context (err=%v)",
+				got.Disposition, got.HasAdmissionContext, got.Err)
+		}
+		if got.AdmissionContext != entryTime {
+			t.Fatalf("published context=%+v, want the entry-time %+v", got.AdmissionContext, entryTime)
 		}
 	})
 }
@@ -986,5 +1070,441 @@ func TestAddRemoteTxForRelayNilReceiverIsUnavailable(t *testing.T) {
 	}
 	if counts := mp.AdmissionCounts(); counts != (MempoolAdmissionCounts{}) {
 		t.Fatalf("nil receiver moved counters: %+v", counts)
+	}
+}
+
+// relaySimplicityProvider publishes exactly ONE of the deployment states that
+// consensus.SimplicityActiveAtHeight collapses into its single (false, nil)
+// "inactive" answer.
+type relaySimplicityProvider struct {
+	consensus.DefaultRotationProvider
+	descriptors []consensus.SimplicityDeploymentDescriptor
+	anchor      [32]byte
+	ok          bool
+	err         error
+}
+
+func (p relaySimplicityProvider) PublishedSimplicityDeployments() ([]consensus.SimplicityDeploymentDescriptor, [32]byte, bool, error) {
+	return p.descriptors, p.anchor, p.ok, p.err
+}
+
+// knownInactiveSimplicityProvider publishes a COMPLETE anchor-verified set whose
+// only descriptor activates far above the candidate height: state known, and
+// known inactive here.
+func knownInactiveSimplicityProvider(t *testing.T) relaySimplicityProvider {
+	t.Helper()
+	descriptor := consensus.LiveSimplicityDeploymentDescriptor(devnetGenesisChainID)
+	descriptor.ActivationHeight = 1 << 40
+	set := []consensus.SimplicityDeploymentDescriptor{descriptor}
+	anchor, err := consensus.SimplicityDeploymentSetAnchor(devnetGenesisChainID, set)
+	if err != nil {
+		t.Fatalf("SimplicityDeploymentSetAnchor: %v", err)
+	}
+	return relaySimplicityProvider{descriptors: set, anchor: anchor, ok: true}
+}
+
+// simplicityPolicyCandidate defers the cheap P2PK floor precheck and reaches the
+// CORE_SIMPLICITY pre-activation policy lane, the branch under test.
+func simplicityPolicyCandidate(h *relayHarness) []byte {
+	return txWithOneInputOneOutput(h.outpoints[0].Txid, h.outpoints[0].Vout, 1,
+		consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x53}, nil), nil)
+}
+
+// TestRelayAdmissionDispositionSimplicityDeploymentState proves the
+// CORE_SIMPLICITY pre-activation lane publishes cache authority ONLY when no
+// deployment provider governs the verdict. With a provider present the outcome
+// depends on a published deployment set that a {StableTip, Generation}
+// admission context does not pin — a lookup failure, an ok=false "unobtainable
+// / only partially known" answer, a set failing its own anchor and a complete
+// set with no governing surface alike — so all of them are UNAVAILABLE, never
+// the stable terminal tag that would let a relay cache blacklist bytes which
+// admit as soon as that set answers differently. Every row pins the EXACT
+// public error and message — only the published classification changes.
+func TestRelayAdmissionDispositionSimplicityDeploymentState(t *testing.T) {
+	known := knownInactiveSimplicityProvider(t)
+	mismatchedAnchor := known
+	mismatchedAnchor.anchor[0] ^= 0xFF
+
+	cases := []struct {
+		name        string
+		rotation    consensus.RotationProvider
+		want        RelayAdmissionDisposition
+		wantMessage string
+	}{
+		{"provider I/O failure cannot determine the state",
+			relaySimplicityProvider{err: errors.New("deployment store offline")},
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY deployment lookup failure: deployment store offline"},
+		{"ok=false publishes an unobtainable or partial set",
+			relaySimplicityProvider{ok: false},
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY output pre-ACTIVE"},
+		{"a set failing its own anchor proves nothing",
+			mismatchedAnchor,
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY output pre-ACTIVE"},
+		// A complete anchor-verified set is still a set the context does not pin:
+		// the same bytes admit at this exact tip and generation once the provider
+		// publishes a descriptor governing this height, and a descriptor's
+		// ActivationHeight makes the rejection flip with height regardless.
+		{"known complete set with no governing surface is still not pinned",
+			known,
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY output pre-ACTIVE"},
+		// The regression guard for the legitimate case, and the default node
+		// wiring: the rotation implements no deployment surface at all, so the
+		// verdict rests on the constructor-frozen configuration.
+		{"no deployment provider configured stays terminal",
+			nil,
+			RelayAdmissionStableTerminalReject, "CORE_SIMPLICITY output pre-ACTIVE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newRelayHarness(t, &MempoolConfig{
+				MaxTransactions:                     10,
+				MaxBytes:                            1 << 20,
+				PolicyRejectSimplicityPreActivation: true,
+				RotationProvider:                    tc.rotation,
+			}, 1_000_000)
+			raw := simplicityPolicyCandidate(h)
+
+			got := h.mp.AddRemoteTxForRelay(raw, h.context())
+			if got.Disposition != tc.want {
+				t.Fatalf("disposition=%v, want %v", got.Disposition, tc.want)
+			}
+			if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+				t.Fatalf("kind=%v, want the unchanged TxAdmitRejected", kind)
+			}
+			if got.Err.Error() != tc.wantMessage {
+				t.Fatalf("message=%q, want the unchanged %q", got.Err.Error(), tc.wantMessage)
+			}
+			if wantContext := tc.want == RelayAdmissionStableTerminalReject; got.HasAdmissionContext != wantContext {
+				t.Fatalf("HasAdmissionContext=%v, want %v", got.HasAdmissionContext, wantContext)
+			}
+			if h.mp.Len() != 0 {
+				t.Fatalf("a rejected candidate became resident: len=%d", h.mp.Len())
+			}
+			// The legacy wrapper observes the byte-identical failure for the same
+			// bytes: the classification is published beside the error, not in it.
+			legacy := h.mp.AddRemoteTx(raw)
+			if legacy == nil || legacy.Error() != tc.wantMessage || admitKind(t, legacy) != TxAdmitRejected {
+				t.Fatalf("legacy AddRemoteTx err=%v, want the identical %q", legacy, tc.wantMessage)
+			}
+		})
+	}
+}
+
+// TestRelayAdmissionDispositionSimplicityPolicyFanOut covers the SECOND
+// CORE_SIMPLICITY site — the applyPolicyAgainstState fan-out reached from
+// mempool_precheck.go — whose plain error is re-wrapped at the seam. The
+// precheck lane returns first for every production candidate, so this site is
+// unreachable end-to-end today and is driven directly; it must still separate
+// the provider-present outcomes from the no-provider one, because the seam
+// consuming it tags the whole fan-out.
+func TestRelayAdmissionDispositionSimplicityPolicyFanOut(t *testing.T) {
+	h := newRelayHarness(t, &MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20}, 1_000_000)
+	checked := &consensus.CheckedTransaction{Tx: mustParseTx(t, simplicityPolicyCandidate(h))}
+
+	for _, tc := range []struct {
+		name        string
+		rotation    consensus.RotationProvider
+		want        RelayAdmissionDisposition
+		wantMessage string
+	}{
+		{"provider I/O failure", relaySimplicityProvider{err: errors.New("offline")},
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY deployment lookup failure: offline"},
+		{"unknown deployment state", relaySimplicityProvider{ok: false},
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY output pre-ACTIVE"},
+		{"no deployment provider configured", nil,
+			RelayAdmissionStableTerminalReject, "CORE_SIMPLICITY output pre-ACTIVE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := applyPolicyAgainstStateSimplicity(checked, nil, devnetGenesisChainID, 1, MempoolConfig{
+				PolicyRejectSimplicityPreActivation: true,
+				RotationProvider:                    tc.rotation,
+			})
+			if err == nil || err.Error() != tc.wantMessage {
+				t.Fatalf("err=%v, want the unchanged %q", err, tc.wantMessage)
+			}
+			if got := relayDispositionForPolicyError(err); got != tc.want {
+				t.Fatalf("disposition=%v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// The same carve-out the precheck call site applies: the well-formedness
+	// tuple (reject == false) reads no deployment set, so it must arrive
+	// UNWRAPPED — terminal — even with a provider governing the lane.
+	malformed := &consensus.CheckedTransaction{Tx: mustParseTx(t, simplicityMalformedSiblingCandidate(t, h))}
+	for _, rotation := range []consensus.RotationProvider{nil, knownInactiveSimplicityProvider(t), relaySimplicityProvider{ok: false}} {
+		err := applyPolicyAgainstStateSimplicity(malformed, nil, devnetGenesisChainID, 1, MempoolConfig{
+			PolicyRejectSimplicityPreActivation: true,
+			RotationProvider:                    rotation,
+		})
+		wantMessage := "TX_ERR_COVENANT_TYPE_INVALID: invalid CORE_P2PK covenant_data length"
+		if err == nil || err.Error() != wantMessage {
+			t.Fatalf("rotation=%T err=%v, want the unchanged %q", rotation, err, wantMessage)
+		}
+		if got := relayDispositionForPolicyError(err); got != RelayAdmissionStableTerminalReject {
+			t.Fatalf("rotation=%T disposition=%v, want STABLE_TERMINAL_REJECT for the well-formedness verdict", rotation, got)
+		}
+	}
+
+	// Every other static-policy term is a decision over pinned inputs.
+	if got := relayDispositionForPolicyError(errors.New("non-coinbase CORE_ANCHOR output")); got != RelayAdmissionStableTerminalReject {
+		t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT for a pinned-input term", got)
+	}
+}
+
+// TestRelayAdmissionDispositionCoreExtNodeRuntimeReject covers the
+// mempool_precheck.go exit where rejectUnsupportedCoreExtNodeRuntime selects
+// RelayAdmissionStableTerminalReject for a CORE_EXT (covenant_type 0x0102)
+// candidate. CORE_EXT is a RETIRED, permanently consensus-rejected surface —
+// this proves it stays rejected through the live relay entry point, reusing
+// the same generic single-output fixture builder simplicityPolicyCandidate
+// above reuses, parameterized with COV_TYPE_CORE_EXT instead of
+// COV_TYPE_CORE_SIMPLICITY.
+func TestRelayAdmissionDispositionCoreExtNodeRuntimeReject(t *testing.T) {
+	h := newRelayHarness(t, nil, 1_000_000)
+	raw := txWithOneInputOneOutput(h.outpoints[0].Txid, h.outpoints[0].Vout, 1,
+		consensus.COV_TYPE_CORE_EXT, nil, nil)
+
+	got := h.mp.AddRemoteTxForRelay(raw, h.context())
+	if got.Disposition != RelayAdmissionStableTerminalReject {
+		t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT (err=%v)", got.Disposition, got.Err)
+	}
+	wantMessage := "CORE_EXT output unsupported by Go node runtime"
+	if got.Err == nil || got.Err.Error() != wantMessage {
+		t.Fatalf("err=%v, want the unchanged %q", got.Err, wantMessage)
+	}
+	if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+		t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, TxAdmitRejected)
+	}
+	if !got.HasAdmissionContext {
+		t.Fatal("a proven stable terminal rejection must publish its exact context")
+	}
+	if h.mp.Len() != 0 {
+		t.Fatalf("a CORE_EXT candidate became resident: len=%d", h.mp.Len())
+	}
+	// The legacy wrapper observes the byte-identical rejection for the same bytes.
+	legacy := h.mp.AddRemoteTx(raw)
+	if legacy == nil || legacy.Error() != wantMessage || admitKind(t, legacy) != TxAdmitRejected {
+		t.Fatalf("legacy AddRemoteTx err=%v, want the identical %q", legacy, wantMessage)
+	}
+}
+
+// simplicityMalformedSiblingCandidate is a CORE_SIMPLICITY output alongside a
+// malformed CORE_P2PK sibling: it reaches the ValidateTxCovenantsGenesis error
+// branch inside rejectCoreSimplicityPreActivation, whose (false, "", err) tuple
+// is the well-formedness half of the lane.
+func simplicityMalformedSiblingCandidate(t *testing.T, h *relayHarness) []byte {
+	t.Helper()
+	return mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []consensus.TxInput{{PrevTxid: h.outpoints[0].Txid, PrevVout: h.outpoints[0].Vout}},
+		Outputs: []consensus.TxOutput{
+			{Value: 1, CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY, CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x59}, nil)},
+			{Value: 1, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: nil},
+		},
+	})
+}
+
+// TestRelayAdmissionDispositionSimplicityGenesisWellFormednessReject covers
+// the ValidateTxCovenantsGenesis error branch inside
+// rejectCoreSimplicityPreActivation — a malformed non-Simplicity
+// output alongside a CORE_SIMPLICITY output, the same shape
+// TestMempoolPolicyDoesNotMaskMalformedNonSimplicityOutput (mempool_test.go)
+// pins the message for without asserting a disposition. That test is not
+// itself a relay-path test and mempool_test.go is outside this issue's
+// allowed surface, so the disposition is proven here instead, driving the
+// identical branch through the live relay entry point.
+//
+// The rows prove the CARVE-OUT on ONE candidate shape: the well-formedness
+// verdict is evaluated against a rotation shim that forces Simplicity active, so
+// it reads no deployment set and stays STABLE_TERMINAL_REJECT with published
+// cache authority whether or not a provider is configured. Only the sibling
+// exit of the same helper — the deployment lookup, which returns
+// (true, reason, err) — depends on the provider and is UNAVAILABLE with no cache
+// authority.
+func TestRelayAdmissionDispositionSimplicityGenesisWellFormednessReject(t *testing.T) {
+	const wellFormedness = "TX_ERR_COVENANT_TYPE_INVALID: invalid CORE_P2PK covenant_data length"
+
+	for _, tc := range []struct {
+		name        string
+		rotation    consensus.RotationProvider
+		want        RelayAdmissionDisposition
+		wantMessage string
+	}{
+		{"no deployment provider configured", nil,
+			RelayAdmissionStableTerminalReject, wellFormedness},
+		// The regression this carve-out exists for: a provider present must not
+		// turn a verdict that never consulted its set into a retryable one.
+		{"complete inactive set present stays terminal", knownInactiveSimplicityProvider(t),
+			RelayAdmissionStableTerminalReject, wellFormedness},
+		{"unobtainable set present stays terminal", relaySimplicityProvider{ok: false},
+			RelayAdmissionStableTerminalReject, wellFormedness},
+		// The sibling exit on the SAME bytes: the lookup fails before the
+		// well-formedness check runs, and that verdict does depend on the provider.
+		{"lookup failure stays unavailable", relaySimplicityProvider{err: errors.New("deployment store offline")},
+			RelayAdmissionUnavailable, "CORE_SIMPLICITY deployment lookup failure: deployment store offline"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newRelayHarness(t, &MempoolConfig{
+				PolicyRejectSimplicityPreActivation: true,
+				RotationProvider:                    tc.rotation,
+			}, 100)
+			raw := simplicityMalformedSiblingCandidate(t, h)
+
+			got := h.mp.AddRemoteTxForRelay(raw, h.context())
+			if got.Disposition != tc.want {
+				t.Fatalf("disposition=%v, want %v (err=%v)", got.Disposition, tc.want, got.Err)
+			}
+			if got.Err == nil || got.Err.Error() != tc.wantMessage {
+				t.Fatalf("err=%v, want the unchanged %q", got.Err, tc.wantMessage)
+			}
+			if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+				t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, TxAdmitRejected)
+			}
+			if wantContext := tc.want == RelayAdmissionStableTerminalReject; got.HasAdmissionContext != wantContext {
+				t.Fatalf("HasAdmissionContext=%v, want %v", got.HasAdmissionContext, wantContext)
+			}
+			if h.mp.Len() != 0 {
+				t.Fatalf("a rejected candidate became resident: len=%d", h.mp.Len())
+			}
+			// The legacy wrapper observes the byte-identical rejection for the same bytes.
+			legacy := h.mp.AddRemoteTx(raw)
+			if legacy == nil || legacy.Error() != tc.wantMessage || admitKind(t, legacy) != TxAdmitRejected {
+				t.Fatalf("legacy AddRemoteTx err=%v, want the identical %q", legacy, tc.wantMessage)
+			}
+		})
+	}
+}
+
+// cleanupRejectionMempool is a bare mempool whose admission-sequence space is
+// exhausted, so a candidate that clears the owner seam is rejected by the LATER
+// admission-sequence check — the exact branch whose post-decision cleanup
+// releases the candidate reservation.
+func cleanupRejectionMempool() *Mempool {
+	return &Mempool{maxTxs: 10, maxBytes: 100, lastAdmissionSeq: ^uint64(0)}
+}
+
+// drivePostDecisionCleanup runs the ONE live locked admission implementation
+// with a relay probe and returns the published result.
+func drivePostDecisionCleanup(t *testing.T, mp *Mempool, entry *mempoolEntry) RelayAdmissionResult {
+	t.Helper()
+	probe := &relayAdmissionProbe{}
+	mp.mu.Lock()
+	err := mp.addEntryLockedProbed(entry, 0, probe)
+	mp.mu.Unlock()
+	return probe.result(err)
+}
+
+// corruptedClaimToken reserves a REAL claim on mp's owner and then deletes the
+// by-outpoint row that claim installed, so the owner's own index disagrees with
+// the token. That is exactly the accounting corruption Release detects and
+// reports as an internal fault.
+//
+// The corruption is installed before the drive because the live path leaves no
+// seam between Reserve and the later check: Reserve installs a self-consistent
+// claim and nothing between it and the rejection touches the owner.
+func corruptedClaimToken(t *testing.T, mp *Mempool, op consensus.Outpoint) PendingOutpointToken {
+	t.Helper()
+	mp.mu.Lock()
+	owner := mp.pendingOutpointOwnerLocked()
+	mp.mu.Unlock()
+	token := mustReserve(t, owner, [32]byte{0x3f}, op)
+	owner.mu.Lock()
+	delete(owner.byOutpoint, op)
+	owner.mu.Unlock()
+	return token
+}
+
+// assertSameAdmissionError proves the public compatibility channel is untouched:
+// same concrete type, same TxAdmitErrorKind, same message bytes.
+func assertSameAdmissionError(t *testing.T, got, want error) {
+	t.Helper()
+	if reflect.TypeOf(got) != reflect.TypeOf(want) {
+		t.Fatalf("error type %T, want the identical %T", got, want)
+	}
+	if gotKind, wantKind := admitKind(t, got), admitKind(t, want); gotKind != wantKind {
+		t.Fatalf("TxAdmitErrorKind=%q, want the identical %q", gotKind, wantKind)
+	}
+	if got.Error() != want.Error() {
+		t.Fatalf("message=%q, want the byte-identical %q", got.Error(), want.Error())
+	}
+}
+
+// admissionCounters is every counter and accounting total this surface can move.
+func admissionCounters(mp *Mempool) [7]uint64 {
+	return [7]uint64{
+		mp.admitAccepted.Load(),
+		mp.admitConflict.Load(),
+		mp.admitRejected.Load(),
+		mp.admitUnavailable.Load(),
+		mp.evictedResidentTotal.Load(),
+		uint64(len(mp.txs)),
+		uint64(mp.usedBytes),
+	}
+}
+
+// TestRelayAdmissionDispositionCleanupFailureOutranksTheBranch pins the
+// fail-closed override: a REQUIRED post-decision cleanup that reports owner
+// accounting corruption publishes INTERNAL even though the deciding branch
+// already tagged the error ADMISSION_SEQUENCE and selectRelayDisposition is
+// first-selection-wins.
+//
+// The control row proves the override cannot swallow an ordinary rejection: an
+// identical rejection whose cleanup succeeds still publishes the branch's own
+// disposition, and both rows return the byte-identical public error.
+func TestRelayAdmissionDispositionCleanupFailureOutranksTheBranch(t *testing.T) {
+	const wantMsg = "mempool admission sequence exhausted"
+
+	// Row 1 — ordinary cleanup: the live conflict slot issues the candidate's
+	// own reservation and the post-decision release succeeds.
+	ordinaryMp := cleanupRejectionMempool()
+	ordinaryEntry := &mempoolEntry{
+		txid: [32]byte{0x2c}, wtxid: [32]byte{0x2d},
+		inputs: []consensus.Outpoint{testOutpoint(11)},
+		fee:    consensus.Uint128FromU64(1), weight: 1, size: 1,
+	}
+	ordinary := drivePostDecisionCleanup(t, ordinaryMp, ordinaryEntry)
+	if ordinary.Disposition != RelayAdmissionAdmissionSequence {
+		t.Fatalf("ordinary disposition=%v, want ADMISSION_SEQUENCE (err=%v)", ordinary.Disposition, ordinary.Err)
+	}
+	assertCandidateExactlyReleased(t, ordinaryMp, ordinaryEntry, ordinary.Err, TxAdmitUnavailable, wantMsg)
+
+	// Row 2 — the same rejection, but the cleanup release hits a claim whose
+	// by-outpoint row disagrees with the token.
+	corruptMp := cleanupRejectionMempool()
+	op := testOutpoint(12)
+	token := corruptedClaimToken(t, corruptMp, op)
+	corruptEntry := &mempoolEntry{
+		txid: [32]byte{0x3c}, wtxid: [32]byte{0x3d}, token: token,
+		fee: consensus.Uint128FromU64(1), weight: 1, size: 1,
+	}
+	corrupted := drivePostDecisionCleanup(t, corruptMp, corruptEntry)
+
+	if corrupted.Disposition != RelayAdmissionInternal {
+		t.Fatalf("corrupted disposition=%v, want INTERNAL (err=%v)", corrupted.Disposition, corrupted.Err)
+	}
+	if corrupted.HasAdmissionContext {
+		t.Fatal("an internal cleanup failure must publish no cache-authorizing context")
+	}
+	// The public compatibility channel is byte-identical to the same rejection
+	// whose cleanup succeeded.
+	assertSameAdmissionError(t, corrupted.Err, ordinary.Err)
+	if got := admissionCounters(corruptMp); got != admissionCounters(ordinaryMp) {
+		t.Fatalf("counters=%v, want the ordinary row's %v", got, admissionCounters(ordinaryMp))
+	}
+	if corruptEntry.token != (PendingOutpointToken{}) {
+		t.Fatalf("rejected candidate token=%+v, want the zero token", corruptEntry.token)
+	}
+	// The release really failed: the corrupted claim is still live and the owner
+	// still reports the exact index-mismatch fault the cleanup step hit.
+	releaseErr := corruptMp.pendingOutpoints.Release(token)
+	if testOwnerKind(t, releaseErr) != PendingOutpointInternal {
+		t.Fatalf("Release after cleanup: %v, want an internal owner fault", releaseErr)
+	}
+	wantRelease := fmt.Sprintf("pending-outpoint index mismatch for txid=%x vout=%d", op.Txid, op.Vout)
+	if releaseErr.Error() != wantRelease {
+		t.Fatalf("Release error=%q, want %q", releaseErr.Error(), wantRelease)
 	}
 }

--- a/clients/go/node/relay_admission_test.go
+++ b/clients/go/node/relay_admission_test.go
@@ -1,0 +1,990 @@
+package node
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// relayHarness is one signed-P2PK admission fixture: a spendable chainstate, a
+// mempool bound to it, and the keys needed to build candidates against it.
+type relayHarness struct {
+	t         *testing.T
+	fromKey   *consensus.MLDSA87Keypair
+	fromAddr  []byte
+	toAddr    []byte
+	st        *ChainState
+	outpoints []consensus.Outpoint
+	mp        *Mempool
+}
+
+func newRelayHarness(t *testing.T, cfg *MempoolConfig, values ...uint64) *relayHarness {
+	t.Helper()
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	h := &relayHarness{
+		t:        t,
+		fromKey:  fromKey,
+		fromAddr: consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes()),
+		toAddr:   consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes()),
+	}
+	h.st, h.outpoints = testSpendableChainState(h.fromAddr, values)
+	var err error
+	if cfg == nil {
+		h.mp, err = NewMempool(h.st, nil, devnetGenesisChainID)
+	} else {
+		h.mp, err = NewMempoolWithConfig(h.st, nil, devnetGenesisChainID, *cfg)
+	}
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	return h
+}
+
+func (h *relayHarness) tx(input int, amount, fee, nonce uint64) []byte {
+	h.t.Helper()
+	return mustBuildSignedTransferTx(h.t, h.st.Utxos, []consensus.Outpoint{h.outpoints[input]}, amount, fee, nonce, h.fromKey, h.fromAddr, h.toAddr)
+}
+
+// context returns the owner's current exact admission context.
+func (h *relayHarness) context() *PendingOutpointAdmissionContext {
+	h.t.Helper()
+	ctx, ok := h.mp.PendingOutpointOwner().AdmissionContext()
+	if !ok {
+		h.t.Fatal("owner admission context unavailable")
+	}
+	return &ctx
+}
+
+// advanceOwnerGeneration commits a transition back onto the SAME stable tip, so
+// the tip compares equal while the generation the owner is bound to has moved
+// past every context observed before this call.
+func (h *relayHarness) advanceOwnerGeneration() {
+	h.t.Helper()
+	owner := h.mp.PendingOutpointOwner()
+	if _, err := owner.beginTransition(); err != nil {
+		h.t.Fatalf("beginTransition: %v", err)
+	}
+	if err := owner.commitStableTip(pendingOutpointTipOf(h.st)); err != nil {
+		h.t.Fatalf("commitStableTip: %v", err)
+	}
+}
+
+func mustSnapshot(t *testing.T, mp *Mempool) mempoolSnapshot {
+	t.Helper()
+	snap, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+	return snap
+}
+
+func admitKind(t *testing.T, err error) TxAdmitErrorKind {
+	t.Helper()
+	var admitErr *TxAdmitError
+	if !errors.As(err, &admitErr) {
+		t.Fatalf("expected *TxAdmitError, got %T: %v", err, err)
+	}
+	return admitErr.Kind
+}
+
+// TestRelayAdmissionDispositionCorpus drives ONE candidate per branch of the
+// closed classifier through the live public relay entry point and pins the
+// disposition its originating branch selected, the unchanged public admission
+// kind, and whether cache-authorizing context evidence was published.
+//
+// The rows deliberately include inputs whose public TxAdmitErrorKind is
+// ambiguous — TxAdmitConflict carries both DUPLICATE and CONFLICT,
+// TxAdmitUnavailable carries ROLLING_FLOOR, CAPACITY, ADMISSION_SEQUENCE and
+// UNAVAILABLE — so a classifier that read the kind instead of the branch would
+// fail here.
+func TestRelayAdmissionDispositionCorpus(t *testing.T) {
+	cases := []struct {
+		name string
+		// build returns the mempool, the candidate bytes, and the caller's
+		// expected admission context (nil for the legacy-equivalent shape).
+		build       func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext)
+		want        RelayAdmissionDisposition
+		wantKind    TxAdmitErrorKind
+		wantNilErr  bool
+		wantContext bool
+		wantTxID    bool
+	}{
+		{
+			name: "retained without expected context",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				return h.mp, h.tx(0, 100_000, 100_000, 1), nil
+			},
+			want:       RelayAdmissionRetained,
+			wantNilErr: true,
+			wantTxID:   true,
+		},
+		{
+			name: "retained with the exact stable context carries no cache authority",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				return h.mp, h.tx(0, 100_000, 100_000, 1), h.context()
+			},
+			want:       RelayAdmissionRetained,
+			wantNilErr: true,
+			wantTxID:   true,
+		},
+		{
+			name: "stable terminal reject: unparseable bytes",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				return h.mp, []byte{0xFF, 0x00, 0x13, 0x37}, h.context()
+			},
+			want:        RelayAdmissionStableTerminalReject,
+			wantKind:    TxAdmitRejected,
+			wantContext: true,
+		},
+		{
+			name: "stable terminal reject: trailing bytes after canonical tx",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				return h.mp, append(h.tx(0, 100_000, 100_000, 1), 0x00), h.context()
+			},
+			want:        RelayAdmissionStableTerminalReject,
+			wantKind:    TxAdmitRejected,
+			wantContext: true,
+		},
+		{
+			name: "stable terminal reject: consensus-invalid signature",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				return h.mp, corruptFirstWitnessSignature(t, h.tx(0, 100_000, 100_000, 1)), h.context()
+			},
+			want:        RelayAdmissionStableTerminalReject,
+			wantKind:    TxAdmitRejected,
+			wantContext: true,
+			wantTxID:    true,
+		},
+		{
+			name: "stable terminal reject: static anchor-output policy",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, &MempoolConfig{
+					MaxTransactions:                      10,
+					MaxBytes:                             1 << 20,
+					PolicyRejectNonCoinbaseAnchorOutputs: true,
+				}, 1_000_000)
+				// A CORE_ANCHOR output of value 0 is CONSENSUS-valid
+				// (clients/go/consensus/covenant_genesis.go
+				// validateAnchorGenesisOutput), so the candidate reaches the
+				// static-policy lane this row is named for and is rejected by
+				// applyPolicyAgainstState — the branch that must select the tag.
+				raw := mustBuildSignedAnchorOutputTx(t, h.st.Utxos, h.outpoints[0], 0, 100_000, 1, h.fromKey, h.fromAddr)
+				return h.mp, raw, h.context()
+			},
+			want:        RelayAdmissionStableTerminalReject,
+			wantKind:    TxAdmitRejected,
+			wantContext: true,
+			wantTxID:    true,
+		},
+		{
+			name: "missing dependency never carries cache authority",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+				raw := h.tx(1, 100_000, 100_000, 1)
+				delete(h.st.Utxos, h.outpoints[1])
+				return h.mp, raw, h.context()
+			},
+			want:     RelayAdmissionMissingDependency,
+			wantKind: TxAdmitRejected,
+			wantTxID: true,
+		},
+		{
+			name: "duplicate resident txid keeps the conflict kind",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				raw := h.tx(0, 100_000, 100_000, 1)
+				if err := h.mp.AddRemoteTx(raw); err != nil {
+					t.Fatalf("seed AddRemoteTx: %v", err)
+				}
+				return h.mp, raw, h.context()
+			},
+			want:     RelayAdmissionDuplicate,
+			wantKind: TxAdmitConflict,
+			wantTxID: true,
+		},
+		{
+			name: "pending-outpoint owner conflict keeps the conflict kind",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				if err := h.mp.AddRemoteTx(h.tx(0, 100_000, 100_000, 1)); err != nil {
+					t.Fatalf("seed AddRemoteTx: %v", err)
+				}
+				return h.mp, h.tx(0, 100_000, 200_000, 2), h.context()
+			},
+			want:     RelayAdmissionConflict,
+			wantKind: TxAdmitConflict,
+			wantTxID: true,
+		},
+		{
+			// The cheap-precheck floor authority: a single-input plain P2PK
+			// shape is fast-rejected at mempool_precheck.go's precheck wrap
+			// before any signature verification.
+			name: "rolling floor: cheap precheck authority",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				raw := h.tx(0, 100_000, 100_000, 1)
+				h.mp.SetCurrentMinFeeRateForTest(1 << 40)
+				return h.mp, raw, h.context()
+			},
+			want:     RelayAdmissionRollingFloor,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+		{
+			// The LOCKED floor authority (validateFeeFloorLockedWithFloor, the
+			// max(snappedFloor, live) re-check). Two inputs mean two witness
+			// items, which disqualifies feePrecheckP2PKInputValue, so the cheap
+			// precheck defers and the locked check owns the outcome.
+			name: "rolling floor: locked max(snapped,live) authority",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+				raw := mustBuildSignedTransferTx(t, h.st.Utxos, h.outpoints, 100_000, 100_000, 1, h.fromKey, h.fromAddr, h.toAddr)
+				h.mp.SetCurrentMinFeeRateForTest(1 << 40)
+				return h.mp, raw, h.context()
+			},
+			want:     RelayAdmissionRollingFloor,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+		{
+			name: "capacity: candidate is the worst under byte pressure",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+				rich := h.tx(0, 100_000, 200_000, 1)
+				poor := h.tx(1, 100_000, 100_000, 2)
+				mp, err := NewMempoolWithConfig(h.st, nil, devnetGenesisChainID, MempoolConfig{
+					MaxTransactions: 10,
+					MaxBytes:        len(rich) + len(poor) - 1,
+				})
+				if err != nil {
+					t.Fatalf("new mempool: %v", err)
+				}
+				if err := mp.AddRemoteTx(rich); err != nil {
+					t.Fatalf("seed AddRemoteTx: %v", err)
+				}
+				ctx, ok := mp.PendingOutpointOwner().AdmissionContext()
+				if !ok {
+					t.Fatal("owner admission context unavailable")
+				}
+				return mp, poor, &ctx
+			},
+			want:     RelayAdmissionCapacity,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+		{
+			name: "admission sequence exhausted",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				raw := h.tx(0, 100_000, 100_000, 1)
+				h.mp.mu.Lock()
+				h.mp.lastAdmissionSeq = ^uint64(0)
+				h.mp.mu.Unlock()
+				return h.mp, raw, h.context()
+			},
+			want:     RelayAdmissionAdmissionSequence,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+		{
+			name: "unavailable: absent chainstate",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				return &Mempool{}, []byte{0x01}, nil
+			},
+			want:     RelayAdmissionUnavailable,
+			wantKind: TxAdmitUnavailable,
+		},
+		{
+			name: "unavailable: superseded expected context at the owner seam",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				raw := h.tx(0, 100_000, 100_000, 1)
+				stale := h.context()
+				h.advanceOwnerGeneration()
+				return h.mp, raw, stale
+			},
+			want:     RelayAdmissionUnavailable,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+		{
+			name: "unavailable: owner transition in progress",
+			build: func(t *testing.T) (*Mempool, []byte, *PendingOutpointAdmissionContext) {
+				h := newRelayHarness(t, nil, 1_000_000)
+				raw := h.tx(0, 100_000, 100_000, 1)
+				expected := h.context()
+				if _, err := h.mp.PendingOutpointOwner().beginTransition(); err != nil {
+					t.Fatalf("beginTransition: %v", err)
+				}
+				return h.mp, raw, expected
+			},
+			want:     RelayAdmissionUnavailable,
+			wantKind: TxAdmitUnavailable,
+			wantTxID: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mp, raw, expected := tc.build(t)
+			got := mp.AddRemoteTxForRelay(raw, expected)
+
+			if got.Disposition != tc.want {
+				t.Fatalf("disposition=%v, want %v (err=%v)", got.Disposition, tc.want, got.Err)
+			}
+			if got.Disposition == RelayAdmissionCancelled {
+				t.Fatal("no production branch may select CANCELLED")
+			}
+			if tc.wantNilErr {
+				if got.Err != nil {
+					t.Fatalf("err=%v, want nil", got.Err)
+				}
+			} else {
+				if got.Err == nil {
+					t.Fatal("err=nil, want a public admission error")
+				}
+				if kind := admitKind(t, got.Err); kind != tc.wantKind {
+					t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, tc.wantKind)
+				}
+			}
+			if got.HasAdmissionContext != tc.wantContext {
+				t.Fatalf("HasAdmissionContext=%v, want %v", got.HasAdmissionContext, tc.wantContext)
+			}
+			if got.HasAdmissionContext {
+				if got.Disposition != RelayAdmissionStableTerminalReject {
+					t.Fatalf("disposition %v published cache-authorizing context", got.Disposition)
+				}
+				if got.AdmissionContext != *expected {
+					t.Fatalf("AdmissionContext=%+v, want the exact expected context %+v", got.AdmissionContext, *expected)
+				}
+			} else if got.AdmissionContext != (PendingOutpointAdmissionContext{}) {
+				t.Fatalf("AdmissionContext=%+v published without HasAdmissionContext", got.AdmissionContext)
+			}
+			if hasTxID := got.TxID != ([32]byte{}); hasTxID != tc.wantTxID {
+				t.Fatalf("TxID present=%v (%x), want present=%v", hasTxID, got.TxID, tc.wantTxID)
+			}
+			if tc.wantTxID {
+				if want := txID(t, raw); got.TxID != want {
+					t.Fatalf("TxID=%x, want the producer-parsed %x", got.TxID, want)
+				}
+				if got.WTxID == ([32]byte{}) {
+					t.Fatalf("WTxID is zero for a parsed candidate")
+				}
+			}
+		})
+	}
+}
+
+// TestRelayAdmissionDispositionNeverInfersFromTheErrorSurface proves the
+// classification is READ from the producing branch's own selection and is never
+// reconstructed from the compatibility kind, the message text, or a default.
+func TestRelayAdmissionDispositionNeverInfersFromTheErrorSurface(t *testing.T) {
+	// An error no branch classified is INTERNAL, never stable-terminal — even
+	// when its kind and message look exactly like a stable rejection.
+	untagged := []error{
+		txAdmitRejected("TX_ERR_SIG_INVALID: signature invalid"),
+		txAdmitConflict("tx already in mempool"),
+		txAdmitUnavailable("mempool fee below rolling minimum: fee=0 weight=1 min_fee_rate=9"),
+		errors.New("not an admission error"),
+	}
+	for _, err := range untagged {
+		if got := relayDispositionOf(err); got != RelayAdmissionInternal {
+			t.Fatalf("relayDispositionOf(%v)=%v, want INTERNAL", err, got)
+		}
+	}
+
+	// The FIRST selection wins: an outer class tag cannot overwrite the precise
+	// disposition an inner branch already selected.
+	inner := txAdmitConflict("tx already in mempool")
+	tagged := selectRelayDisposition(inner, RelayAdmissionDuplicate)
+	tagged = selectRelayDisposition(tagged, RelayAdmissionInternal)
+	if got := relayDispositionOf(tagged); got != RelayAdmissionDuplicate {
+		t.Fatalf("disposition=%v after an outer tag, want the inner DUPLICATE", got)
+	}
+
+	// Tagging changes no public surface.
+	if inner.Kind != TxAdmitConflict || inner.Error() != "tx already in mempool" {
+		t.Fatalf("tagging mutated the public error surface: kind=%q message=%q", inner.Kind, inner.Error())
+	}
+
+	// Pass-through shapes.
+	if selectRelayDisposition(nil, RelayAdmissionRetained) != nil {
+		t.Fatal("selectRelayDisposition(nil) must stay nil")
+	}
+	plain := errors.New("plain")
+	if selectRelayDisposition(plain, RelayAdmissionCapacity) != plain {
+		t.Fatal("selectRelayDisposition must return a non-admission error unchanged")
+	}
+}
+
+// TestRelayAdmissionDispositionEnumIsClosed pins the eleven-value taxonomy and
+// the deliberately-unselected zero value.
+func TestRelayAdmissionDispositionEnumIsClosed(t *testing.T) {
+	want := map[RelayAdmissionDisposition]string{
+		RelayAdmissionRetained:             "RETAINED",
+		RelayAdmissionStableTerminalReject: "STABLE_TERMINAL_REJECT",
+		RelayAdmissionDuplicate:            "DUPLICATE",
+		RelayAdmissionConflict:             "CONFLICT",
+		RelayAdmissionMissingDependency:    "MISSING_DEPENDENCY",
+		RelayAdmissionRollingFloor:         "ROLLING_FLOOR",
+		RelayAdmissionCapacity:             "CAPACITY",
+		RelayAdmissionAdmissionSequence:    "ADMISSION_SEQUENCE",
+		RelayAdmissionUnavailable:          "UNAVAILABLE",
+		RelayAdmissionInternal:             "INTERNAL",
+		RelayAdmissionCancelled:            "CANCELLED",
+	}
+	if len(want) != 11 {
+		t.Fatalf("taxonomy has %d values, want exactly 11", len(want))
+	}
+	seen := make(map[RelayAdmissionDisposition]struct{}, len(want))
+	for value, name := range want {
+		if value == 0 {
+			t.Fatalf("%s must not be the zero value", name)
+		}
+		if _, dup := seen[value]; dup {
+			t.Fatalf("%s duplicates another enum value", name)
+		}
+		seen[value] = struct{}{}
+		if got := value.String(); got != name {
+			t.Fatalf("String()=%q, want %q", got, name)
+		}
+	}
+	for _, outside := range []RelayAdmissionDisposition{0, 12, 255} {
+		if got := outside.String(); got != "UNSELECTED" {
+			t.Fatalf("String() for %d = %q, want UNSELECTED", outside, got)
+		}
+	}
+}
+
+// TestRelayAdmissionDispositionTypedProducerMappings pins the two producer
+// mappings that read a TYPED code from the failing producer rather than any
+// rendered text, including the retryable-dependency class that must never be
+// published as a stable terminal rejection.
+func TestRelayAdmissionDispositionTypedProducerMappings(t *testing.T) {
+	ownerCases := []struct {
+		err  error
+		want RelayAdmissionDisposition
+	}{
+		{&PendingOutpointError{Kind: PendingOutpointConflict, Msg: "mempool double-spend conflict with ab"}, RelayAdmissionConflict},
+		{&PendingOutpointError{Kind: PendingOutpointUnavailable, Msg: "pending-outpoint expected tip mismatch"}, RelayAdmissionUnavailable},
+		{&PendingOutpointError{Kind: PendingOutpointInternal, Msg: "zero or foreign pending-outpoint token"}, RelayAdmissionInternal},
+		{errors.New("not an owner error"), RelayAdmissionInternal},
+	}
+	for _, tc := range ownerCases {
+		if got := relayDispositionForOwnerError(tc.err); got != tc.want {
+			t.Fatalf("relayDispositionForOwnerError(%v)=%v, want %v", tc.err, got, tc.want)
+		}
+	}
+
+	dependency := []consensus.ErrorCode{
+		consensus.TX_ERR_MISSING_UTXO,
+		consensus.TX_ERR_COINBASE_IMMATURE,
+		consensus.TX_ERR_TIMELOCK_NOT_MET,
+	}
+	for _, code := range dependency {
+		err := &consensus.TxError{Code: code, Msg: "input"}
+		for _, nonDependency := range []RelayAdmissionDisposition{RelayAdmissionStableTerminalReject, RelayAdmissionInternal} {
+			if got := relayDispositionForInputError(err, nonDependency); got != RelayAdmissionMissingDependency {
+				t.Fatalf("relayDispositionForInputError(%s)=%v, want MISSING_DEPENDENCY", code, got)
+			}
+		}
+	}
+	stable := &consensus.TxError{Code: consensus.TX_ERR_SIG_INVALID, Msg: "bad signature"}
+	if got := relayDispositionForInputError(stable, RelayAdmissionStableTerminalReject); got != RelayAdmissionStableTerminalReject {
+		t.Fatalf("non-dependency consensus failure=%v, want STABLE_TERMINAL_REJECT", got)
+	}
+	if got := relayDispositionForInputError(errors.New("nil utxo set"), RelayAdmissionInternal); got != RelayAdmissionInternal {
+		t.Fatalf("non-typed input failure=%v, want the branch's own INTERNAL", got)
+	}
+}
+
+// TestRelayAdmissionDispositionRetainedProvesResidency pins RETAINED against the
+// live index rather than against a nil error: a published record that is not the
+// exact candidate is the retained-identity-mismatch invariant, i.e. INTERNAL.
+func TestRelayAdmissionDispositionRetainedProvesResidency(t *testing.T) {
+	entry := &mempoolEntry{txid: [32]byte{0x01}, wtxid: [32]byte{0x02}, weight: 1, size: 1}
+	mp := &Mempool{txs: map[[32]byte]*mempoolEntry{entry.txid: entry}}
+
+	probe := &relayAdmissionProbe{}
+	mp.noteRetainedLocked(entry, probe)
+	if probe.success != RelayAdmissionRetained {
+		t.Fatalf("resident exact candidate selected %v, want RETAINED", probe.success)
+	}
+	if probe.txid != entry.txid || probe.wtxid != entry.wtxid {
+		t.Fatalf("identity=(%x,%x), want the candidate's own (%x,%x)", probe.txid, probe.wtxid, entry.txid, entry.wtxid)
+	}
+
+	impostor := &mempoolEntry{txid: entry.txid, wtxid: entry.wtxid, weight: 1, size: 1}
+	mismatch := &relayAdmissionProbe{}
+	mp.noteRetainedLocked(impostor, mismatch)
+	if mismatch.success != RelayAdmissionInternal {
+		t.Fatalf("retained identity mismatch selected %v, want INTERNAL", mismatch.success)
+	}
+
+	missing := &relayAdmissionProbe{}
+	(&Mempool{}).noteRetainedLocked(entry, missing)
+	if missing.success != RelayAdmissionInternal {
+		t.Fatalf("absent record selected %v, want INTERNAL", missing.success)
+	}
+
+	// A nil probe is the legacy path and must stay a no-op — including result,
+	// which the type documents as nil-safe like every other method here.
+	mp.noteRetainedLocked(entry, nil)
+	var legacy *relayAdmissionProbe
+	cause := txAdmitUnavailable("nil mempool")
+	if got := legacy.result(selectRelayDisposition(cause, RelayAdmissionUnavailable)); got.Disposition != RelayAdmissionUnavailable || got.Err != error(cause) {
+		t.Fatalf("nil probe result=%+v, want the producer's UNAVAILABLE and its error", got)
+	}
+	if got := legacy.result(nil); got.Disposition != RelayAdmissionInternal {
+		t.Fatalf("nil probe with an unselected outcome=%v, want INTERNAL fail closed", got.Disposition)
+	}
+}
+
+// TestRelayAdmissionDispositionDuplicateWtxidBranch covers the second duplicate
+// branch: a candidate whose wtxid is already indexed under another txid. It is
+// unreachable through two distinct signed candidates, so the index is seeded
+// directly, exactly as the baseline wtxid test does.
+func TestRelayAdmissionDispositionDuplicateWtxidBranch(t *testing.T) {
+	h := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+	tx1 := h.tx(0, 100_000, 100_000, 1)
+	if err := h.mp.AddRemoteTx(tx1); err != nil {
+		t.Fatalf("seed AddRemoteTx: %v", err)
+	}
+	tx2 := h.tx(1, 100_000, 100_000, 2)
+	_, tx2ID, tx2Wtxid, _, err := consensus.ParseTx(tx2)
+	if err != nil {
+		t.Fatalf("ParseTx(tx2): %v", err)
+	}
+	h.mp.mu.Lock()
+	h.mp.wtxids[tx2Wtxid] = txID(t, tx1)
+	h.mp.mu.Unlock()
+
+	got := h.mp.AddRemoteTxForRelay(tx2, h.context())
+	if got.Disposition != RelayAdmissionDuplicate {
+		t.Fatalf("disposition=%v, want DUPLICATE (err=%v)", got.Disposition, got.Err)
+	}
+	if kind := admitKind(t, got.Err); kind != TxAdmitConflict {
+		t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, TxAdmitConflict)
+	}
+	if got.HasAdmissionContext {
+		t.Fatal("a duplicate must never publish cache-authorizing context")
+	}
+	if got.TxID != tx2ID || got.WTxID != tx2Wtxid {
+		t.Fatalf("identity=(%x,%x), want the producer-parsed (%x,%x)", got.TxID, got.WTxID, tx2ID, tx2Wtxid)
+	}
+	if h.mp.Contains(tx2ID) {
+		t.Fatal("a duplicate candidate entered the mempool")
+	}
+}
+
+// TestRelayAdmissionDispositionDuplicateTxidWithAlternateWtxid covers the mirror
+// hostile row: a re-signed candidate carries the SAME txid under a different
+// wtxid, and the resident-txid branch must keep winning over the wtxid branch.
+func TestRelayAdmissionDispositionDuplicateTxidWithAlternateWtxid(t *testing.T) {
+	h := newRelayHarness(t, nil, 1_000_000)
+	first := h.tx(0, 100_000, 100_000, 1)
+	second := h.tx(0, 100_000, 100_000, 1)
+	if bytes.Equal(first, second) {
+		t.Skip("signature backend is deterministic: no alternate witness representation available")
+	}
+	_, firstTxid, firstWtxid, _, err := consensus.ParseTx(first)
+	if err != nil {
+		t.Fatalf("ParseTx(first): %v", err)
+	}
+	_, secondTxid, secondWtxid, _, err := consensus.ParseTx(second)
+	if err != nil {
+		t.Fatalf("ParseTx(second): %v", err)
+	}
+	if firstTxid != secondTxid || firstWtxid == secondWtxid {
+		t.Fatalf("fixture is not same-txid/alternate-wtxid: txids (%x,%x) wtxids (%x,%x)", firstTxid, secondTxid, firstWtxid, secondWtxid)
+	}
+	if err := h.mp.AddRemoteTx(first); err != nil {
+		t.Fatalf("seed AddRemoteTx: %v", err)
+	}
+
+	got := h.mp.AddRemoteTxForRelay(second, h.context())
+	if got.Disposition != RelayAdmissionDuplicate {
+		t.Fatalf("disposition=%v, want DUPLICATE (err=%v)", got.Disposition, got.Err)
+	}
+	// The resident-txid branch owns this outcome, not the wtxid branch.
+	if got.Err.Error() != "tx already in mempool" {
+		t.Fatalf("message=%q, want the resident-txid branch's %q", got.Err.Error(), "tx already in mempool")
+	}
+	if kind := admitKind(t, got.Err); kind != TxAdmitConflict {
+		t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, TxAdmitConflict)
+	}
+	if got.WTxID != secondWtxid {
+		t.Fatalf("WTxID=%x, want the producer-parsed %x", got.WTxID, secondWtxid)
+	}
+	if got.HasAdmissionContext {
+		t.Fatal("a duplicate must never publish cache-authorizing context")
+	}
+}
+
+// TestRelayAdmissionDispositionMixedViolations pins the disposition of
+// candidates that violate TWO rules at once. The winner must be the branch the
+// baseline validation order reaches first, unchanged by this surface.
+func TestRelayAdmissionDispositionMixedViolations(t *testing.T) {
+	t.Run("missing input plus malformed witness stays a dependency gap", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+		raw := corruptFirstWitnessSignature(t, h.tx(1, 100_000, 100_000, 1))
+		delete(h.st.Utxos, h.outpoints[1])
+		got := h.mp.AddRemoteTxForRelay(raw, h.context())
+		if got.Disposition != RelayAdmissionMissingDependency {
+			t.Fatalf("disposition=%v, want MISSING_DEPENDENCY (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("a dependency gap must never publish cache-authorizing context")
+		}
+	})
+
+	t.Run("below floor plus invalid signature keeps the cheap-floor precedence", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		raw := corruptFirstWitnessSignature(t, h.tx(0, 100_000, 100_000, 1))
+		h.mp.SetCurrentMinFeeRateForTest(1 << 40)
+		got := h.mp.AddRemoteTxForRelay(raw, h.context())
+		if got.Disposition != RelayAdmissionRollingFloor {
+			t.Fatalf("disposition=%v, want ROLLING_FLOOR (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("a floor rejection must never publish cache-authorizing context")
+		}
+	})
+
+	t.Run("below floor plus a shape the precheck defers on is stable terminal", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		// tx_nonce == 0 is a shape the cheap precheck refuses to decide, so the
+		// slow path owns the outcome and reports terminal invalidity.
+		raw := h.tx(0, 100_000, 100_000, 0)
+		h.mp.SetCurrentMinFeeRateForTest(1 << 40)
+		got := h.mp.AddRemoteTxForRelay(raw, h.context())
+		if got.Disposition != RelayAdmissionStableTerminalReject {
+			t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT (err=%v)", got.Disposition, got.Err)
+		}
+		if !got.HasAdmissionContext {
+			t.Fatal("a proven stable terminal rejection must publish its exact context")
+		}
+	})
+}
+
+// TestRelayAdmissionDispositionContextTransitionsNeverAuthorizeCaching walks the
+// owner generations a tip comparison alone cannot see. An A-to-B-to-A reorg and
+// an aborted transition both leave the stable tip equal and the generation past
+// every earlier context, so a cached expected context must lose.
+func TestRelayAdmissionDispositionContextTransitionsNeverAuthorizeCaching(t *testing.T) {
+	t.Run("A to B to A with the same tip", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		raw := h.tx(0, 100_000, 100_000, 1)
+		stale := h.context()
+
+		owner := h.mp.PendingOutpointOwner()
+		otherTip := PendingOutpointTip{HasTip: true, Height: 101, Hash: [32]byte{0x22}}
+		if _, err := owner.beginTransition(); err != nil {
+			t.Fatalf("beginTransition(B): %v", err)
+		}
+		if err := owner.commitStableTip(otherTip); err != nil {
+			t.Fatalf("commitStableTip(B): %v", err)
+		}
+		if _, err := owner.beginTransition(); err != nil {
+			t.Fatalf("beginTransition(A): %v", err)
+		}
+		if err := owner.commitStableTip(pendingOutpointTipOf(h.st)); err != nil {
+			t.Fatalf("commitStableTip(A): %v", err)
+		}
+
+		current, ok := owner.AdmissionContext()
+		if !ok {
+			t.Fatal("owner admission context unavailable")
+		}
+		if current.StableTip != stale.StableTip {
+			t.Fatalf("stable tip moved: got %+v, want the original %+v", current.StableTip, stale.StableTip)
+		}
+		if current.Generation == stale.Generation {
+			t.Fatal("generation did not advance across the reorg")
+		}
+
+		before := mustSnapshot(t, h.mp)
+		got := h.mp.AddRemoteTxForRelay(raw, stale)
+		if got.Disposition != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("a superseded context must never be published as cache authority")
+		}
+		// The owner refuses an unavailable binding before it scans for a
+		// conflict and before it consumes a sequence: nothing moved at all.
+		if after := mustSnapshot(t, h.mp); !reflect.DeepEqual(after, before) {
+			t.Fatalf("superseded-context admission mutated state: before=%+v after=%+v", before, after)
+		}
+	})
+
+	t.Run("superseded context loses to nothing at the conflict slot", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		if err := h.mp.AddRemoteTx(h.tx(0, 100_000, 100_000, 1)); err != nil {
+			t.Fatalf("seed AddRemoteTx: %v", err)
+		}
+		conflicting := h.tx(0, 100_000, 200_000, 2)
+		stale := h.context()
+		h.advanceOwnerGeneration()
+
+		// The SAME candidate is a live owner conflict. Availability is checked
+		// first, so the superseded context wins over the conflict.
+		got := h.mp.AddRemoteTxForRelay(conflicting, stale)
+		if got.Disposition != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE ahead of the conflict (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("a superseded context must never be published as cache authority")
+		}
+		// With a current context the same candidate reaches the conflict.
+		current := h.context()
+		if again := h.mp.AddRemoteTxForRelay(conflicting, current); again.Disposition != RelayAdmissionConflict {
+			t.Fatalf("disposition=%v with the current context, want CONFLICT (err=%v)", again.Disposition, again.Err)
+		}
+	})
+}
+
+// TestAddRemoteTxForRelayMatchesAddRemoteTxExactly proves the new entry point is
+// a compatibility-preserving twin of AddRemoteTx: same public error kind and
+// message, same residency, same admission counters, same rolling floor, same
+// byte accounting, for accepted and rejected candidates alike.
+func TestAddRemoteTxForRelayMatchesAddRemoteTxExactly(t *testing.T) {
+	relay := newRelayHarness(t, nil, 1_000_000, 1_000_000)
+	// The SAME candidate bytes drive both sides, so every public message —
+	// including the ones that embed a conflicting txid — must compare equal.
+	// testSpendableChainState is deterministic for a given address, so the
+	// legacy twin starts from an identical, separately owned chainstate.
+	legacySt, _ := testSpendableChainState(relay.fromAddr, []uint64{1_000_000, 1_000_000})
+	legacyMp, err := NewMempool(legacySt, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new legacy mempool: %v", err)
+	}
+
+	accepted := relay.tx(0, 100_000, 100_000, 1)
+	candidates := [][]byte{
+		accepted,                         // accepted
+		accepted,                         // duplicate txid
+		relay.tx(0, 100_000, 200_000, 2), // owner conflict
+		{0xFF, 0x00},                     // unparseable
+		append(relay.tx(1, 100_000, 100_000, 3), 0x00),                    // trailing bytes
+		corruptFirstWitnessSignature(t, relay.tx(1, 100_000, 100_000, 4)), // consensus-invalid
+	}
+
+	for i := range candidates {
+		legacyErr := legacyMp.AddRemoteTx(candidates[i])
+		result := relay.mp.AddRemoteTxForRelay(candidates[i], nil)
+
+		switch {
+		case legacyErr == nil && result.Err != nil:
+			t.Fatalf("candidate %d: legacy accepted, relay returned %v", i, result.Err)
+		case legacyErr != nil && result.Err == nil:
+			t.Fatalf("candidate %d: legacy returned %v, relay accepted", i, legacyErr)
+		case legacyErr != nil:
+			if got, want := admitKind(t, result.Err), admitKind(t, legacyErr); got != want {
+				t.Fatalf("candidate %d: relay kind=%q, want the legacy %q", i, got, want)
+			}
+			if got, want := result.Err.Error(), legacyErr.Error(); got != want {
+				t.Fatalf("candidate %d: relay message=%q, want the legacy %q", i, got, want)
+			}
+		}
+		if result.HasAdmissionContext {
+			t.Fatalf("candidate %d: a nil expected context authorized caching", i)
+		}
+		if result.AdmissionContext != (PendingOutpointAdmissionContext{}) {
+			t.Fatalf("candidate %d: a nil expected context published a context", i)
+		}
+	}
+
+	if got, want := relay.mp.AdmissionCounts(), legacyMp.AdmissionCounts(); got != want {
+		t.Fatalf("admission counters=%+v, want the legacy %+v", got, want)
+	}
+	if got, want := relay.mp.Stats(), legacyMp.Stats(); got != want {
+		t.Fatalf("mempool stats=%+v, want the legacy %+v", got, want)
+	}
+	if got, want := relay.mp.Len(), legacyMp.Len(); got != want {
+		t.Fatalf("mempool len=%d, want the legacy %d", got, want)
+	}
+	relay.mp.mu.RLock()
+	relaySeq := relay.mp.lastAdmissionSeq
+	relay.mp.mu.RUnlock()
+	legacyMp.mu.RLock()
+	legacySeq := legacyMp.lastAdmissionSeq
+	legacyMp.mu.RUnlock()
+	if relaySeq != legacySeq {
+		t.Fatalf("lastAdmissionSeq=%d, want the legacy %d", relaySeq, legacySeq)
+	}
+}
+
+// TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam pins the
+// ordering clause: a supplied expected context is validated AT the owner seam
+// and never earlier, so it cannot preempt the baseline parse or duplicate
+// precedence — and validating it mutates nothing.
+func TestAddRemoteTxForRelayValidatesExpectedContextAtTheOwnerSeam(t *testing.T) {
+	t.Run("parse precedes the context check", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		stale := h.context()
+		h.advanceOwnerGeneration()
+		before := mustSnapshot(t, h.mp)
+
+		got := h.mp.AddRemoteTxForRelay([]byte{0xFF, 0x00, 0x13, 0x37}, stale)
+		if got.Disposition != RelayAdmissionStableTerminalReject {
+			t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT ahead of the context check (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("a superseded context must not be published for the parse rejection")
+		}
+		if after := mustSnapshot(t, h.mp); !reflect.DeepEqual(after, before) {
+			t.Fatalf("classification mutated state: before=%+v after=%+v", before, after)
+		}
+	})
+
+	t.Run("the duplicate slot precedes the context check", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		raw := h.tx(0, 100_000, 100_000, 1)
+		if err := h.mp.AddRemoteTx(raw); err != nil {
+			t.Fatalf("seed AddRemoteTx: %v", err)
+		}
+		stale := h.context()
+		h.advanceOwnerGeneration()
+
+		got := h.mp.AddRemoteTxForRelay(raw, stale)
+		if got.Disposition != RelayAdmissionDuplicate {
+			t.Fatalf("disposition=%v, want DUPLICATE ahead of the context check (err=%v)", got.Disposition, got.Err)
+		}
+	})
+
+	t.Run("an unavailable owner context is not proven and admits nothing", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		raw := h.tx(0, 100_000, 100_000, 1)
+		expected := h.context()
+		if _, err := h.mp.PendingOutpointOwner().beginTransition(); err != nil {
+			t.Fatalf("beginTransition: %v", err)
+		}
+		got := h.mp.AddRemoteTxForRelay(raw, expected)
+		if got.Disposition != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE (err=%v)", got.Disposition, got.Err)
+		}
+		if got.HasAdmissionContext {
+			t.Fatal("an active transition must never publish cache authority")
+		}
+		if h.mp.Len() != 0 {
+			t.Fatal("a candidate entered the mempool during an active owner transition")
+		}
+	})
+
+	t.Run("an input-less candidate still validates the supplied context", func(t *testing.T) {
+		h := newRelayHarness(t, nil, 1_000_000)
+		stale := h.context()
+		h.advanceOwnerGeneration()
+
+		entry := &mempoolEntry{txid: [32]byte{0x71}, wtxid: [32]byte{0x72}, weight: 1, size: 1}
+		probe := &relayAdmissionProbe{expected: stale}
+		h.mp.mu.Lock()
+		err := h.mp.reserveEntryInputsLocked(entry, probe)
+		h.mp.mu.Unlock()
+		if err == nil {
+			t.Fatal("a superseded context must not pass the input-less seam")
+		}
+		if got := relayDispositionOf(err); got != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE", got)
+		}
+		if entry.token != (PendingOutpointToken{}) {
+			t.Fatal("the input-less seam issued a token")
+		}
+
+		// The current context passes, and a nil probe keeps the baseline no-op.
+		probe = &relayAdmissionProbe{expected: h.context()}
+		h.mp.mu.Lock()
+		err = h.mp.reserveEntryInputsLocked(entry, probe)
+		if err == nil {
+			err = h.mp.reserveEntryInputsLocked(entry, nil)
+		}
+		h.mp.mu.Unlock()
+		if err != nil {
+			t.Fatalf("input-less seam with the current context: %v", err)
+		}
+	})
+
+	t.Run("the input-less seam refuses a nil owner exactly as the sibling does", func(t *testing.T) {
+		// A bare Mempool value has no owner at all, so the owner's admission
+		// context is unavailable — the same first check the input-bearing
+		// sibling runs, and the shape a nil owner can only take.
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		bare := &Mempool{}
+		entry := &mempoolEntry{txid: [32]byte{0x81}, wtxid: [32]byte{0x82}, weight: 1, size: 1}
+		probe := &relayAdmissionProbe{expected: expected}
+		bare.mu.Lock()
+		err := bare.reserveEntryInputsLocked(entry, probe)
+		bare.mu.Unlock()
+		if err == nil {
+			t.Fatal("a nil owner must not pass the input-less seam")
+		}
+		if got := relayDispositionOf(err); got != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE", got)
+		}
+		if got, want := err.Error(), "pending-outpoint owner admission context unavailable"; got != want {
+			t.Fatalf("message=%q, want the sibling's %q", got, want)
+		}
+		if bare.pendingOutpoints != nil {
+			t.Fatal("classifying created an owner")
+		}
+	})
+
+	t.Run("the input-less seam refuses an owner tip that left the guarded chainstate tip", func(t *testing.T) {
+		// The input-bearing sibling refuses this shape (mempool_policy.go's
+		// reserveEntryInputsLocked tip check); the input-less seam must refuse
+		// it identically, or a candidate that claims no outpoint would pass
+		// what every other candidate is held to.
+		h := newRelayHarness(t, nil, 1_000_000)
+		expected := h.context()
+		h.st.Height = 101
+
+		entry := &mempoolEntry{txid: [32]byte{0x91}, wtxid: [32]byte{0x92}, weight: 1, size: 1}
+		probe := &relayAdmissionProbe{expected: expected}
+		h.mp.mu.Lock()
+		err := h.mp.reserveEntryInputsLocked(entry, probe)
+		h.mp.mu.Unlock()
+		if err == nil {
+			t.Fatal("an owner tip behind the guarded chainstate tip must not pass the input-less seam")
+		}
+		if got := relayDispositionOf(err); got != RelayAdmissionUnavailable {
+			t.Fatalf("disposition=%v, want UNAVAILABLE", got)
+		}
+		if got, want := err.Error(), "pending-outpoint owner tip does not match the guarded chainstate tip"; got != want {
+			t.Fatalf("message=%q, want the sibling's %q", got, want)
+		}
+	})
+}
+
+// TestAddRemoteTxForRelayNilReceiverIsUnavailable pins the nil-receiver contract
+// shared with every other exported Mempool accessor: a typed unavailable result,
+// no panic, and no counter movement.
+func TestAddRemoteTxForRelayNilReceiverIsUnavailable(t *testing.T) {
+	var mp *Mempool
+	got := mp.AddRemoteTxForRelay([]byte{0x01}, nil)
+	if got.Disposition != RelayAdmissionUnavailable {
+		t.Fatalf("disposition=%v, want UNAVAILABLE", got.Disposition)
+	}
+	if kind := admitKind(t, got.Err); kind != TxAdmitUnavailable {
+		t.Fatalf("TxAdmitErrorKind=%q, want %q", kind, TxAdmitUnavailable)
+	}
+	if got.Err.Error() != "nil mempool" {
+		t.Fatalf("message=%q, want the legacy %q", got.Err.Error(), "nil mempool")
+	}
+	if got.TxID != ([32]byte{}) || got.HasAdmissionContext {
+		t.Fatalf("nil receiver published identity or context: %+v", got)
+	}
+	if counts := mp.AdmissionCounts(); counts != (MempoolAdmissionCounts{}) {
+		t.Fatalf("nil receiver moved counters: %+v", counts)
+	}
+}


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1120
- GitHub Issue mirror (non-authoritative): #2834

Refs: Q-GO-RELAY-ADMISSION-DISPOSITION-01

## Summary
Adds the closed RelayAdmissionDisposition taxonomy, the immutable RelayAdmissionResult, and Mempool.AddRemoteTxForRelay, plus the concrete CanonicalMempoolTxPool relay-admission method. AddRemoteTx remains a compatibility wrapper over the same implementation.

## Invariant
Every Go remote-mempool admission returns one producer-selected closed relay disposition and, only when proven against the exact complete stable AdmissionContext, the context evidence needed for relay caching, while all existing public admission errors, counters, validation order, mutation order, and callers retain their baseline behavior.

## Scope
- Changed files: 12
- Surfaces: clients/go/node, clients/go/node/p2p
- Non-scope: no relay cache, no P2P suppression, no callback or cancellation framework, no consensus change, no Rust mirror, no RPC/wire/persistence/metrics-schema change; p2p service and handlers untouched; the generic p2p.TxPool interface is not widened
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks at head b30b69ec: `gofmt -l ./node ./node/p2p` — PASS; `go build ./...` — PASS; `go vet ./...` — PASS; `go test -count=1 ./...` — PASS; `go test -race -count=1 ./node ./node/p2p` — PASS; `go test -count=1 ./node -run '^(TestRelayAdmissionDisposition|TestAddRemoteTxForRelay|TestMempoolPolicy)'` — PASS; `go test -count=1 ./node/p2p -run '^TestCanonicalMempoolTxPoolRelayAdmission'` — PASS; `cd conformance && go test ./...` — PASS; `git diff --check` — PASS

## Follow-ups / Waivers
- https://linear.app/rubinp/issue/RUB-1145
- https://linear.app/rubinp/issue/RUB-1115
- https://linear.app/rubinp/issue/RUB-1124

### Parity exemption justification
This is a contract-approved Go-only policy-layer slice (RUB-1120: parity_status GO_REFERENCE_ONLY; forbidden_files_or_surfaces includes clients/rust). It changes no consensus rule, error identity, first-error order, serialization, hash, or shared-fixture surface — a result-classification layer over the existing Go Mempool admission path whose new API has no production caller yet (p2p service and handlers are a forbidden surface, and the method is deliberately off the generic p2p.TxPool interface). The Rust TxPool sibling is the registered post-Go parity contract that must consume this merged Go reference, recorded on the Linear issue.
