### PR TITLE
RUB-1146: distinguish local crypto-backend faults from candidate invalidity

### DIFF
--- a/clients/go/consensus/errors.go
+++ b/clients/go/consensus/errors.go
@@ -63,10 +63,21 @@ const (
 // cannot express that difference: TX_ERR_PARSE, TX_ERR_SIG_INVALID and
 // TX_ERR_SIG_ALG_INVALID each carry both meanings today.
 //
-// It is additive only. The zero value is UNSPECIFIED and changes nothing: no
-// public code, message, Error() rendering, accept/reject decision, counter or
-// validation order reads it, and an error whose producer selected no cause
-// keeps its exact baseline classification everywhere.
+// It is additive in BEHAVIOR, not in struct shape. Preserved exactly: every
+// public ErrorCode, every message, Error() rendering, every accept/reject
+// decision, every counter, and validation order — none of them read the cause,
+// and an error whose producer selected no cause keeps its exact baseline
+// classification everywhere. NOT preserved: the shape of the exported TxError,
+// which grows an unexported field, so an UNKEYED composite literal such as
+// consensus.TxError{code, msg} no longer compiles.
+//
+// That source break is deliberate and accepted. Keeping the cause unexported
+// is what makes it unforgeable outside this package and invisible to every
+// public view, and an unkeyed literal fails LOUDLY at compile time rather than
+// silently mis-assigning. `go vet` runs the composites check by default, so the
+// fragile form is reported before it can become a hard break, and every TxError
+// literal in this repository is already keyed. To migrate one: name the fields,
+// or construct through txerr / txerrWithCause inside this package.
 //
 // The FIRST producing branch owns the cause. An outer wrapper may carry an
 // already-selected cause forward but must never overwrite or erase it, and no
@@ -133,6 +144,10 @@ func txerr(code ErrorCode, msg string) error {
 // txerrWithCause is the ONE cause-aware constructor. It is used only AT a
 // producing branch that owns the classification, or by a wrapper carrying an
 // already-selected cause forward unchanged.
+//
+// First-wins is a CALLER obligation, not a constructor guard: this function
+// accepts any cause and always builds a fresh error, so a wrapper MUST pass the
+// inner error's own Cause() and never a cause literal of its own.
 func txerrWithCause(code ErrorCode, msg string, cause TxErrorCause) error {
 	return &TxError{Code: code, Msg: msg, cause: cause}
 }

--- a/clients/go/consensus/errors.go
+++ b/clients/go/consensus/errors.go
@@ -57,9 +57,51 @@ const (
 	BLOCK_ERR_DA_BATCH_EXCEEDED         ErrorCode = "BLOCK_ERR_DA_BATCH_EXCEEDED"
 )
 
+// TxErrorCause is the closed, source-owned classification of WHY a consensus
+// error was produced, for the consumers that must tell a fault of THIS PROCESS
+// apart from invalidity of the candidate bytes. The public ErrorCode alone
+// cannot express that difference: TX_ERR_PARSE, TX_ERR_SIG_INVALID and
+// TX_ERR_SIG_ALG_INVALID each carry both meanings today.
+//
+// It is additive only. The zero value is UNSPECIFIED and changes nothing: no
+// public code, message, Error() rendering, accept/reject decision, counter or
+// validation order reads it, and an error whose producer selected no cause
+// keeps its exact baseline classification everywhere.
+//
+// The FIRST producing branch owns the cause. An outer wrapper may carry an
+// already-selected cause forward but must never overwrite or erase it, and no
+// consumer may infer one from message text.
+//
+// Adding a member is a constant plus one consumer arm. It never changes this
+// type, the accessor, or an existing mapping.
+type TxErrorCause uint8
+
+const (
+	// TxErrorCauseUnspecified means no producing branch selected a cause. It is
+	// the zero value and carries no new meaning.
+	TxErrorCauseUnspecified TxErrorCause = iota
+	// TxErrorCauseLocalCryptoBackendFault means this node's own OpenSSL
+	// consensus backend could not initialize, could not resolve its live
+	// verifier binding from local runtime/configuration state, or failed
+	// INSIDE verification for a reason that is not a property of the candidate.
+	// It is evidence about this process, never about the transaction, so a
+	// consumer must not publish the outcome as a stable terminal rejection of
+	// these bytes and must not let it authorize a negative cache.
+	//
+	// It is deliberately NOT selected when the candidate itself selected an
+	// unsupported or unauthorized suite: that verdict is a property of the
+	// bytes and keeps its baseline classification.
+	TxErrorCauseLocalCryptoBackendFault
+)
+
 type TxError struct {
 	Code ErrorCode
 	Msg  string
+	// cause is the producing branch's own typed classification. It is
+	// unexported and outside every public view — Error(), Code, Msg, the JSON
+	// and HTTP mappings neither read it nor change with it — so a consumer that
+	// wants it MUST call Cause(). Its zero value is TxErrorCauseUnspecified.
+	cause TxErrorCause
 }
 
 func (e *TxError) Error() string {
@@ -72,6 +114,25 @@ func (e *TxError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Msg)
 }
 
+// Cause reports the typed cause the producing branch selected, or
+// TxErrorCauseUnspecified when none did. It is a pure read: it allocates
+// nothing, mutates nothing, and is nil-safe like Error().
+func (e *TxError) Cause() TxErrorCause {
+	if e == nil {
+		return TxErrorCauseUnspecified
+	}
+	return e.cause
+}
+
+// txerr is the compatibility constructor: it selects no cause, so every
+// existing call site keeps its exact baseline behavior.
 func txerr(code ErrorCode, msg string) error {
 	return &TxError{Code: code, Msg: msg}
+}
+
+// txerrWithCause is the ONE cause-aware constructor. It is used only AT a
+// producing branch that owns the classification, or by a wrapper carrying an
+// already-selected cause forward unchanged.
+func txerrWithCause(code ErrorCode, msg string, cause TxErrorCause) error {
+	return &TxError{Code: code, Msg: msg, cause: cause}
 }

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -258,6 +258,16 @@ func ensureOpenSSLConsensusInit() error {
 // process-start configuration, not a per-call runtime knob. If bootstrap fails after
 // those env vars are misconfigured, the recovery path is process restart. Test code may
 // use resetOpenSSLBootstrapStateForTests to re-arm the bootstrap between isolated cases.
+//
+// Both failure exits below are process-local faults of exactly the same kind as
+// ensureOpenSSLConsensusInit's, yet they deliberately select NO TxErrorCause.
+// That is correct only because of WHO CALLS THEM: every caller is a keygen,
+// signing or conformance-fixture path (openssl_signer.go,
+// openssl_signer_conformance_fixture.go), never transaction validation, so no
+// error from here can reach relay admission. A new caller on the admission path
+// would make these untyped local faults publish as stable terminal rejections
+// under TX_ERR_PARSE — add TxErrorCauseLocalCryptoBackendFault here before
+// adding such a caller.
 func ensureOpenSSLBootstrap() error {
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("RUBIN_OPENSSL_FIPS_MODE")))
 	switch mode {
@@ -488,6 +498,12 @@ func resolveSuiteVerifierBindingPolicyInvalidError(algName string, pubkeyLen int
 // already-selected cause forward unchanged and never selects, overwrites or
 // erases one. The non-TxError arm cannot classify what it did not produce, so
 // it stays cause-unspecified.
+//
+// That arm is UNREACHABLE today only because resolveSuiteVerifierBinding
+// returns a *TxError on both of its failure exits. If a future exit there
+// returns a plain error, this arm becomes live and starts producing an UNCAUSED
+// local binding fault — which relay admission would publish as a stable
+// terminal rejection. Classify at that new exit, not here.
 func wrapResolveSuiteVerifierBindingError(suiteID uint8, err error) error {
 	var txErr *TxError
 	if errors.As(err, &txErr) {
@@ -549,6 +565,12 @@ func verifySigWithBinding(binding suiteVerifierBinding, pubkey []byte, signature
 			// err) is the candidate's own invalidity and stays uncaused; this
 			// arm is the local runtime fault, with the same public
 			// TX_ERR_SIG_INVALID code and the same message as before.
+			//
+			// Both operands here are CANDIDATE bytes, length-checked only, so
+			// this arm is a local fault ONLY while their content cannot make
+			// the backend error instead of returning a false verdict. For
+			// ML-DSA-87 it cannot, and that premise is pinned by
+			// TestVerifyMLDSA87Digest32_CorrectLengthGarbageIsInvalidNotFault.
 			return false, txerrWithCause(
 				TX_ERR_SIG_INVALID,
 				"verify_sig: EVP_DigestVerify internal error",

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -237,7 +237,15 @@ func defaultRuntimeSuiteRegistry() *SuiteRegistry {
 func ensureOpenSSLConsensusInit() error {
 	opensslConsensusInitOnce.Do(func() {
 		if err := opensslConsensusInitFn(); err != nil {
-			opensslConsensusInitErr = txerr(TX_ERR_PARSE, fmt.Sprintf("openssl consensus init: %v", err))
+			// PROCESS-LOCAL fault, latched by the sync.Once until restart: it
+			// is not evidence about any candidate's bytes. The public
+			// TX_ERR_PARSE code and this exact message are unchanged; only the
+			// typed cause is added, at the branch that owns the decision.
+			opensslConsensusInitErr = txerrWithCause(
+				TX_ERR_PARSE,
+				fmt.Sprintf("openssl consensus init: %v", err),
+				TxErrorCauseLocalCryptoBackendFault,
+			)
 		}
 	})
 	return opensslConsensusInitErr
@@ -438,8 +446,15 @@ type suiteVerifierBinding struct {
 	sigLen     int
 }
 
+// resolveSuiteVerifierBindingUnsupportedError is a LOCAL fault at every call
+// site of resolveSuiteVerifierBinding: the (alg, pubkey_len, sig_len) tuple it
+// reports comes from this node's own constants or from its configured
+// SuiteRegistry entry, never from the candidate. A candidate that selects a
+// suite this node does not authorize is rejected EARLIER — by the native
+// spend-set check, the registry lookup, or verifySig's suite switch — and those
+// exits deliberately select no cause.
 func resolveSuiteVerifierBindingUnsupportedError(algName string, pubkeyLen int, sigLen int) error {
-	return txerr(
+	return txerrWithCause(
 		TX_ERR_SIG_ALG_INVALID,
 		fmt.Sprintf(
 			"resolveSuiteVerifierBinding: unsupported alg=%q pubkey_len=%d sig_len=%d",
@@ -447,11 +462,15 @@ func resolveSuiteVerifierBindingUnsupportedError(algName string, pubkeyLen int, 
 			pubkeyLen,
 			sigLen,
 		),
+		TxErrorCauseLocalCryptoBackendFault,
 	)
 }
 
+// resolveSuiteVerifierBindingPolicyInvalidError reports that this node's local
+// live-binding policy artifact could not be loaded or validated. That is a
+// property of the local installation only.
 func resolveSuiteVerifierBindingPolicyInvalidError(algName string, pubkeyLen int, sigLen int, err error) error {
-	return txerr(
+	return txerrWithCause(
 		TX_ERR_SIG_ALG_INVALID,
 		fmt.Sprintf(
 			"resolveSuiteVerifierBinding: live binding policy invalid alg=%q pubkey_len=%d sig_len=%d: %v",
@@ -460,15 +479,22 @@ func resolveSuiteVerifierBindingPolicyInvalidError(algName string, pubkeyLen int
 			sigLen,
 			err,
 		),
+		TxErrorCauseLocalCryptoBackendFault,
 	)
 }
 
+// wrapResolveSuiteVerifierBindingError adds the suite_id context to a binding
+// resolution failure. It is an OUTER WRAPPER: it CARRIES the inner branch's
+// already-selected cause forward unchanged and never selects, overwrites or
+// erases one. The non-TxError arm cannot classify what it did not produce, so
+// it stays cause-unspecified.
 func wrapResolveSuiteVerifierBindingError(suiteID uint8, err error) error {
 	var txErr *TxError
 	if errors.As(err, &txErr) {
-		return txerr(
+		return txerrWithCause(
 			txErr.Code,
 			fmt.Sprintf("suite_id=0x%02x %s", suiteID, txErr.Msg),
+			txErr.Cause(),
 		)
 	}
 	return txerr(
@@ -519,13 +545,25 @@ func verifySigWithBinding(binding suiteVerifierBinding, pubkey []byte, signature
 	case suiteVerifierBindingOpenSSLDigest32V1:
 		ok, err := opensslVerifySigOneShotFn(binding.opensslAlg, pubkey, signature, digest32[:])
 		if err != nil {
-			return false, txerr(TX_ERR_SIG_INVALID, "verify_sig: EVP_DigestVerify internal error")
+			// The backend could not DECIDE. A false verdict (ok == false, nil
+			// err) is the candidate's own invalidity and stays uncaused; this
+			// arm is the local runtime fault, with the same public
+			// TX_ERR_SIG_INVALID code and the same message as before.
+			return false, txerrWithCause(
+				TX_ERR_SIG_INVALID,
+				"verify_sig: EVP_DigestVerify internal error",
+				TxErrorCauseLocalCryptoBackendFault,
+			)
 		}
 		return ok, nil
 	default:
-		return false, txerr(TX_ERR_SIG_ALG_INVALID,
+		// Only resolveSuiteVerifierBinding builds a binding, and it returns
+		// either the one known kind or an error, so this is a local structural
+		// invariant of this build — never a candidate property.
+		return false, txerrWithCause(TX_ERR_SIG_ALG_INVALID,
 			fmt.Sprintf("verifySigWithBinding: unsupported binding kind=%d alg=%q",
-				binding.kind, binding.opensslAlg))
+				binding.kind, binding.opensslAlg),
+			TxErrorCauseLocalCryptoBackendFault)
 	}
 }
 
@@ -537,7 +575,13 @@ func runtimeVerificationRegistry(registry *SuiteRegistry) (*SuiteRegistry, error
 	}
 	registry = defaultRuntimeSuiteRegistryForVerification()
 	if !registry.IsCanonicalDefaultLiveManifest() {
-		return nil, txerr(TX_ERR_SIG_ALG_INVALID, "verify_sig: default runtime registry drift")
+		// The process-cached default registry no longer matches the live
+		// manifest: local runtime state, not anything the candidate chose.
+		return nil, txerrWithCause(
+			TX_ERR_SIG_ALG_INVALID,
+			"verify_sig: default runtime registry drift",
+			TxErrorCauseLocalCryptoBackendFault,
+		)
 	}
 	return registry, nil
 }

--- a/clients/go/consensus/verify_sig_openssl_additional_test.go
+++ b/clients/go/consensus/verify_sig_openssl_additional_test.go
@@ -198,6 +198,26 @@ func TestVerifySig_UnsupportedSuiteIDMessageCarriesSuiteID(t *testing.T) {
 	}
 }
 
+// txErrorCauseOf reads the typed cause a consensus error carries.
+func txErrorCauseOf(t *testing.T, err error) TxErrorCause {
+	t.Helper()
+	var txErr *TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("errors.As(*TxError) failed for %T: %v", err, err)
+	}
+	return txErr.Cause()
+}
+
+// Cause() is nil-safe exactly like Error(), and a nil receiver carries no
+// meaning: a consumer that dereferences a nil *TxError must not be handed a
+// local-fault classification it can act on.
+func TestTxErrorCause_NilReceiverIsUnspecified(t *testing.T) {
+	var nilErr *TxError
+	if got := nilErr.Cause(); got != TxErrorCauseUnspecified {
+		t.Fatalf("nil Cause()=%d, want TxErrorCauseUnspecified", got)
+	}
+}
+
 func TestResolveSuiteVerifierBinding_UnknownCarriesAlgAndLens(t *testing.T) {
 	_, err := resolveSuiteVerifierBinding("FAKE-ALG", 7, 9)
 	if err == nil {
@@ -205,6 +225,9 @@ func TestResolveSuiteVerifierBinding_UnknownCarriesAlgAndLens(t *testing.T) {
 	}
 	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_ALG_INVALID {
 		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_ALG_INVALID)
+	}
+	if got := txErrorCauseOf(t, err); got != TxErrorCauseLocalCryptoBackendFault {
+		t.Fatalf("cause=%d, want TxErrorCauseLocalCryptoBackendFault", got)
 	}
 	msg := err.Error()
 	for _, needle := range []string{
@@ -237,6 +260,80 @@ func TestWrapResolveSuiteVerifierBindingError_PreservesTxErrorCodeAndSuiteID(t *
 	if strings.Count(msg, "resolveSuiteVerifierBinding:") != 1 {
 		t.Fatalf("wrapped error should keep a single resolveSuiteVerifierBinding prefix, got %q", msg)
 	}
+	// The wrapper CARRIES the inner branch's cause and never erases it.
+	if got := txErrorCauseOf(t, err); got != TxErrorCauseLocalCryptoBackendFault {
+		t.Fatalf("wrapped cause=%d, want TxErrorCauseLocalCryptoBackendFault", got)
+	}
+	// ...and never INVENTS one for an inner error that selected none.
+	uncaused := wrapResolveSuiteVerifierBindingError(0x2a, txerr(TX_ERR_SIG_ALG_INVALID, "no cause here"))
+	if got := txErrorCauseOf(t, uncaused); got != TxErrorCauseUnspecified {
+		t.Fatalf("wrapped uncaused cause=%d, want TxErrorCauseUnspecified", got)
+	}
+}
+
+// Matrix row 3: a live verifier binding this node cannot resolve because of its
+// OWN registry configuration keeps the existing public code and message and is
+// typed LOCAL_CRYPTO_BACKEND_FAULT. The registry here is exactly what
+// node.MempoolConfig.SuiteRegistry carries into consensus validation.
+func TestVerifySigWithRegistryCache_LocalBindingFaultCarriesCause(t *testing.T) {
+	const unboundAlg = "ML-DSA-87-NOT-LIVE-BOUND"
+	registry := NewSuiteRegistryFromParams([]SuiteParams{{
+		SuiteID:    SUITE_ID_ML_DSA_87,
+		PubkeyLen:  ML_DSA_87_PUBKEY_BYTES,
+		SigLen:     ML_DSA_87_SIG_BYTES,
+		VerifyCost: VERIFY_COST_ML_DSA_87,
+		AlgName:    unboundAlg,
+	}})
+	_, err := verifySigWithRegistryCache(
+		SUITE_ID_ML_DSA_87,
+		make([]byte, ML_DSA_87_PUBKEY_BYTES),
+		make([]byte, ML_DSA_87_SIG_BYTES),
+		[32]byte{},
+		registry,
+		nil,
+	)
+	wantMsg := fmt.Sprintf(
+		"suite_id=0x%02x resolveSuiteVerifierBinding: unsupported alg=%q pubkey_len=%d sig_len=%d",
+		SUITE_ID_ML_DSA_87, unboundAlg, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
+	)
+	mustTxErrorCause(t, err, TX_ERR_SIG_ALG_INVALID, wantMsg, TxErrorCauseLocalCryptoBackendFault)
+}
+
+// The local default-registry drift guard is node-local runtime state too.
+func TestRuntimeVerificationRegistry_DriftCarriesCause(t *testing.T) {
+	previous := defaultRuntimeSuiteRegistryForVerification
+	t.Cleanup(func() { defaultRuntimeSuiteRegistryForVerification = previous })
+	defaultRuntimeSuiteRegistryForVerification = func() *SuiteRegistry {
+		return NewSuiteRegistryFromParams(nil)
+	}
+
+	_, err := runtimeVerificationRegistry(nil)
+	mustTxErrorCause(
+		t,
+		err,
+		TX_ERR_SIG_ALG_INVALID,
+		"verify_sig: default runtime registry drift",
+		TxErrorCauseLocalCryptoBackendFault,
+	)
+}
+
+// Matrix row 6: a suite the CANDIDATE selected and this node does not authorize
+// keeps TX_ERR_SIG_ALG_INVALID and selects NO cause, at both exits that decide
+// it — verifySig's legacy switch and the registry lookup.
+func TestUnauthorizedCandidateSuiteCarriesNoLocalCause(t *testing.T) {
+	var digest [32]byte
+	_, err := verifySig(0x7b, []byte{0x01}, []byte{0x02}, digest)
+	mustTxErrorCause(t, err, TX_ERR_SIG_ALG_INVALID, "verify_sig: unsupported suite_id=0x7b", TxErrorCauseUnspecified)
+
+	_, err = verifySigWithRegistryCache(
+		SUITE_ID_ML_DSA_87,
+		make([]byte, ML_DSA_87_PUBKEY_BYTES),
+		make([]byte, ML_DSA_87_SIG_BYTES),
+		digest,
+		NewSuiteRegistryFromParams(nil),
+		nil,
+	)
+	mustTxErrorCause(t, err, TX_ERR_SIG_ALG_INVALID, "verify_sig: unsupported suite_id", TxErrorCauseUnspecified)
 }
 
 func TestResolveSuiteVerifierBinding_InvalidPolicyReturnsTxError(t *testing.T) {
@@ -261,6 +358,9 @@ func TestResolveSuiteVerifierBinding_InvalidPolicyReturnsTxError(t *testing.T) {
 		if !strings.Contains(msg, needle) {
 			t.Fatalf("invalid policy error missing %q, got %q", needle, msg)
 		}
+	}
+	if got := txErrorCauseOf(t, err); got != TxErrorCauseLocalCryptoBackendFault {
+		t.Fatalf("invalid policy cause=%d, want TxErrorCauseLocalCryptoBackendFault", got)
 	}
 }
 
@@ -287,5 +387,8 @@ func TestVerifySigWithBinding_UnknownKindCarriesContext(t *testing.T) {
 		if !strings.Contains(msg, needle) {
 			t.Fatalf("verifySigWithBinding error missing %q, got %q", needle, msg)
 		}
+	}
+	if got := txErrorCauseOf(t, err); got != TxErrorCauseLocalCryptoBackendFault {
+		t.Fatalf("unknown binding kind cause=%d, want TxErrorCauseLocalCryptoBackendFault", got)
 	}
 }

--- a/clients/go/consensus/verify_sig_openssl_additional_test.go
+++ b/clients/go/consensus/verify_sig_openssl_additional_test.go
@@ -96,6 +96,49 @@ func TestVerifyMLDSA87Digest32UsesNativeBackend(t *testing.T) {
 	}
 }
 
+// TestVerifyMLDSA87Digest32_CorrectLengthGarbageIsInvalidNotFault pins the
+// premise the LOCAL_CRYPTO_BACKEND_FAULT arm of verifySigWithBinding asserts:
+// for ML-DSA-87 the backend never reports a one-shot ERROR because of the
+// CONTENT of a correct-length pubkey or signature, only a false VERDICT. Both
+// operands on that call are candidate bytes, length-checked only, so if a
+// future suite or backend revision started rejecting a malformed key structure
+// with rc<0 instead of a false verdict, a candidate could self-select the
+// local-fault cause and permanently escape the cache-authorizing class. This
+// test fails the moment that becomes possible.
+func TestVerifyMLDSA87Digest32_CorrectLengthGarbageIsInvalidNotFault(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0x5a
+
+	zeros := func(n int) []byte { return make([]byte, n) }
+	pattern := func(n int, seed byte) []byte {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = byte(i*31) ^ seed
+		}
+		return b
+	}
+
+	for _, tc := range []struct {
+		name   string
+		pubkey []byte
+		sig    []byte
+	}{
+		{"all_zero", zeros(ML_DSA_87_PUBKEY_BYTES), zeros(ML_DSA_87_SIG_BYTES)},
+		{"garbage", pattern(ML_DSA_87_PUBKEY_BYTES, 0xa7), pattern(ML_DSA_87_SIG_BYTES, 0x3c)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := VerifyMLDSA87Digest32(tc.pubkey, tc.sig, digest)
+			if err != nil {
+				t.Fatalf("correct-length garbage must be an invalid VERDICT, not an error: %v (cause=%d)",
+					err, txErrorCauseOf(t, err))
+			}
+			if ok {
+				t.Fatal("VerifyMLDSA87Digest32=true for correct-length garbage")
+			}
+		})
+	}
+}
+
 func TestOpenSSLVerifySig_UnknownAlgErrors(t *testing.T) {
 	var d [32]byte
 	ok, err := opensslVerifySigOneShot("NO_SUCH_ALG", []byte{0x01}, []byte{0x02}, d[:])

--- a/clients/go/consensus/verify_sig_openssl_bootstrap_test.go
+++ b/clients/go/consensus/verify_sig_openssl_bootstrap_test.go
@@ -3,10 +3,158 @@
 package consensus
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 )
+
+// localFaultFixture is one signed single-input CORE_P2PK transaction plus the
+// utxo set it spends, built while the backend is HEALTHY so every row below
+// differs from the accepting baseline only in the fault it injects.
+type localFaultFixture struct {
+	txBytes []byte
+	utxos   map[Outpoint]UtxoEntry
+	chainID [32]byte
+}
+
+func newLocalFaultFixture(t *testing.T) localFaultFixture {
+	t.Helper()
+	kp := mustMLDSA87Keypair(t)
+	covData := P2PKCovenantDataForPubkey(kp.PubkeyBytes())
+	var prevTxid [32]byte
+	prevTxid[0] = 0xAA
+	op := Outpoint{Txid: prevTxid, Vout: 0}
+	utxos := map[Outpoint]UtxoEntry{op: {
+		Value:             100_000_000,
+		CovenantType:      COV_TYPE_P2PK,
+		CovenantData:      covData,
+		CreationHeight:    1,
+		CreatedByCoinbase: true,
+	}}
+	tx := &Tx{
+		Version:  1,
+		TxNonce:  1,
+		Locktime: 0,
+		Inputs:   []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0x7FFFFFFF}},
+		Outputs:  []TxOutput{{Value: 90_000_000, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	var chainID [32]byte
+	chainID[0] = 0x88
+	if err := SignTransaction(tx, utxos, chainID, kp); err != nil {
+		t.Fatalf("SignTransaction: %v", err)
+	}
+	txBytes, err := MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx: %v", err)
+	}
+	return localFaultFixture{txBytes: txBytes, utxos: utxos, chainID: chainID}
+}
+
+// check drives the LIVE consensus validation entry point over the fixture.
+func (f localFaultFixture) check(chainID [32]byte) error {
+	_, err := CheckTransaction(f.txBytes, f.utxos, 200, 0, chainID)
+	return err
+}
+
+// mustTxErrorCause pins the whole public surface of a consensus error together
+// with the typed cause its producing branch selected: the code, the exact
+// message bytes, the exact Error() rendering, and that errors.As to *TxError
+// still resolves.
+func mustTxErrorCause(t *testing.T, err error, wantCode ErrorCode, wantMsg string, wantCause TxErrorCause) {
+	t.Helper()
+	var txErr *TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("errors.As(*TxError) failed for %T: %v", err, err)
+	}
+	if txErr.Code != wantCode {
+		t.Fatalf("Code=%s, want %s", txErr.Code, wantCode)
+	}
+	if txErr.Msg != wantMsg {
+		t.Fatalf("Msg=%q, want %q", txErr.Msg, wantMsg)
+	}
+	if want := string(wantCode) + ": " + wantMsg; txErr.Error() != want {
+		t.Fatalf("Error()=%q, want %q", txErr.Error(), want)
+	}
+	if txErr.Cause() != wantCause {
+		t.Fatalf("Cause()=%d, want %d", txErr.Cause(), wantCause)
+	}
+}
+
+// Matrix row 1: an OpenSSL consensus INIT failure keeps TX_ERR_PARSE and its
+// exact message, and is typed LOCAL_CRYPTO_BACKEND_FAULT at the branch that
+// latched it.
+func TestConsensusValidation_OpenSSLInitFaultCarriesLocalCryptoBackendFaultCause(t *testing.T) {
+	fixture := newLocalFaultFixture(t)
+
+	resetOpenSSLBootstrapStateForTests()
+	t.Cleanup(resetOpenSSLBootstrapStateForTests)
+	opensslConsensusInitFn = func() error {
+		return errors.New("synthetic consensus init failure")
+	}
+
+	mustTxErrorCause(
+		t,
+		fixture.check(fixture.chainID),
+		TX_ERR_PARSE,
+		"openssl consensus init: synthetic consensus init failure",
+		TxErrorCauseLocalCryptoBackendFault,
+	)
+}
+
+// Matrix row 2: the one-shot verifier returning an INTERNAL error keeps
+// TX_ERR_SIG_INVALID and its exact message, typed LOCAL_CRYPTO_BACKEND_FAULT.
+func TestConsensusValidation_OpenSSLOneShotFaultCarriesLocalCryptoBackendFaultCause(t *testing.T) {
+	fixture := newLocalFaultFixture(t)
+
+	resetOpenSSLBootstrapStateForTests()
+	t.Cleanup(resetOpenSSLBootstrapStateForTests)
+	t.Cleanup(func() { opensslVerifySigOneShotFn = opensslVerifySigOneShot })
+	opensslVerifySigOneShotFn = func(string, []byte, []byte, []byte) (bool, error) {
+		return false, errors.New("synthetic EVP_DigestVerify failure")
+	}
+
+	mustTxErrorCause(
+		t,
+		fixture.check(fixture.chainID),
+		TX_ERR_SIG_INVALID,
+		"verify_sig: EVP_DigestVerify internal error",
+		TxErrorCauseLocalCryptoBackendFault,
+	)
+}
+
+// Matrix rows 4 and 5 at the SOURCE: with a healthy backend a
+// cryptographically invalid signature and a structurally malformed candidate
+// keep their public errors and select NO cause, so no consumer can mistake
+// them for a local fault.
+func TestConsensusValidation_HealthyBackendCandidateFailuresCarryNoCause(t *testing.T) {
+	fixture := newLocalFaultFixture(t)
+
+	// Signed against fixture.chainID, validated against a different chain id:
+	// the sighash digest differs, so the backend decides "invalid" with no
+	// error of its own.
+	var otherChainID [32]byte
+	otherChainID[0] = 0x99
+	mustTxErrorCause(
+		t,
+		fixture.check(otherChainID),
+		TX_ERR_SIG_INVALID,
+		"CORE_P2PK signature invalid",
+		TxErrorCauseUnspecified,
+	)
+
+	_, err := CheckTransaction([]byte{0xFF, 0x00, 0x13, 0x37}, fixture.utxos, 200, 0, fixture.chainID)
+	var txErr *TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("malformed candidate: errors.As(*TxError) failed for %T: %v", err, err)
+	}
+	if txErr.Code != TX_ERR_PARSE {
+		t.Fatalf("malformed candidate Code=%s, want %s", txErr.Code, TX_ERR_PARSE)
+	}
+	if txErr.Cause() != TxErrorCauseUnspecified {
+		t.Fatalf("malformed candidate Cause()=%d, want TxErrorCauseUnspecified", txErr.Cause())
+	}
+}
 
 func TestEnsureOpenSSLBootstrap_ModeOffNoop(t *testing.T) {
 	resetOpenSSLBootstrapStateForTests()

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -63,8 +63,15 @@ const (
 	// retryable runtime unavailability.
 	RelayAdmissionUnavailable
 	// RelayAdmissionInternal covers an impossible invariant, a retained
-	// identity mismatch, accounting corruption, and an adapter contract
-	// violation.
+	// identity mismatch, accounting corruption, an adapter contract violation,
+	// and a process-local crypto-backend fault — a consensus error carrying
+	// consensus.TxErrorCauseLocalCryptoBackendFault, whose public code says
+	// nothing about whether this node could decide at all.
+	//
+	// That last class is INTERNAL rather than UNAVAILABLE because it is THIS
+	// process failing closed, not a missing admission input the node is waiting
+	// on; either way it is not stable invalidity of these bytes, so neither is
+	// cache-authorizing.
 	//
 	// It is also the ONE disposition a branch does not have to select: a
 	// REQUIRED post-decision cleanup step that reports a fault — pending-outpoint

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -530,11 +530,24 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 	return RelayAdmissionStableTerminalReject
 }
 
-// relayDispositionForInputError separates the RETRYABLE input-dependency class
-// from the branch's own non-dependency selection, discriminating on the typed
-// consensus error CODE rather than on its rendered text. An input that is
-// absent, still immature, or not yet unlocked becomes spendable at a later
-// height, so it must never be published as a stable terminal rejection.
+// relayDispositionForInputError separates the outcomes that are NOT stable
+// invalidity of these exact bytes from the branch's own non-dependency
+// selection, reading only typed values the producer set — never Error(), Msg,
+// backend text, or an OpenSSL error string.
+//
+// It reads the typed CAUSE first, because the cause outranks the code: a
+// process-local crypto-backend fault is published under a public code that also
+// carries genuine candidate invalidity (TX_ERR_PARSE for a latched
+// initialization failure, TX_ERR_SIG_INVALID for a verifier that could not
+// decide, TX_ERR_SIG_ALG_INVALID for a binding this node could not resolve from
+// its own configuration). That error is evidence about THIS process, so it is
+// INTERNAL — never a stable terminal rejection, and therefore never
+// cache-authorizing. A candidate that selected an unsupported or unauthorized
+// suite carries no such cause and keeps its baseline classification.
+//
+// Only then does the CODE fallback apply: an input that is absent, still
+// immature, or not yet unlocked becomes spendable at a later height, so it must
+// never be published as a stable terminal rejection either.
 //
 // nonDependency is the disposition the calling branch selects for everything
 // else it can produce: stable terminal invalidity for the consensus validation
@@ -542,6 +555,9 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 func relayDispositionForInputError(err error, nonDependency RelayAdmissionDisposition) RelayAdmissionDisposition {
 	var txErr *consensus.TxError
 	if errors.As(err, &txErr) {
+		if txErr.Cause() == consensus.TxErrorCauseLocalCryptoBackendFault {
+			return RelayAdmissionInternal
+		}
 		switch txErr.Code {
 		case consensus.TX_ERR_MISSING_UTXO, consensus.TX_ERR_COINBASE_IMMATURE, consensus.TX_ERR_TIMELOCK_NOT_MET:
 			return RelayAdmissionMissingDependency

--- a/clients/go/node/relay_admission_test.go
+++ b/clients/go/node/relay_admission_test.go
@@ -1508,3 +1508,140 @@ func TestRelayAdmissionDispositionCleanupFailureOutranksTheBranch(t *testing.T) 
 		t.Fatalf("Release error=%q, want %q", releaseErr.Error(), wantRelease)
 	}
 }
+
+// unboundAlgSuiteRegistry is the node-side configuration that makes THIS
+// process unable to resolve a live verifier binding for a suite it otherwise
+// authorizes: the registry entry keeps the canonical suite id, lengths and
+// verify cost — so the candidate passes every suite-authorization and
+// canonical-length check — and only its algorithm identity has no entry in the
+// local live-binding policy artifact. It is reached through
+// MempoolConfig.SuiteRegistry, the exported node configuration seam
+// NewMempoolWithConfig carries into consensus validation; no unexported
+// consensus hook, linkname or production test knob is involved.
+func unboundAlgSuiteRegistry() *consensus.SuiteRegistry {
+	return consensus.NewSuiteRegistryFromParams([]consensus.SuiteParams{{
+		SuiteID:    consensus.SUITE_ID_ML_DSA_87,
+		PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+		SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+		VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+		AlgName:    "ML-DSA-87-NOT-LIVE-BOUND",
+	}})
+}
+
+// TestRelayAdmissionLocalCryptoBackendFaultPublishesInternal is the END-TO-END
+// row of the classification matrix: a PROCESS-LOCAL crypto-backend fault driven
+// through the real relay-admission entry point publishes INTERNAL and no
+// cache-authorizing context, while the public admission error — kind and
+// message alike — stays byte-identical to what the same fault produced before
+// the typed cause existed.
+//
+// The consumer decides from the typed cause alone. The public code carrying it
+// here, TX_ERR_SIG_ALG_INVALID, is the SAME code an unauthorized candidate suite
+// produces, and that row still classifies as a stable terminal rejection below,
+// so a classifier reading the code — or the message — could not tell them apart.
+func TestRelayAdmissionLocalCryptoBackendFaultPublishesInternal(t *testing.T) {
+	h := newRelayHarness(t, &MempoolConfig{SuiteRegistry: unboundAlgSuiteRegistry()}, 1_000_000)
+	raw := h.tx(0, 100_000, 100_000, 1)
+
+	got := h.mp.AddRemoteTxForRelay(raw, h.context())
+
+	if got.Disposition != RelayAdmissionInternal {
+		t.Fatalf("disposition=%v, want INTERNAL (err=%v)", got.Disposition, got.Err)
+	}
+	if got.HasAdmissionContext {
+		t.Fatal("a local backend fault must publish no cache-authorizing context")
+	}
+	if got.AdmissionContext != (PendingOutpointAdmissionContext{}) {
+		t.Fatalf("published context=%+v, want the zero context", got.AdmissionContext)
+	}
+	if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+		t.Fatalf("public admission kind=%s, want %s (unchanged)", kind, TxAdmitRejected)
+	}
+	wantMsg := fmt.Sprintf(
+		"%s: suite_id=0x%02x resolveSuiteVerifierBinding: unsupported alg=%q pubkey_len=%d sig_len=%d",
+		consensus.TX_ERR_SIG_ALG_INVALID,
+		consensus.SUITE_ID_ML_DSA_87,
+		"ML-DSA-87-NOT-LIVE-BOUND",
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+	)
+	if got.Err.Error() != wantMsg {
+		t.Fatalf("public message=%q, want %q (unchanged)", got.Err.Error(), wantMsg)
+	}
+	if h.mp.Len() != 0 {
+		t.Fatalf("mempool len=%d, want 0", h.mp.Len())
+	}
+}
+
+// TestRelayAdmissionCandidateFailuresKeepBaselineClassification pins the three
+// NEGATIVE rows of the matrix: with a healthy backend, invalidity that belongs
+// to the candidate bytes carries no local-fault cause, so each one keeps its
+// baseline STABLE_TERMINAL_REJECT and its cache-authorizing context evidence.
+func TestRelayAdmissionCandidateFailuresKeepBaselineClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		// wantMsg pins the exact public message, so a row can never silently
+		// become a different rejection than the one it is named for.
+		wantMsg string
+		build   func(t *testing.T, h *relayHarness) []byte
+	}{
+		{
+			name:    "cryptographically invalid signature",
+			wantMsg: "TX_ERR_SIG_INVALID: CORE_P2PK signature invalid",
+			build: func(t *testing.T, h *relayHarness) []byte {
+				return corruptFirstWitnessSignature(t, h.tx(0, 100_000, 100_000, 1))
+			},
+		},
+		{
+			name:    "structurally malformed candidate",
+			wantMsg: "TX_ERR_PARSE: unsupported tx version",
+			build: func(t *testing.T, h *relayHarness) []byte {
+				return []byte{0xFF, 0x00, 0x13, 0x37}
+			},
+		},
+		{
+			name:    "candidate selected an unauthorized suite",
+			wantMsg: "TX_ERR_SIG_ALG_INVALID: CORE_P2PK suite not in native spend set",
+			build: func(t *testing.T, h *relayHarness) []byte {
+				return retargetFirstWitnessSuite(t, h.tx(0, 100_000, 100_000, 1), 0x02)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newRelayHarness(t, nil, 1_000_000)
+			got := h.mp.AddRemoteTxForRelay(tc.build(t, h), h.context())
+			if got.Disposition != RelayAdmissionStableTerminalReject {
+				t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT (err=%v)", got.Disposition, got.Err)
+			}
+			if !got.HasAdmissionContext {
+				t.Fatal("a proven candidate-intrinsic rejection keeps its cache-authorizing context")
+			}
+			if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+				t.Fatalf("public admission kind=%s, want %s", kind, TxAdmitRejected)
+			}
+			if got.Err.Error() != tc.wantMsg {
+				t.Fatalf("public message=%q, want %q (unchanged)", got.Err.Error(), tc.wantMsg)
+			}
+		})
+	}
+}
+
+// retargetFirstWitnessSuite rewrites the suite_id the CANDIDATE selected in its
+// first witness item, leaving every other byte the producer signed in place.
+func retargetFirstWitnessSuite(t *testing.T, txBytes []byte, suiteID uint8) []byte {
+	t.Helper()
+	tx, _, _, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("ParseTx before retarget: %v", err)
+	}
+	if len(tx.Witness) == 0 {
+		t.Fatal("expected a first witness item")
+	}
+	tx.Witness[0].SuiteID = suiteID
+	out, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx after retarget: %v", err)
+	}
+	return out
+}


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1146
- GitHub Issue mirror (non-authoritative): #2876

Refs: Q-GO-CRYPTO-BACKEND-LOCAL-FAULT-CAUSE-01

## Summary
Adds TxErrorCause, a closed additive classification of why a consensus error was produced, and attaches its first member to the local OpenSSL backend faults. The public Code, Msg and Error() are unchanged, txerr remains the compatibility constructor, and one cause-aware constructor is added beside it. Relay admission reads the typed cause before the error-code fallback, so a local backend fault publishes INTERNAL with no cache authority while a cryptographically invalid signature, a malformed candidate and a candidate-selected unauthorized suite keep their existing classification.

## Invariant
A process-local OpenSSL consensus-backend initialization, binding-resolution, or verification-runtime fault is distinguishable by type from candidate-invalid transaction bytes at the consensus boundary, so relay admission publishes INTERNAL with no cache authority instead of a stable terminal rejection, while every existing public TxError code, message, accept/reject decision, and validation order remains unchanged.

## Scope
- Changed files: 6
- Surfaces: clients/go/consensus, clients/go/node
- Non-scope: no new public consensus error code, no spec change, no conformance fixture change, no Rust mirror, no relay cache, no change to any accept/reject decision, counter, metric or validation order; the CORE_SIMPLICITY deployment seam and the non-spendable covenant reuse are separate contracts
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks at head 6339ee79: `gofmt -l ./consensus ./node` — PASS; `go build ./...` — PASS; `go vet ./...` — PASS; `go test -count=1 ./...` — PASS; `cd conformance && go test ./...` — PASS; `go test -race -count=1 ./consensus ./node ./node/p2p` — PASS; `go test -count=1 ./consensus -run 'OpenSSL|TxErrorCause|Cause'` — PASS; `go test -count=1 ./consensus -run 'ResolveSuiteVerifierBinding|WrapResolveSuiteVerifierBindingError|VerifySigWithBinding'` — PASS; `go test -count=1 ./node -run '^(TestRelayAdmissionDisposition|TestAddRemoteTxForRelay)'` — PASS; `git diff --check` — PASS
- Falsification receipts: removing the cause at only the consensus producing branch, with no change in package node, flips the node-side row from INTERNAL to STABLE_TERMINAL_REJECT; and a correct-length pubkey and signature of pure garbage yield an invalid verdict with a nil error, so no candidate can select the local-fault cause through content

## Follow-ups / Waivers
- https://linear.app/rubinp/issue/RUB-1145
- https://linear.app/rubinp/issue/RUB-1147
- https://linear.app/rubinp/issue/RUB-1115

### Parity exemption justification
This is a contract-approved Go-only slice (RUB-1146: the Rust mirror is ordered after this Go reference merges and freezes). It adds no public consensus error code and changes no consensus rule, error identity, first-error order, serialization, hash, or shared-fixture surface: the added field is unexported, additive, zero-value-inert, and read only by the Go node's relay-admission classifier, which has no production caller on the transaction relay path yet. Every existing public code, message, accept/reject decision, counter and validation order is unchanged, so no conformance vector or formal claim is implicated.
