### PR TITLE
RUB-1145: distinguish an unanswerable CORE_SIMPLICITY deployment lookup at the consensus seam

### DIFF
--- a/clients/go/consensus/errors.go
+++ b/clients/go/consensus/errors.go
@@ -58,10 +58,12 @@ const (
 )
 
 // TxErrorCause is the closed, source-owned classification of WHY a consensus
-// error was produced, for the consumers that must tell a fault of THIS PROCESS
-// apart from invalidity of the candidate bytes. The public ErrorCode alone
-// cannot express that difference: TX_ERR_PARSE, TX_ERR_SIG_INVALID and
-// TX_ERR_SIG_ALG_INVALID each carry both meanings today.
+// error was produced, for the consumers that must tell an outcome that is NOT
+// stable invalidity of the candidate bytes — a fault of THIS PROCESS, or an
+// admission input this node could not determine — apart from invalidity of the
+// bytes themselves. The public ErrorCode alone cannot express that difference:
+// TX_ERR_PARSE, TX_ERR_SIG_INVALID, TX_ERR_SIG_ALG_INVALID and
+// TX_ERR_COVENANT_TYPE_INVALID each carry both meanings today.
 //
 // It is additive in BEHAVIOR, not in struct shape. Preserved exactly: every
 // public ErrorCode, every message, Error() rendering, every accept/reject
@@ -103,6 +105,35 @@ const (
 	// unsupported or unauthorized suite: that verdict is a property of the
 	// bytes and keeps its baseline classification.
 	TxErrorCauseLocalCryptoBackendFault
+	// TxErrorCauseSimplicityDeploymentUnavailable means the single provider
+	// observation that had to decide CORE_SIMPLICITY deployment state could not
+	// answer at all: the provider returned an I/O error, or it reported the
+	// published set as unobtainable / only partially known (ok=false). The
+	// activation state is UNDETERMINED, not decided against the candidate, so a
+	// consumer must not publish the outcome as a stable terminal rejection of
+	// these bytes and must not let it authorize a cache.
+	TxErrorCauseSimplicityDeploymentUnavailable
+	// TxErrorCauseSimplicityDeploymentEvidenceInvalid means the provider
+	// answered, but its evidence failed its own set integrity: the published set
+	// does not match the published set anchor, or it carries a duplicate
+	// descriptor anchor. The activation state still cannot be computed from a
+	// required admission input, so it is exactly as undetermined as an absent
+	// answer; the separate cause exists so diagnostics can tell corrupted
+	// evidence from ordinary unavailability.
+	TxErrorCauseSimplicityDeploymentEvidenceInvalid
+	// TxErrorCauseSimplicityDeploymentInactiveProvider means a NON-NIL provider
+	// returned a complete anchor-verified set with no descriptor governing this
+	// height. The state is determined and inactive — but determined FROM a
+	// published deployment set, and the same bytes admit unchanged as soon as
+	// that set publishes a governing descriptor. A consumer whose context does
+	// not pin the deployment set must therefore not treat it as stable.
+	TxErrorCauseSimplicityDeploymentInactiveProvider
+	// TxErrorCauseSimplicityDeploymentInactiveFrozen means no deployment
+	// provider is configured at all. No provider I/O happened and no published
+	// set was read, so the verdict rests entirely on constructor-frozen
+	// configuration: it is the ONE deployment outcome that is stable for these
+	// bytes under a context a consumer has already proven.
+	TxErrorCauseSimplicityDeploymentInactiveFrozen
 )
 
 type TxError struct {

--- a/clients/go/consensus/simplicity_covenant.go
+++ b/clients/go/consensus/simplicity_covenant.go
@@ -56,6 +56,48 @@ func parseCoreSimplicityCovenantData(value uint64, covenantData []byte) ([32]byt
 	return programCMR, state, nil
 }
 
+// simplicityDeploymentEvidenceAtHeight is the ONE observation that decides
+// CORE_SIMPLICITY deployment state (§23.2.4). It performs EXACTLY ONE provider
+// read and returns, from that same read, the governing surface (nil = not
+// active), the typed cause a rejecting caller attaches, and the provider's own
+// I/O error. Every consumer of deployment state in this package is expressed
+// over this helper, so the evidence a caller publishes is always evidence about
+// the observation that actually decided the outcome — a second provider call
+// would be a DIFFERENT observation and may never authorize a disposition.
+//
+// Rows, in evaluation order (surface, cause, err); the node owns the mapping
+// from cause to relay disposition:
+//
+//	provider == nil                       (nil, InactiveFrozen,   nil)
+//	provider I/O error                    (nil, Unavailable,      err)
+//	ok == false                           (nil, Unavailable,      nil)
+//	set-anchor mismatch / duplicate       (nil, EvidenceInvalid,  nil)
+//	verified set, no governing descriptor (nil, InactiveProvider, nil)
+//	governing descriptor at height        (surface, Unspecified,  nil)
+//
+// The cause is meaningful ONLY on a non-affirmative row: the active row selects
+// TxErrorCauseUnspecified because it produces no error to carry one.
+func simplicityDeploymentEvidenceAtHeight(chainID [32]byte, height uint64, provider SimplicityDeploymentProvider) (*VerifiedSimplicitySurface, TxErrorCause, error) {
+	if provider == nil {
+		return nil, TxErrorCauseSimplicityDeploymentInactiveFrozen, nil
+	}
+	descriptors, setAnchor, ok, err := provider.PublishedSimplicityDeployments()
+	if err != nil {
+		return nil, TxErrorCauseSimplicityDeploymentUnavailable, err
+	}
+	if !ok {
+		return nil, TxErrorCauseSimplicityDeploymentUnavailable, nil
+	}
+	surface, err := selectGoverningSurface(descriptors, setAnchor, chainID, height, liveArtifactHashes())
+	if err != nil {
+		return nil, TxErrorCauseSimplicityDeploymentEvidenceInvalid, nil
+	}
+	if surface == nil {
+		return nil, TxErrorCauseSimplicityDeploymentInactiveProvider, nil
+	}
+	return surface, TxErrorCauseUnspecified, nil
+}
+
 // SimplicityActiveAtHeight reports whether a verified CORE_SIMPLICITY surface
 // governs at height on the validating chain. STATELESS and fail-closed: a provider
 // I/O error is the ONE distinct disposition (returned as an error → "deployment
@@ -64,31 +106,30 @@ func parseCoreSimplicityCovenantData(value uint64, covenantData []byte) ([32]byt
 // output does NOT distinguish "UNKNOWN" from "not active" (both are inactive here).
 // Not deactivating an ALREADY-active surface on a later UNKNOWN lookup is a
 // STATEFUL live-spend property owned by the RUB-601 call-site, not enforced here.
+//
+// It is the evidence helper with the cause COLLAPSED away: the (bool, error)
+// surface, the returned provider error value and the single provider read are
+// byte-for-byte what this function did before the cause existed.
 func SimplicityActiveAtHeight(chainID [32]byte, height uint64, provider SimplicityDeploymentProvider) (bool, error) {
-	if provider == nil {
-		return false, nil
-	}
-	descriptors, setAnchor, ok, err := provider.PublishedSimplicityDeployments()
+	surface, _, err := simplicityDeploymentEvidenceAtHeight(chainID, height, provider)
 	if err != nil {
 		return false, err
-	}
-	if !ok {
-		return false, nil
-	}
-	surface, err := selectGoverningSurface(descriptors, setAnchor, chainID, height, liveArtifactHashes())
-	if err != nil {
-		return false, nil
 	}
 	return surface != nil, nil
 }
 
+// validateCoreSimplicityDeploymentActive is the §23.2.4 activation gate. The
+// two public messages and the single public code are unchanged and still
+// collapse five distinct deployment states onto two strings; the typed cause
+// carries the state the strings lose, taken from the SAME read that decided the
+// rejection, so no consumer has to match on message text.
 func validateCoreSimplicityDeploymentActive(chainID [32]byte, height uint64, provider SimplicityDeploymentProvider) error {
-	active, err := SimplicityActiveAtHeight(chainID, height, provider)
+	surface, cause, err := simplicityDeploymentEvidenceAtHeight(chainID, height, provider)
 	if err != nil {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY deployment lookup failure")
+		return txerrWithCause(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY deployment lookup failure", cause)
 	}
-	if !active {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY deployment not active")
+	if surface == nil {
+		return txerrWithCause(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY deployment not active", cause)
 	}
 	return nil
 }

--- a/clients/go/consensus/simplicity_deployment_cause_test.go
+++ b/clients/go/consensus/simplicity_deployment_cause_test.go
@@ -1,0 +1,354 @@
+package consensus
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// This file is the CONSENSUS CAUSE CORPUS for the CORE_SIMPLICITY deployment
+// gate: it drives validateCoreSimplicityDeploymentActive and the real
+// ValidateTxCovenantsGenesis entry for every same-read deployment state and
+// pins, per row, the exact public ErrorCode, the exact message, and the typed
+// cause read through errors.As plus Cause().
+//
+// The cause is NOT observable through the node's relay surface (that publishes
+// a rendered string), so the relay corpus can only prove it INDIRECTLY through
+// the disposition it selects. The exact cause per state is proven HERE.
+
+var errCauseCorpusLookup = errors.New("deployment store offline")
+
+// causeRotation is a live RotationProvider whose deployment surface publishes
+// exactly one same-read state, so a row can drive the REAL production entry
+// (ValidateTxCovenantsGenesis -> validateCoreSimplicityGenesisOutput -> the
+// gate) and not only the gate helper.
+type causeRotation struct {
+	DefaultRotationProvider
+	deployments SimplicityDeploymentProvider
+}
+
+func (r causeRotation) PublishedSimplicityDeployments() ([]SimplicityDeploymentDescriptor, [32]byte, bool, error) {
+	return r.deployments.PublishedSimplicityDeployments()
+}
+
+// countingDeploymentProvider answers differently on the FIRST read than on any
+// later one, and counts reads. It is the executable proof that the gate takes
+// exactly ONE observation and classifies from that one.
+type countingDeploymentProvider struct {
+	reads  *int
+	first  stubDeploymentProvider
+	later  stubDeploymentProvider
+	single bool // true => every read answers `first`
+}
+
+func (p countingDeploymentProvider) PublishedSimplicityDeployments() ([]SimplicityDeploymentDescriptor, [32]byte, bool, error) {
+	*p.reads++
+	if p.single || *p.reads == 1 {
+		return p.first.PublishedSimplicityDeployments()
+	}
+	return p.later.PublishedSimplicityDeployments()
+}
+
+// deploymentCauseRow is one row of the required classification matrix: the
+// same-read state, the unchanged public result, the typed cause it must carry,
+// and the exported SimplicityActiveAtHeight baseline for the same state.
+type deploymentCauseRow struct {
+	name           string
+	provider       SimplicityDeploymentProvider // nil => no provider configured
+	wantErr        bool
+	wantMessage    string
+	wantCause      TxErrorCause
+	wantActive     bool
+	wantLookupFail bool
+}
+
+// deploymentCauseMatrix builds every same-read state at the pinned height.
+func deploymentCauseMatrix(t *testing.T, chainID [32]byte, height uint64) []deploymentCauseRow {
+	t.Helper()
+	anchorOf := func(set []SimplicityDeploymentDescriptor) [32]byte {
+		t.Helper()
+		anchor, err := SimplicityDeploymentSetAnchor(chainID, set)
+		if err != nil {
+			t.Fatalf("SimplicityDeploymentSetAnchor: %v", err)
+		}
+		return anchor
+	}
+
+	governing := []SimplicityDeploymentDescriptor{liveValidDescriptor(chainID, height)}
+	governingAnchor := anchorOf(governing)
+
+	// A complete, anchor-valid set whose only descriptor activates above the
+	// candidate height: state known, and known inactive here.
+	future := []SimplicityDeploymentDescriptor{liveValidDescriptor(chainID, height+1)}
+	futureAnchor := anchorOf(future)
+
+	// Self-consistent descriptors paired with a mismatched anchor.
+	mismatched := governingAnchor
+	mismatched[0] ^= 0xFF
+
+	// Duplicate anchors: the set anchor cannot even be computed, so the failure
+	// arrives from SimplicityDeploymentSetAnchor, not from the compare.
+	duplicate := []SimplicityDeploymentDescriptor{governing[0], governing[0]}
+
+	const notActive = "CORE_SIMPLICITY deployment not active"
+	const lookupFailure = "CORE_SIMPLICITY deployment lookup failure"
+
+	// The ok=false row carries a NON-EMPTY partial set on purpose: those
+	// descriptors must not be read as evidence of anything.
+	return []deploymentCauseRow{
+		{name: "no provider configured", provider: nil,
+			wantErr: true, wantMessage: notActive, wantCause: TxErrorCauseSimplicityDeploymentInactiveFrozen},
+		{name: "provider returns an I/O error", provider: stubDeploymentProvider{err: errCauseCorpusLookup},
+			wantErr: true, wantMessage: lookupFailure, wantCause: TxErrorCauseSimplicityDeploymentUnavailable, wantLookupFail: true},
+		{name: "provider returns ok=false with partial descriptors", provider: stubDeploymentProvider{set: governing, setAnchor: governingAnchor, ok: false},
+			wantErr: true, wantMessage: notActive, wantCause: TxErrorCauseSimplicityDeploymentUnavailable},
+		{name: "set anchor mismatch", provider: stubDeploymentProvider{set: governing, setAnchor: mismatched, ok: true},
+			wantErr: true, wantMessage: notActive, wantCause: TxErrorCauseSimplicityDeploymentEvidenceInvalid},
+		{name: "duplicate descriptor anchors", provider: stubDeploymentProvider{set: duplicate, setAnchor: governingAnchor, ok: true},
+			wantErr: true, wantMessage: notActive, wantCause: TxErrorCauseSimplicityDeploymentEvidenceInvalid},
+		{name: "complete anchor-valid set with no governing descriptor", provider: stubDeploymentProvider{set: future, setAnchor: futureAnchor, ok: true},
+			wantErr: true, wantMessage: notActive, wantCause: TxErrorCauseSimplicityDeploymentInactiveProvider},
+		{name: "governing descriptor active", provider: stubDeploymentProvider{set: governing, setAnchor: governingAnchor, ok: true},
+			wantCause: TxErrorCauseUnspecified, wantActive: true},
+	}
+}
+
+// assertDeploymentCause pins the exact public code, the exact message and the
+// typed cause, all read through the public accessors a consumer would use.
+func assertDeploymentCause(t *testing.T, err error, row deploymentCauseRow) {
+	t.Helper()
+	if !row.wantErr {
+		if err != nil {
+			t.Fatalf("active deployment produced %v, want nil", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("want error %q, got nil", row.wantMessage)
+	}
+	var txErr *TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("error %v is not a *TxError", err)
+	}
+	if txErr.Code != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("code=%s, want the unchanged %s", txErr.Code, TX_ERR_COVENANT_TYPE_INVALID)
+	}
+	if txErr.Msg != row.wantMessage {
+		t.Fatalf("msg=%q, want the unchanged %q", txErr.Msg, row.wantMessage)
+	}
+	if want := fmt.Sprintf("%s: %s", TX_ERR_COVENANT_TYPE_INVALID, row.wantMessage); txErr.Error() != want {
+		t.Fatalf("Error()=%q, want the unchanged %q", txErr.Error(), want)
+	}
+	if got := txErr.Cause(); got != row.wantCause {
+		t.Fatalf("Cause()=%d, want %d", got, row.wantCause)
+	}
+}
+
+// TestSimplicityDeploymentCauseMatrix drives the gate directly for every
+// same-read state: the public result is byte-identical to the pre-cause
+// baseline and the typed cause is one-to-one with the state.
+func TestSimplicityDeploymentCauseMatrix(t *testing.T) {
+	chainID := bytes32(0xAB)
+	const height = 10
+	for _, row := range deploymentCauseMatrix(t, chainID, height) {
+		t.Run(row.name, func(t *testing.T) {
+			assertDeploymentCause(t, validateCoreSimplicityDeploymentActive(chainID, height, row.provider), row)
+		})
+	}
+}
+
+// TestSimplicityDeploymentCauseThroughProductionEntry is the dataflow proof:
+// candidate BYTES -> ParseTx -> ValidateTxCovenantsGenesis -> the deployment
+// gate. Each row's trigger is reached from a real CORE_SIMPLICITY creation
+// output, not by calling the gate helper, so the matrix rows are proven over
+// the trigger set production actually produces.
+func TestSimplicityDeploymentCauseThroughProductionEntry(t *testing.T) {
+	chainID := bytes32(0xAB)
+	const height = 10
+	var cmr [32]byte
+	cmr[0] = 0xa5
+	tx := &Tx{Outputs: []TxOutput{{
+		Value:        1,
+		CovenantType: COV_TYPE_CORE_SIMPLICITY,
+		CovenantData: encodeSimplicityCovenantData(cmr, []byte{0x01, 0x02}),
+	}}}
+
+	for _, row := range deploymentCauseMatrix(t, chainID, height) {
+		t.Run(row.name, func(t *testing.T) {
+			var rotation RotationProvider = DefaultRotationProvider{}
+			if row.provider != nil {
+				rotation = causeRotation{deployments: row.provider}
+			}
+			assertDeploymentCause(t, ValidateTxCovenantsGenesis(tx, chainID, height, rotation), row)
+		})
+	}
+}
+
+// TestSimplicityActiveAtHeightBaselineUnchanged is the COMPATIBILITY CORPUS for
+// the exported accessor: nil provider -> (false,nil); provider error -> the
+// provider's OWN error value; ok=false -> (false,nil); invalid set/anchor ->
+// (false,nil); verified inactive -> (false,nil); active -> (true,nil).
+func TestSimplicityActiveAtHeightBaselineUnchanged(t *testing.T) {
+	// Dynamic-type / signature dimension: the exported symbol still has exactly
+	// the baseline function type, so no caller's assignment or call shape moves.
+	var _ func([32]byte, uint64, SimplicityDeploymentProvider) (bool, error) = SimplicityActiveAtHeight
+
+	chainID := bytes32(0xAB)
+	const height = 10
+	for _, row := range deploymentCauseMatrix(t, chainID, height) {
+		t.Run(row.name, func(t *testing.T) {
+			active, err := SimplicityActiveAtHeight(chainID, height, row.provider)
+			if active != row.wantActive {
+				t.Fatalf("active=%v, want %v", active, row.wantActive)
+			}
+			if !row.wantLookupFail {
+				if err != nil {
+					t.Fatalf("err=%v, want nil", err)
+				}
+				return
+			}
+			// The provider's own error value is returned unwrapped and untyped:
+			// the exported surface never converts it into a *TxError.
+			if !errors.Is(err, errCauseCorpusLookup) {
+				t.Fatalf("err=%v, want the provider's own %v", err, errCauseCorpusLookup)
+			}
+			var txErr *TxError
+			if errors.As(err, &txErr) {
+				t.Fatalf("exported accessor converted the provider error into %v", txErr)
+			}
+		})
+	}
+}
+
+// TestSimplicityDeploymentSameReadEvidence proves the classification comes from
+// ONE observation. A provider that fails the FIRST read and would succeed on a
+// hypothetical second must still classify as UNAVAILABLE and must be read
+// exactly once; the mirrored case pins that a set inactive now and active at a
+// greater height is read once per gate call too.
+func TestSimplicityDeploymentSameReadEvidence(t *testing.T) {
+	chainID := bytes32(0xAB)
+	const height = 10
+	governing := []SimplicityDeploymentDescriptor{liveValidDescriptor(chainID, height)}
+	anchor, err := SimplicityDeploymentSetAnchor(chainID, governing)
+	if err != nil {
+		t.Fatalf("SimplicityDeploymentSetAnchor: %v", err)
+	}
+	active := stubDeploymentProvider{set: governing, setAnchor: anchor, ok: true}
+
+	t.Run("a failing first read is never rescued by a later one", func(t *testing.T) {
+		reads := 0
+		provider := countingDeploymentProvider{
+			reads: &reads,
+			first: stubDeploymentProvider{err: errCauseCorpusLookup},
+			later: active,
+		}
+		gotErr := validateCoreSimplicityDeploymentActive(chainID, height, provider)
+		var txErr *TxError
+		if !errors.As(gotErr, &txErr) {
+			t.Fatalf("err=%v, want a *TxError", gotErr)
+		}
+		if txErr.Msg != "CORE_SIMPLICITY deployment lookup failure" {
+			t.Fatalf("msg=%q, want the first read's failure", txErr.Msg)
+		}
+		if txErr.Cause() != TxErrorCauseSimplicityDeploymentUnavailable {
+			t.Fatalf("cause=%d, want UNAVAILABLE from the first read", txErr.Cause())
+		}
+		if reads != 1 {
+			t.Fatalf("provider reads=%d, want exactly 1 (a second read is a different observation)", reads)
+		}
+	})
+
+	t.Run("one read per gate call on the affirmative row", func(t *testing.T) {
+		reads := 0
+		provider := countingDeploymentProvider{reads: &reads, first: active, single: true}
+		if err := validateCoreSimplicityDeploymentActive(chainID, height, provider); err != nil {
+			t.Fatalf("active gate: %v", err)
+		}
+		if reads != 1 {
+			t.Fatalf("provider reads=%d, want exactly 1", reads)
+		}
+	})
+
+	t.Run("the same complete set is inactive below its activation height", func(t *testing.T) {
+		reads := 0
+		provider := countingDeploymentProvider{reads: &reads, first: active, single: true}
+		gotErr := validateCoreSimplicityDeploymentActive(chainID, height-1, provider)
+		var txErr *TxError
+		if !errors.As(gotErr, &txErr) {
+			t.Fatalf("err=%v, want a *TxError", gotErr)
+		}
+		if txErr.Cause() != TxErrorCauseSimplicityDeploymentInactiveProvider {
+			t.Fatalf("cause=%d, want INACTIVE_PROVIDER for a complete verified set", txErr.Cause())
+		}
+		if reads != 1 {
+			t.Fatalf("provider reads=%d, want exactly 1", reads)
+		}
+	})
+}
+
+// TestSimplicityDeploymentCauseSurvivesWrappers pins BOTH directions of the
+// wrapper contract: an outer %w wrapper preserves the cause the producing
+// branch selected, and a wrapper around an UNCAUSED error never invents one.
+func TestSimplicityDeploymentCauseSurvivesWrappers(t *testing.T) {
+	chainID := bytes32(0xAB)
+	inner := validateCoreSimplicityDeploymentActive(chainID, 10, stubDeploymentProvider{err: errCauseCorpusLookup})
+
+	wrapped := fmt.Errorf("CORE_SIMPLICITY deployment lookup failure: %w", inner)
+	var txErr *TxError
+	if !errors.As(wrapped, &txErr) {
+		t.Fatalf("wrapped error lost its *TxError: %v", wrapped)
+	}
+	if txErr.Cause() != TxErrorCauseSimplicityDeploymentUnavailable {
+		t.Fatalf("wrapped cause=%d, want UNAVAILABLE preserved", txErr.Cause())
+	}
+	// Double wrapping is still lossless.
+	if !errors.As(fmt.Errorf("outer: %w", wrapped), &txErr) || txErr.Cause() != TxErrorCauseSimplicityDeploymentUnavailable {
+		t.Fatal("a second wrapper erased the cause")
+	}
+
+	// The uncaused direction: a baseline txerr wrapped the same way stays
+	// UNSPECIFIED, so no wrapper can manufacture a deployment cause.
+	uncaused := txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY deployment not active")
+	if !errors.As(fmt.Errorf("outer: %w", uncaused), &txErr) {
+		t.Fatalf("wrapped baseline error lost its *TxError: %v", uncaused)
+	}
+	if txErr.Cause() != TxErrorCauseUnspecified {
+		t.Fatalf("wrapper invented cause=%d on an uncaused error", txErr.Cause())
+	}
+}
+
+// TestSimplicityDeploymentCauseLegacyValuesAreBaseline pins that the values a
+// caller can build outside this package — the zero TxError, a keyed literal, a
+// value copy — stay panic-free and cause-UNSPECIFIED.
+func TestSimplicityDeploymentCauseLegacyValuesAreBaseline(t *testing.T) {
+	var zero TxError
+	if zero.Cause() != TxErrorCauseUnspecified {
+		t.Fatalf("zero TxError cause=%d", zero.Cause())
+	}
+	var nilErr *TxError
+	if nilErr.Cause() != TxErrorCauseUnspecified || nilErr.Error() != "<nil>" {
+		t.Fatalf("nil *TxError is not baseline: cause=%d error=%q", nilErr.Cause(), nilErr.Error())
+	}
+	legacy := TxError{Code: TX_ERR_COVENANT_TYPE_INVALID, Msg: "CORE_SIMPLICITY deployment not active"}
+	if legacy.Cause() != TxErrorCauseUnspecified {
+		t.Fatalf("keyed legacy literal cause=%d", legacy.Cause())
+	}
+
+	// Value-copy dimension: copying a caused error carries the cause with it and
+	// comparison over the copies still agrees.
+	caused := validateCoreSimplicityDeploymentActive(bytes32(0xAB), 10, nil)
+	var txErr *TxError
+	if !errors.As(caused, &txErr) {
+		t.Fatalf("no *TxError: %v", caused)
+	}
+	copied := *txErr
+	if copied.Cause() != TxErrorCauseSimplicityDeploymentInactiveFrozen {
+		t.Fatalf("value copy cause=%d, want INACTIVE_FROZEN", copied.Cause())
+	}
+	if copied != *txErr {
+		t.Fatal("value copies of the same TxError compare unequal")
+	}
+}
+
+var _ SimplicityDeploymentProvider = causeRotation{}
+var _ SimplicityDeploymentProvider = countingDeploymentProvider{}

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -59,8 +59,14 @@ const (
 	// RelayAdmissionAdmissionSequence is the admission-sequence outcome.
 	RelayAdmissionAdmissionSequence
 	// RelayAdmissionUnavailable covers an absent chain, owner or admission
-	// context, an active canonical transition, a stale expected context, and
-	// retryable runtime unavailability.
+	// context, an active canonical transition, a stale expected context,
+	// retryable runtime unavailability, and a CORE_SIMPLICITY deployment state
+	// this node could not determine from the admission inputs it has — a
+	// consensus error carrying TxErrorCauseSimplicityDeployment{Unavailable,
+	// EvidenceInvalid, InactiveProvider}, whose public code and message say only
+	// "not active" while the deployment set the answer came from is not pinned
+	// by the published context. The frozen no-provider state is NOT one of
+	// these: it reads no set and stays a stable terminal rejection.
 	RelayAdmissionUnavailable
 	// RelayAdmissionInternal covers an impossible invariant, a retained
 	// identity mismatch, accounting corruption, an adapter contract violation,
@@ -542,15 +548,53 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 // selection, reading only typed values the producer set — never Error(), Msg,
 // backend text, or an OpenSSL error string.
 //
-// It reads the typed CAUSE first, because the cause outranks the code: a
-// process-local crypto-backend fault is published under a public code that also
-// carries genuine candidate invalidity (TX_ERR_PARSE for a latched
-// initialization failure, TX_ERR_SIG_INVALID for a verifier that could not
-// decide, TX_ERR_SIG_ALG_INVALID for a binding this node could not resolve from
-// its own configuration). That error is evidence about THIS process, so it is
-// INTERNAL — never a stable terminal rejection, and therefore never
-// cache-authorizing. A candidate that selected an unsupported or unauthorized
-// suite carries no such cause and keeps its baseline classification.
+// It reads the typed CAUSE first, because the cause outranks the code. Two
+// families need it:
+//
+//   - A process-local crypto-backend fault is published under a public code that
+//     also carries genuine candidate invalidity (TX_ERR_PARSE for a latched
+//     initialization failure, TX_ERR_SIG_INVALID for a verifier that could not
+//     decide, TX_ERR_SIG_ALG_INVALID for a binding this node could not resolve
+//     from its own configuration). That error is evidence about THIS process, so
+//     it is INTERNAL — never a stable terminal rejection, and therefore never
+//     cache-authorizing. A candidate that selected an unsupported or
+//     unauthorized suite carries no such cause and keeps its baseline
+//     classification.
+//   - A CORE_SIMPLICITY deployment rejection collapses five distinct states onto
+//     TX_ERR_COVENANT_TYPE_INVALID and two fixed messages. Three of them —
+//     provider unavailability, invalid provider evidence, and inactivity
+//     DECIDED FROM a published deployment set — rest on an admission input the
+//     {StableTip, Generation} context does not pin, so they are UNAVAILABLE and
+//     never cache-authorizing: the same bytes admit unchanged once that set
+//     answers differently. Corrupted evidence is UNAVAILABLE, not INTERNAL,
+//     because the activation state simply cannot be computed from a required
+//     admission input; INTERNAL stays reserved for an impossible internal state,
+//     an unknown non-zero cause, or a producer-result contract violation. A
+//     cause a WRAPPER lost is deliberately NOT in that set: losing a cause is
+//     observationally TxErrorCauseUnspecified, and an unspecified cause
+//     preserves every existing ErrorCode-based mapping. Only the
+//     no-provider-configured state rests entirely on constructor-frozen
+//     configuration and stays a stable terminal rejection, with cache authority
+//     still governed by the caller's own exact-context proof.
+//
+// ORDERING NOTE — structural, and deliberately NOT claimed by any test. Reading
+// the cause before the code switch is a PAIRWISE fact, and on today's inputs the
+// two orders are observationally identical: the closed cause set is
+// {LocalCryptoBackendFault, SimplicityDeploymentUnavailable,
+// SimplicityDeploymentEvidenceInvalid, SimplicityDeploymentInactiveProvider,
+// SimplicityDeploymentInactiveFrozen}, every producer of those causes emits
+// TX_ERR_PARSE, TX_ERR_SIG_INVALID, TX_ERR_SIG_ALG_INVALID or
+// TX_ERR_COVENANT_TYPE_INVALID, and none of those codes is a member of the
+// switch set below. No error can therefore carry a cause AND a switch-set code,
+// so no test can separate the two orders — the order is load-bearing only for a
+// FUTURE producer whose cause and code disagree, and none exists today.
+//
+// The cause switch is closed in BOTH directions. TxErrorCauseUnspecified is an
+// explicit arm that falls through to the code fallback below; every other value
+// this consumer does not enumerate takes the default arm and becomes INTERNAL,
+// so a cause added upstream without its arm here fails closed instead of
+// publishing a cache-authorizing stable terminal rejection. Nothing reaches that
+// arm today — the cause set is closed and every member has an arm.
 //
 // Only then does the CODE fallback apply: an input that is absent, still
 // immature, or not yet unlocked becomes spendable at a later height, so it must
@@ -562,7 +606,19 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 func relayDispositionForInputError(err error, nonDependency RelayAdmissionDisposition) RelayAdmissionDisposition {
 	var txErr *consensus.TxError
 	if errors.As(err, &txErr) {
-		if txErr.Cause() == consensus.TxErrorCauseLocalCryptoBackendFault {
+		switch txErr.Cause() {
+		case consensus.TxErrorCauseUnspecified:
+			// No producing branch selected a cause (or a wrapper lost one):
+			// the code fallback below decides, exactly as it did before.
+		case consensus.TxErrorCauseLocalCryptoBackendFault:
+			return RelayAdmissionInternal
+		case consensus.TxErrorCauseSimplicityDeploymentUnavailable,
+			consensus.TxErrorCauseSimplicityDeploymentEvidenceInvalid,
+			consensus.TxErrorCauseSimplicityDeploymentInactiveProvider:
+			return RelayAdmissionUnavailable
+		case consensus.TxErrorCauseSimplicityDeploymentInactiveFrozen:
+			return RelayAdmissionStableTerminalReject
+		default:
 			return RelayAdmissionInternal
 		}
 		switch txErr.Code {

--- a/clients/go/node/relay_admission_simplicity_cause_test.go
+++ b/clients/go/node/relay_admission_simplicity_cause_test.go
@@ -1,0 +1,318 @@
+package node
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// This file is the RELAY CLASSIFICATION CORPUS for the CORE_SIMPLICITY
+// deployment seam reached through CONSENSUS validation — the path taken when
+// PolicyRejectSimplicityPreActivation is DISABLED, so the deployment gate fires
+// inside CheckTransactionWithOwnedUtxoSetAndValidationContext and the error
+// arrives at relayDispositionForInputError.
+//
+// OBSERVABILITY: the typed consensus cause is NOT published through this
+// surface. AddRemoteTxForRelay exposes the disposition, the identity fields, the
+// context authority and the rendered "CODE: message" text — never a
+// *consensus.TxError. These rows therefore prove the cause only INDIRECTLY,
+// through the disposition it selects. THREE of the four causes share the
+// UNAVAILABLE disposition and are NOT separable from each other here; that
+// distinction is proven in the consensus corpus
+// (consensus/simplicity_deployment_cause_test.go) and a row claiming to
+// separate them at this surface would be a false claim.
+
+// deploymentCauseRotation publishes one CORE_SIMPLICITY deployment state
+// through a live RotationProvider. It is a POINTER receiver so a single mempool
+// can observe a different published set at the SAME tip and generation.
+type deploymentCauseRotation struct {
+	consensus.DefaultRotationProvider
+	descriptors []consensus.SimplicityDeploymentDescriptor
+	anchor      [32]byte
+	ok          bool
+	err         error
+}
+
+func (p *deploymentCauseRotation) PublishedSimplicityDeployments() ([]consensus.SimplicityDeploymentDescriptor, [32]byte, bool, error) {
+	return p.descriptors, p.anchor, p.ok, p.err
+}
+
+// deploymentSetAt builds a complete, anchor-valid published set whose single
+// descriptor activates at activationHeight.
+func deploymentSetAt(t *testing.T, activationHeight uint64) ([]consensus.SimplicityDeploymentDescriptor, [32]byte) {
+	t.Helper()
+	descriptor := consensus.LiveSimplicityDeploymentDescriptor(devnetGenesisChainID)
+	descriptor.ActivationHeight = activationHeight
+	set := []consensus.SimplicityDeploymentDescriptor{descriptor}
+	anchor, err := consensus.SimplicityDeploymentSetAnchor(devnetGenesisChainID, set)
+	if err != nil {
+		t.Fatalf("SimplicityDeploymentSetAnchor: %v", err)
+	}
+	return set, anchor
+}
+
+// consensusSeamHarness builds a mempool whose CORE_SIMPLICITY pre-activation
+// POLICY lane is disabled, so the candidate reaches consensus validation and the
+// deployment gate decides there.
+func consensusSeamHarness(t *testing.T, rotation consensus.RotationProvider) *relayHarness {
+	t.Helper()
+	return newRelayHarness(t, &MempoolConfig{
+		MaxTransactions:                     10,
+		MaxBytes:                            1 << 20,
+		PolicyRejectSimplicityPreActivation: false,
+		RotationProvider:                    rotation,
+	}, 1_000_000)
+}
+
+// candidateIdentity is the canonical identity the producer must publish for the
+// candidate bytes, parsed independently of the mempool.
+func candidateIdentity(t *testing.T, raw []byte) ([32]byte, [32]byte) {
+	t.Helper()
+	_, txid, wtxid, _, err := consensus.ParseTx(raw)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+	return txid, wtxid
+}
+
+// TestRelayAdmissionSimplicityDeploymentCauseDispositions is the FAULT-INJECTION
+// MATRIX over the consensus seam: provider I/O error, ok=false, anchor mismatch,
+// duplicate anchor, a complete verified inactive set, a governing active set, and
+// no provider configured — all through the same real public entry point.
+//
+// Only the no-provider state rests on constructor-frozen configuration and stays
+// a stable terminal rejection carrying context authority. Every provider-decided
+// state is UNAVAILABLE and publishes no context, so none of them can authorize a
+// relay representation cache.
+func TestRelayAdmissionSimplicityDeploymentCauseDispositions(t *testing.T) {
+	governingSet, governingAnchor := deploymentSetAt(t, 0)
+	futureSet, futureAnchor := deploymentSetAt(t, 1<<40)
+	mismatchedAnchor := governingAnchor
+	mismatchedAnchor[0] ^= 0xFF
+
+	const notActive = "TX_ERR_COVENANT_TYPE_INVALID: CORE_SIMPLICITY deployment not active"
+	const lookupFailure = "TX_ERR_COVENANT_TYPE_INVALID: CORE_SIMPLICITY deployment lookup failure"
+
+	duplicateSet := []consensus.SimplicityDeploymentDescriptor{governingSet[0], governingSet[0]}
+
+	cases := []struct {
+		name        string
+		rotation    consensus.RotationProvider
+		want        RelayAdmissionDisposition
+		wantMessage string
+	}{
+		{name: "no provider configured is constructor-frozen and terminal", rotation: nil,
+			want: RelayAdmissionStableTerminalReject, wantMessage: notActive},
+		{name: "provider I/O error cannot determine the state", rotation: &deploymentCauseRotation{err: errors.New("deployment store offline")},
+			want: RelayAdmissionUnavailable, wantMessage: lookupFailure},
+		{name: "ok=false publishes an unobtainable or partial set", rotation: &deploymentCauseRotation{descriptors: governingSet, anchor: governingAnchor, ok: false},
+			want: RelayAdmissionUnavailable, wantMessage: notActive},
+		{name: "a set failing its own anchor is invalid evidence", rotation: &deploymentCauseRotation{descriptors: governingSet, anchor: mismatchedAnchor, ok: true},
+			want: RelayAdmissionUnavailable, wantMessage: notActive},
+		{name: "a duplicate descriptor anchor is invalid evidence", rotation: &deploymentCauseRotation{descriptors: duplicateSet, anchor: governingAnchor, ok: true},
+			want: RelayAdmissionUnavailable, wantMessage: notActive},
+		{name: "a complete verified set with no governing descriptor is still provider-dependent", rotation: &deploymentCauseRotation{descriptors: futureSet, anchor: futureAnchor, ok: true},
+			want: RelayAdmissionUnavailable, wantMessage: notActive},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := consensusSeamHarness(t, tc.rotation)
+			raw := simplicityPolicyCandidate(h)
+			wantTxID, wantWTxID := candidateIdentity(t, raw)
+			expected := h.context()
+			entryTime := *expected
+
+			got := h.mp.AddRemoteTxForRelay(raw, expected)
+
+			if got.Disposition != tc.want {
+				t.Fatalf("disposition=%v, want %v (err=%v)", got.Disposition, tc.want, got.Err)
+			}
+			if kind := admitKind(t, got.Err); kind != TxAdmitRejected {
+				t.Fatalf("kind=%v, want the unchanged TxAdmitRejected", kind)
+			}
+			if got.Err.Error() != tc.wantMessage {
+				t.Fatalf("message=%q, want the unchanged %q", got.Err.Error(), tc.wantMessage)
+			}
+			if got.TxID != wantTxID || got.WTxID != wantWTxID {
+				t.Fatalf("identity=(%x,%x), want (%x,%x)", got.TxID, got.WTxID, wantTxID, wantWTxID)
+			}
+			wantContext := tc.want == RelayAdmissionStableTerminalReject
+			if got.HasAdmissionContext != wantContext {
+				t.Fatalf("HasAdmissionContext=%v, want %v", got.HasAdmissionContext, wantContext)
+			}
+			if wantContext && got.AdmissionContext != entryTime {
+				t.Fatalf("published context=%+v, want the entry-time %+v", got.AdmissionContext, entryTime)
+			}
+			if !wantContext && got.AdmissionContext != (PendingOutpointAdmissionContext{}) {
+				t.Fatalf("a provider-decided outcome published cache authority: %+v", got.AdmissionContext)
+			}
+			if h.mp.Len() != 0 {
+				t.Fatalf("a rejected candidate became resident: len=%d", h.mp.Len())
+			}
+			// The legacy wrapper observes the byte-identical failure: the
+			// classification is published beside the error, never inside it.
+			legacy := h.mp.AddRemoteTx(raw)
+			if legacy == nil || legacy.Error() != tc.wantMessage || admitKind(t, legacy) != TxAdmitRejected {
+				t.Fatalf("legacy AddRemoteTx err=%v, want the identical %q", legacy, tc.wantMessage)
+			}
+		})
+	}
+}
+
+// TestRelayAdmissionSimplicityDeploymentActiveContinues is the matrix's
+// affirmative row at this surface: with a governing descriptor the deployment
+// gate produces no error at all, so validation CONTINUES and the candidate is
+// judged on its own bytes. The published outcome must therefore be neither
+// deployment message.
+func TestRelayAdmissionSimplicityDeploymentActiveContinues(t *testing.T) {
+	governingSet, governingAnchor := deploymentSetAt(t, 0)
+	h := consensusSeamHarness(t, &deploymentCauseRotation{descriptors: governingSet, anchor: governingAnchor, ok: true})
+	raw := simplicityPolicyCandidate(h)
+
+	got := h.mp.AddRemoteTxForRelay(raw, h.context())
+	if got.Err == nil {
+		t.Fatal("the unsigned candidate was admitted")
+	}
+	// The candidate is unsigned, so validation runs PAST the deployment gate and
+	// stops at the witness it does not carry.
+	if got.Err.Error() != witnessUnderflow {
+		t.Fatalf("message=%q, want validation to continue to %q", got.Err.Error(), witnessUnderflow)
+	}
+	// Its own bytes are stably invalid against this exact context.
+	if got.Disposition != RelayAdmissionStableTerminalReject {
+		t.Fatalf("disposition=%v, want STABLE_TERMINAL_REJECT for candidate invalidity (err=%v)", got.Disposition, got.Err)
+	}
+}
+
+// witnessUnderflow is the first error the unsigned corpus candidate meets ONCE
+// the CORE_SIMPLICITY deployment gate stops deciding: proof that the gate is out
+// of the way, not that the candidate is well formed.
+const witnessUnderflow = "TX_ERR_PARSE: witness underflow"
+
+// TestRelayAdmissionSimplicityDeploymentSetIsNotPinnedByContext is the hostile
+// row that motivates the whole classification: at the SAME stable tip and the
+// SAME generation, a non-nil provider publishing a DIFFERENT complete set flips
+// the outcome for byte-identical candidate bytes. The admission context compares
+// equal across both calls, which is exactly why a provider-decided outcome may
+// never publish that context as cache authority.
+func TestRelayAdmissionSimplicityDeploymentSetIsNotPinnedByContext(t *testing.T) {
+	futureSet, futureAnchor := deploymentSetAt(t, 1<<40)
+	rotation := &deploymentCauseRotation{descriptors: futureSet, anchor: futureAnchor, ok: true}
+	h := consensusSeamHarness(t, rotation)
+	raw := simplicityPolicyCandidate(h)
+
+	before := *h.context()
+	first := h.mp.AddRemoteTxForRelay(raw, &before)
+	if first.Disposition != RelayAdmissionUnavailable {
+		t.Fatalf("first disposition=%v, want UNAVAILABLE (err=%v)", first.Disposition, first.Err)
+	}
+
+	// Same mempool, same tip, same generation — only the published set moves.
+	governingSet, governingAnchor := deploymentSetAt(t, 0)
+	rotation.descriptors = governingSet
+	rotation.anchor = governingAnchor
+
+	after := *h.context()
+	if after != before {
+		t.Fatalf("admission context moved between calls: %+v vs %+v", after, before)
+	}
+	second := h.mp.AddRemoteTxForRelay(raw, &after)
+	if second.Err == nil || second.Err.Error() != witnessUnderflow {
+		t.Fatalf("second outcome=%v, want the gate to stop deciding and validation to reach %q", second.Err, witnessUnderflow)
+	}
+	if first.HasAdmissionContext {
+		t.Fatal("a provider-decided outcome published cache authority")
+	}
+}
+
+// TestRelayDispositionForInputErrorCauseArms pins the consumer arm itself,
+// including the property the end-to-end rows cannot reach: an UNSPECIFIED cause
+// preserves every existing ErrorCode-based mapping, in both the dependency and
+// the non-dependency direction.
+//
+// An UNKNOWN non-zero cause is deliberately NOT a row: the cause field is
+// unexported and only a consensus producer can set one, so package node cannot
+// construct that value and no test here may claim to have exercised it. Its
+// behavior is structural instead — the cause switch's default arm returns
+// INTERNAL, so a cause added upstream without an arm here fails closed rather
+// than reaching the caller's nonDependency verdict. An UNSPECIFIED cause is a
+// separate explicit arm and does keep the ErrorCode fallback; that half IS
+// pinned by the uncaused rows below.
+//
+// It does NOT claim to prove the cause-before-code ORDER: no error can carry a
+// deployment cause AND one of the switch-set codes, so the two orders are
+// observationally identical here (see the ordering note on
+// relayDispositionForInputError).
+func TestRelayDispositionForInputErrorCauseArms(t *testing.T) {
+	chainID := devnetGenesisChainID
+	// Real producer errors, not literals: the cause field is unexported, so
+	// package node can only obtain a caused error from the consensus producer.
+	futureDescriptor := consensus.LiveSimplicityDeploymentDescriptor(chainID)
+	futureDescriptor.ActivationHeight = 1 << 40
+	futureSet := []consensus.SimplicityDeploymentDescriptor{futureDescriptor}
+	futureAnchor, err := consensus.SimplicityDeploymentSetAnchor(chainID, futureSet)
+	if err != nil {
+		t.Fatalf("SimplicityDeploymentSetAnchor: %v", err)
+	}
+
+	simplicityOutputTx := func() *consensus.Tx {
+		return &consensus.Tx{Outputs: []consensus.TxOutput{{
+			Value:        1,
+			CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY,
+			CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x53}, nil),
+		}}}
+	}
+	causedBy := func(rotation consensus.RotationProvider) error {
+		e := consensus.ValidateTxCovenantsGenesis(simplicityOutputTx(), chainID, 10, rotation)
+		if e == nil {
+			t.Fatal("expected a deployment rejection")
+		}
+		return e
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want RelayAdmissionDisposition
+	}{
+		{"frozen no-provider stays terminal", causedBy(nil), RelayAdmissionStableTerminalReject},
+		{"provider I/O error is unavailable",
+			causedBy(&deploymentCauseRotation{err: errors.New("offline")}), RelayAdmissionUnavailable},
+		{"ok=false is unavailable",
+			causedBy(&deploymentCauseRotation{descriptors: futureSet, anchor: futureAnchor, ok: false}), RelayAdmissionUnavailable},
+		{"provider-dependent inactivity is unavailable",
+			causedBy(&deploymentCauseRotation{descriptors: futureSet, anchor: futureAnchor, ok: true}), RelayAdmissionUnavailable},
+		// UNSPECIFIED preserves the baseline mappings in both directions.
+		{"uncaused missing utxo keeps the dependency mapping",
+			&consensus.TxError{Code: consensus.TX_ERR_MISSING_UTXO, Msg: "missing utxo"}, RelayAdmissionMissingDependency},
+		{"uncaused covenant rejection keeps the caller's non-dependency verdict",
+			&consensus.TxError{Code: consensus.TX_ERR_COVENANT_TYPE_INVALID, Msg: "CORE_SIMPLICITY deployment not active"},
+			RelayAdmissionStableTerminalReject},
+		{"a non-TxError keeps the caller's non-dependency verdict",
+			errors.New("plain"), RelayAdmissionStableTerminalReject},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relayDispositionForInputError(tc.err, RelayAdmissionStableTerminalReject); got != tc.want {
+				t.Fatalf("disposition=%v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// The OTHER caller — the policy input-snapshot seam — passes
+	// RelayAdmissionInternal as its non-dependency verdict, and an uncaused error
+	// must still receive exactly that.
+	if got := relayDispositionForInputError(errors.New("nil utxo set"), RelayAdmissionInternal); got != RelayAdmissionInternal {
+		t.Fatalf("snapshot-seam non-dependency=%v, want INTERNAL", got)
+	}
+	// The frozen arm selects its disposition rather than deferring to the
+	// caller's. That difference is NOT production-reachable — policyInputSnapshot
+	// produces only errors.New and a cause-free TX_ERR_MISSING_UTXO, so no
+	// deployment cause reaches the snapshot seam — but it is the code's behavior
+	// and is pinned here rather than left for a reader to infer.
+	if got := relayDispositionForInputError(causedBy(nil), RelayAdmissionInternal); got != RelayAdmissionStableTerminalReject {
+		t.Fatalf("frozen cause under an INTERNAL caller=%v, want STABLE_TERMINAL_REJECT", got)
+	}
+}


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1145
- GitHub Issue mirror (non-authoritative): #2875

Refs: Q-GO-SIMPLICITY-DEPLOYMENT-UNAVAILABLE-CODE-01

## Summary
The CORE_SIMPLICITY deployment gate collapsed five distinct states onto one public code and two fixed messages, so relay admission could not tell a deployment state this node was unable to determine from stable invalidity of the candidate bytes, and published the former as a cache-authorizing stable terminal rejection. One unexported evidence helper now performs the single provider read and returns the governing surface together with a typed cause from that same read; both the exported SimplicityActiveAtHeight and validateCoreSimplicityDeploymentActive are expressed over it. Relay admission maps provider unavailability, invalid provider evidence and provider-decided inactivity to UNAVAILABLE with no cache authority, and keeps constructor-frozen no-provider inactivity a stable terminal rejection. No shipped rotation provider implements the deployment interface, so this changes no outcome on the default node wiring; it closes the path ahead of the live descriptor set being wired.

## Invariant
The single provider observation that decides CORE_SIMPLICITY deployment state also emits one source-owned typed cause, allowing Go relay admission to distinguish provider unavailability, invalid deployment evidence, provider-dependent inactivity, and constructor-frozen no-provider inactivity without message matching, while every public TxError code, message, accept/reject decision, exported SimplicityActiveAtHeight behavior, and validation order remains unchanged.

## Scope
- Changed files: 5
- Surfaces: clients/go/consensus, clients/go/node
- Non-scope: no relay cache, no new public consensus error code, no deployment-policy change, no Rust mirror, no deployment-set context expansion, no change to the frozen rejectCoreSimplicityPreActivation lane or its tuple shape
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks at head f8fc44ce: `gofmt -l ./consensus ./node` — PASS; `go build ./...` — PASS; `go vet ./consensus ./node` — PASS; `go test -count=1 -timeout 30m ./consensus` — PASS; `go test -count=1 -timeout 30m ./node` — PASS; `go test -race -count=1 -timeout 40m ./consensus` — PASS; `go test -race -count=1 -timeout 40m ./node` — PASS; `cd conformance && go build ./... && go vet ./... && go test -count=1 ./...` — PASS; `go test -count=1 -run 'TestSimplicityDeployment|TestSimplicityActiveAtHeight|Deployment' ./consensus` — PASS; `go test -count=1 -run 'TestRelayAdmissionSimplicity|TestRelayDispositionForInputErrorCauseArms' ./node` — PASS; `python3 tools/check_consensus_openssl_isolation.py <changed files>` — PASS; `python3 tools/check_pre_commit_hygiene.py` — PASS
- Falsification receipts: removing the cause from the ok=false branch flips two consensus rows and two relay rows to the pre-change classification; and with the fail-closed default arm removed, a forged unknown cause publishes STABLE_TERMINAL_REJECT instead of INTERNAL

## Follow-ups / Waivers
- https://linear.app/rubinp/issue/RUB-1115
- https://linear.app/rubinp/issue/RUB-1147
- https://linear.app/rubinp/issue/RUB-1124

### Parity exemption justification
This is a contract-approved Go-only slice (RUB-1145: the Rust mirror is ordered after the Go reference merges and freezes, and is tracked by RUB-1124). It adds no public consensus error code and changes no consensus rule, error identity, first-error order, serialization, hash, or shared-fixture surface: every deployment rejection keeps TX_ERR_COVENANT_TYPE_INVALID and its exact existing message, the added cause constants are unexported in effect (the field carrying them is unexported and absent from every public view), and the exported SimplicityActiveAtHeight surface is byte-identical for all six states including the unwrapped provider error. The only behavior that moves is the Go node's relay-admission disposition, which has no Rust counterpart on this surface. No conformance vector or formal claim is implicated.
