### PR TITLE
RUB-698: refresh the formal section-hash pin for the tx wire version rule

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -5,7 +5,7 @@
   "package_maturity": "experimental_pending_reverification",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "be9f22ec2ed0c6234adb0fc106a486a0eb32c309cc4a1100171724f72180ab29",
+  "spec_section_hashes_sha3_256": "39b23c5adf0423f3a5dec347697c0d7e591ad6b92822b1d433737eab30968d71",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "source_rebind": {


### PR DESCRIPTION
## Issue
- Linear: RUB-698
- GitHub Issue mirror (non-authoritative): #698

Refs: U2-TX-WIRE-VERSION-SPEC-01

## Summary
`tools/check_section_hashes.py` lines 173-190 is a governance merge gate: it hashes the whole `spec/SECTION_HASHES.json` byte-for-byte with LF normalization and requires `rubin-formal/proof_coverage.json` to carry that digest. rubin-spec#325 pins the transaction wire version normatively and regenerates the `transaction_wire` section hash, which moves the whole-file digest and leaves this pin stale.

This refreshes the pin, one key, nothing else.

**Merge order:** spec CI checks out `rubin-protocol` at its default branch, so this must land before rubin-spec#325 can go green.

## Invariant
The formal disposition's `spec_section_hashes_sha3_256` equals the LF-normalized sha3-256 of the current `spec/SECTION_HASHES.json`.

## Scope
- Changed files: 1
- Surfaces: `rubin-formal/proof_coverage.json`, key `spec_section_hashes_sha3_256` only
- Non-scope: every other key in that file, all Lean sources, `refinement_bridge.json`, coverage rows, claim level, package maturity, and the spec repository
- Consensus rules unchanged: yes
- SECTION_HASHES.json unchanged: yes — that file lives in the spec repository and is changed by rubin-spec#325, not here
- Wire format unchanged: yes

## Validation
- Dynamic checks: `git diff --check` — PASS; `python3 -c "import json; json.load(open('rubin-formal/proof_coverage.json'))"` — PASS

## Follow-ups / Waivers
- Not run: `tools/check_section_hashes.py` end to end. It needs the spec and protocol co-checkout layout CI builds; the digest was derived locally with the checker's own `sha3_256_hex_lf_normalized_bytes` and equals the value spec CI computed when it failed on the stale pin.
- No theorem, coverage row, bridge row or claim changes, so the formal claim/coverage/risk/bridge checkers are outside this diff's blast radius and were not executed.
