### PR TITLE
RUB-1149: refresh the formal section-hash pin

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -5,7 +5,7 @@
   "package_maturity": "experimental_pending_reverification",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "39b23c5adf0423f3a5dec347697c0d7e591ad6b92822b1d433737eab30968d71",
+  "spec_section_hashes_sha3_256": "4f02a7fd352ed168b82218006da467a58e3f158fb8fcb28dab5a757b4a8e7b74",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "source_rebind": {


### PR DESCRIPTION
## Issue
- Linear: RUB-1149
- GitHub Issue mirror (non-authoritative): #1149

Refs: Q-SPEC-TX-WIRE-VERSION-COMPLETENESS-01

## Summary
`tools/check_section_hashes.py` lines 173-190 hash the whole `spec/SECTION_HASHES.json` and require `rubin-formal/proof_coverage.json` to carry that digest. RUB-1149 regenerates three section keys in the spec repository — `consensus_constants`, `transaction_wire` and `consensus_error_codes` — which moves the whole-file digest.

The previous value was written by RUB-698 and was correct for that intermediate state; this supersedes it.

**Merge order:** spec CI checks out `rubin-protocol` at its default branch, so this must land before the spec pull request can go green.

## Invariant
The formal disposition's `spec_section_hashes_sha3_256` equals the LF-normalized sha3-256 of the current `spec/SECTION_HASHES.json`.

## Scope
- Changed files: 1
- Surfaces: `rubin-formal/proof_coverage.json`, key `spec_section_hashes_sha3_256` only
- Non-scope: every other key in that file, all Lean sources, `refinement_bridge.json`, coverage rows, claim level, package maturity, and the spec repository
- Consensus rules unchanged: yes
- SECTION_HASHES.json unchanged: yes — that file lives in the spec repository and changes in the sibling pull request
- Wire format unchanged: yes

## Validation
- Dynamic checks: `git diff --check` — PASS; `python3 -c "import json; json.load(open('rubin-formal/proof_coverage.json'))"` — PASS

## Follow-ups / Waivers
- Not run: `tools/check_section_hashes.py` end to end. It needs the spec and protocol co-checkout layout CI builds; the digest was derived with the checker's own `sha3_256_hex_lf_normalized_bytes` and reproduced independently three times.
- No theorem, coverage row, bridge row or claim changes, so the formal claim, coverage, risk and bridge checkers are outside this diff's blast radius and were not executed.
