### PR TITLE
[Q-XCLIENT-UNDO-PAYLOAD-MEMORY-01] Bound undo payload validation and existing-record memory

### DIFF
--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -566,19 +566,11 @@ func (bs *BlockStore) checkExistingUndo(path string, blockHash [32]byte, undo *B
 	if err != nil {
 		return err
 	}
-	existing, err := unmarshalUndoEnvelope(blockHash, existingRaw)
+	existing, err := unmarshalUndoEnvelopeDisk(blockHash, existingRaw)
 	if err != nil {
 		return err
 	}
-	existingPayload, err := marshalBlockUndoV2(existing)
-	if err != nil {
-		return err
-	}
-	wantedPayload, err := marshalBlockUndoV2(undo)
-	if err != nil {
-		return err
-	}
-	if !bytes.Equal(existingPayload, wantedPayload) {
+	if !validatedBlockUndoMatches(existing, undo) {
 		return errExistingContentDiffers(path)
 	}
 	return nil

--- a/clients/go/node/undo.go
+++ b/clients/go/node/undo.go
@@ -60,6 +60,12 @@ type blockUndoDiskRaw struct {
 	Txs                      []txUndoDisk    `json:"txs"`
 }
 
+type validatedBlockUndoDisk struct {
+	blockHeight              uint64
+	previousAlreadyGenerated consensus.Uint128
+	txs                      []txUndoDisk
+}
+
 type txUndoDisk struct {
 	Spent []spentUndoDisk `json:"spent"`
 }
@@ -326,39 +332,67 @@ func marshalBlockUndoV2(undo *BlockUndo) ([]byte, error) {
 // unmarshalBlockUndo checks shape, supply, and scalar domains before conversion,
 // preserving error priority. Rust twin: `unmarshal_block_undo`.
 func unmarshalBlockUndo(raw []byte) (*BlockUndo, error) {
-	disk, err := decodeBlockUndoDiskV1(raw)
+	disk, err := decodeValidatedBlockUndoV1(raw)
 	if err != nil {
 		return nil, err
 	}
-	if err := checkUndoDiskCanonicalFields(disk); err != nil {
-		return nil, err
-	}
-	canonical, err := json.Marshal(disk)
-	if err != nil {
-		return nil, fmt.Errorf("encode undo: %w", err)
-	}
-	if !bytes.Equal(canonical, raw) {
-		return nil, errUndoPayloadNotCanonical
-	}
-	return blockUndoFromDisk(disk)
+	return blockUndoFromValidatedDisk(disk)
 }
 
 func unmarshalBlockUndoV2(raw []byte) (*BlockUndo, error) {
+	disk, err := decodeValidatedBlockUndoV2(raw)
+	if err != nil {
+		return nil, err
+	}
+	return blockUndoFromValidatedDisk(disk)
+}
+
+func decodeValidatedBlockUndoV1(raw []byte) (validatedBlockUndoDisk, error) {
+	disk, err := decodeBlockUndoDiskV1(raw)
+	if err != nil {
+		return validatedBlockUndoDisk{}, err
+	}
+	if err := checkUndoDiskCanonicalFields(disk); err != nil {
+		return validatedBlockUndoDisk{}, err
+	}
+	if ok, err := canonicalBlockUndoMatches(raw, disk); err != nil {
+		return validatedBlockUndoDisk{}, err
+	} else if !ok {
+		return validatedBlockUndoDisk{}, errUndoPayloadNotCanonical
+	}
+	return validatedBlockUndoDisk{
+		blockHeight:              disk.BlockHeight,
+		previousAlreadyGenerated: consensus.Uint128FromU64(disk.PreviousAlreadyGenerated),
+		txs:                      disk.Txs,
+	}, nil
+}
+
+func decodeValidatedBlockUndoV2(raw []byte) (validatedBlockUndoDisk, error) {
 	disk, supply, err := decodeBlockUndoDiskV2(raw)
 	if err != nil {
-		return nil, err
+		return validatedBlockUndoDisk{}, err
 	}
 	if err := checkUndoDiskCanonicalFieldsV2(disk); err != nil {
-		return nil, err
+		return validatedBlockUndoDisk{}, err
 	}
+	if ok, err := canonicalBlockUndoMatches(raw, disk); err != nil {
+		return validatedBlockUndoDisk{}, err
+	} else if !ok {
+		return validatedBlockUndoDisk{}, errUndoPayloadNotCanonical
+	}
+	return validatedBlockUndoDisk{
+		blockHeight:              disk.BlockHeight,
+		previousAlreadyGenerated: supply,
+		txs:                      disk.Txs,
+	}, nil
+}
+
+func canonicalBlockUndoMatches(raw []byte, disk any) (bool, error) {
 	canonical, err := json.Marshal(disk)
 	if err != nil {
-		return nil, fmt.Errorf("encode undo: %w", err)
+		return false, fmt.Errorf("encode undo: %w", err)
 	}
-	if !bytes.Equal(canonical, raw) {
-		return nil, errUndoPayloadNotCanonical
-	}
-	return blockUndoFromParts(disk.BlockHeight, supply, disk.Txs)
+	return bytes.Equal(canonical, raw), nil
 }
 
 func decodeBlockUndoDiskV1(raw []byte) (blockUndoDisk, error) {
@@ -708,6 +742,49 @@ func blockUndoFromDisk(disk blockUndoDisk) (*BlockUndo, error) {
 	return blockUndoFromParts(disk.BlockHeight, consensus.Uint128FromU64(disk.PreviousAlreadyGenerated), disk.Txs)
 }
 
+func blockUndoFromValidatedDisk(disk validatedBlockUndoDisk) (*BlockUndo, error) {
+	return blockUndoFromParts(disk.blockHeight, disk.previousAlreadyGenerated, disk.txs)
+}
+
+func validatedBlockUndoMatches(disk validatedBlockUndoDisk, candidate *BlockUndo) bool {
+	if candidate == nil || disk.blockHeight != candidate.BlockHeight ||
+		disk.previousAlreadyGenerated != candidate.PreviousAlreadyGenerated || len(disk.txs) != len(candidate.Txs) {
+		return false
+	}
+	for txIndex, diskTx := range disk.txs {
+		candidateSpent := candidate.Txs[txIndex].Spent
+		if len(diskTx.Spent) != len(candidateSpent) {
+			return false
+		}
+		for spentIndex, diskSpent := range diskTx.Spent {
+			candidateSpent := candidateSpent[spentIndex]
+			if diskSpent.Vout != candidateSpent.Outpoint.Vout ||
+				diskSpent.Value != candidateSpent.Entry.Value ||
+				diskSpent.CovenantType != candidateSpent.Entry.CovenantType ||
+				diskSpent.CreationHeight != candidateSpent.Entry.CreationHeight ||
+				diskSpent.CreatedByCoinbase != candidateSpent.Entry.CreatedByCoinbase ||
+				!lowercaseHexMatchesBytes(diskSpent.Txid, candidateSpent.Outpoint.Txid[:]) ||
+				!lowercaseHexMatchesBytes(diskSpent.CovenantData, candidateSpent.Entry.CovenantData) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func lowercaseHexMatchesBytes(value string, bytes []byte) bool {
+	if len(value) != len(bytes)*2 {
+		return false
+	}
+	const hexDigits = "0123456789abcdef"
+	for index, valueByte := range bytes {
+		if value[index*2] != hexDigits[valueByte>>4] || value[index*2+1] != hexDigits[valueByte&0x0f] {
+			return false
+		}
+	}
+	return true
+}
+
 func blockUndoFromParts(blockHeight uint64, previousAlreadyGenerated consensus.Uint128, diskTxs []txUndoDisk) (*BlockUndo, error) {
 	txs := make([]TxUndo, 0, len(diskTxs))
 	for txIndex, txUndo := range diskTxs {
@@ -918,7 +995,7 @@ func marshalUndoEnvelopeVersion(version uint32, blockHash [32]byte, undo *BlockU
 // (which subsumes shape, version-literal, duplicate, unknown, missing, null,
 // ordering, whitespace and trailing-token rejection), hash equality against the
 // hash the CALLER asked for, canonical base64, decoded payload bound, checksum —
-// and only then the payload decode and BlockUndo conversion.
+// and only then the payload decode into the validated disk tree.
 //
 // MEMORY: everything before the checksum decision allocates exactly ONE
 // payload-sized buffer — the base64 output, which is unavoidable because the
@@ -928,33 +1005,41 @@ func marshalUndoEnvelopeVersion(version uint32, blockHash [32]byte, undo *BlockU
 // decision is the caller's buffer plus 3/4 of it, ~1.75x. The payload decode
 // past the checksum is far more expensive (~5.7x cumulative, dominated by the
 // per-spent-entry structs) and runs only once the bytes are proven intact.
-func unmarshalUndoEnvelope(blockHash [32]byte, raw []byte) (*BlockUndo, error) {
+func unmarshalUndoEnvelopeDisk(blockHash [32]byte, raw []byte) (validatedBlockUndoDisk, error) {
 	if int64(len(raw)) > int64(undoFileMaxBytes) {
-		return nil, fmt.Errorf("%w: undo record is %d bytes, class bound %d",
+		return validatedBlockUndoDisk{}, fmt.Errorf("%w: undo record is %d bytes, class bound %d",
 			ErrUndoIntegrity, len(raw), int64(undoFileMaxBytes))
 	}
 	version, hashHex, payloadB64, checksumHex, err := splitUndoEnvelopeVersioned(raw)
 	if err != nil {
-		return nil, err
+		return validatedBlockUndoDisk{}, err
 	}
 	if string(hashHex) != hex.EncodeToString(blockHash[:]) {
-		return nil, errUndoBlockHashMismatch
+		return validatedBlockUndoDisk{}, errUndoBlockHashMismatch
 	}
 	payload, err := decodeCanonicalBase64(payloadB64)
 	if err != nil {
-		return nil, err
+		return validatedBlockUndoDisk{}, err
 	}
 	if int64(len(payload)) > int64(undoPayloadMaxBytes) {
-		return nil, fmt.Errorf("%w: decoded payload is %d bytes, class bound %d",
+		return validatedBlockUndoDisk{}, fmt.Errorf("%w: decoded payload is %d bytes, class bound %d",
 			ErrUndoIntegrity, len(payload), int64(undoPayloadMaxBytes))
 	}
 	if err := validateUndoEnvelopeChecksum(version, blockHash, payload, checksumHex); err != nil {
-		return nil, err
+		return validatedBlockUndoDisk{}, err
 	}
 	if version == undoEnvelopeVersionV1 {
-		return unmarshalBlockUndo(payload)
+		return decodeValidatedBlockUndoV1(payload)
 	}
-	return unmarshalBlockUndoV2(payload)
+	return decodeValidatedBlockUndoV2(payload)
+}
+
+func unmarshalUndoEnvelope(blockHash [32]byte, raw []byte) (*BlockUndo, error) {
+	disk, err := unmarshalUndoEnvelopeDisk(blockHash, raw)
+	if err != nil {
+		return nil, err
+	}
+	return blockUndoFromValidatedDisk(disk)
 }
 
 func validateUndoEnvelopeChecksum(version uint32, blockHash [32]byte, payload, checksumHex []byte) error {

--- a/clients/go/node/undo.go
+++ b/clients/go/node/undo.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -747,29 +748,28 @@ func blockUndoFromValidatedDisk(disk validatedBlockUndoDisk) (*BlockUndo, error)
 }
 
 func validatedBlockUndoMatches(disk validatedBlockUndoDisk, candidate *BlockUndo) bool {
-	if candidate == nil || disk.blockHeight != candidate.BlockHeight ||
-		disk.previousAlreadyGenerated != candidate.PreviousAlreadyGenerated || len(disk.txs) != len(candidate.Txs) {
-		return false
-	}
-	for txIndex, diskTx := range disk.txs {
-		candidateSpent := candidate.Txs[txIndex].Spent
-		if len(diskTx.Spent) != len(candidateSpent) {
-			return false
-		}
-		for spentIndex, diskSpent := range diskTx.Spent {
-			candidateSpent := candidateSpent[spentIndex]
-			if diskSpent.Vout != candidateSpent.Outpoint.Vout ||
-				diskSpent.Value != candidateSpent.Entry.Value ||
-				diskSpent.CovenantType != candidateSpent.Entry.CovenantType ||
-				diskSpent.CreationHeight != candidateSpent.Entry.CreationHeight ||
-				diskSpent.CreatedByCoinbase != candidateSpent.Entry.CreatedByCoinbase ||
-				!lowercaseHexMatchesBytes(diskSpent.Txid, candidateSpent.Outpoint.Txid[:]) ||
-				!lowercaseHexMatchesBytes(diskSpent.CovenantData, candidateSpent.Entry.CovenantData) {
-				return false
-			}
-		}
-	}
-	return true
+	return validatedBlockUndoHeaderMatches(disk, candidate) &&
+		slices.EqualFunc(disk.txs, candidate.Txs, validatedTxUndoMatches)
+}
+
+func validatedBlockUndoHeaderMatches(disk validatedBlockUndoDisk, candidate *BlockUndo) bool {
+	return candidate != nil &&
+		disk.blockHeight == candidate.BlockHeight &&
+		disk.previousAlreadyGenerated == candidate.PreviousAlreadyGenerated
+}
+
+func validatedTxUndoMatches(disk txUndoDisk, candidate TxUndo) bool {
+	return slices.EqualFunc(disk.Spent, candidate.Spent, validatedSpentUndoMatches)
+}
+
+func validatedSpentUndoMatches(disk spentUndoDisk, candidate SpentUndo) bool {
+	return disk.Vout == candidate.Outpoint.Vout &&
+		disk.Value == candidate.Entry.Value &&
+		disk.CovenantType == candidate.Entry.CovenantType &&
+		disk.CreationHeight == candidate.Entry.CreationHeight &&
+		disk.CreatedByCoinbase == candidate.Entry.CreatedByCoinbase &&
+		lowercaseHexMatchesBytes(disk.Txid, candidate.Outpoint.Txid[:]) &&
+		lowercaseHexMatchesBytes(disk.CovenantData, candidate.Entry.CovenantData)
 }
 
 func lowercaseHexMatchesBytes(value string, bytes []byte) bool {

--- a/clients/go/node/undo_payload_allocation_test.go
+++ b/clients/go/node/undo_payload_allocation_test.go
@@ -1,0 +1,114 @@
+package node
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+const undoPayloadAllocationRows = 1 << 17
+
+func undoPayloadAllocationCorpus(t *testing.T, hash [32]byte, version uint32, covenantBytes int) (*BlockUndo, []byte, []byte) {
+	txs := []TxUndo{{Spent: []SpentUndo{{
+		Outpoint: consensus.Outpoint{Txid: [32]byte{1}, Vout: 2},
+		Entry: consensus.UtxoEntry{
+			Value: 3, CovenantType: 4, CovenantData: bytes.Repeat([]byte{0xab}, covenantBytes),
+			CreationHeight: 5, CreatedByCoinbase: true,
+		},
+	}}}}
+	undo := &BlockUndo{BlockHeight: 0, PreviousAlreadyGenerated: consensus.Uint128FromU64(7), Txs: txs}
+	marshalPayload := marshalBlockUndoV2
+	if version == undoEnvelopeVersionV1 {
+		marshalPayload = marshalBlockUndo
+	}
+	payload, payloadErr := marshalPayload(undo)
+	raw, rawErr := marshalUndoEnvelopeVersion(version, hash, undo)
+	if payloadErr != nil || rawErr != nil || len(undo.Txs[0].Spent[0].Entry.CovenantData) != covenantBytes {
+		t.Fatalf("build undo corpus: payload=%v envelope=%v bytes=%d", payloadErr, rawErr, len(payload))
+	}
+	return undo, payload, raw
+}
+func undoPayloadWrite(t *testing.T, path string, raw []byte) {
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+func undoPayloadAllocationDelta(t *testing.T, warm, run func() error) uint64 {
+	procs, gc := runtime.GOMAXPROCS(1), debug.SetGCPercent(-1)
+	defer func() { debug.SetGCPercent(gc); runtime.GOMAXPROCS(procs) }()
+	if err := warm(); err != nil {
+		t.Fatalf("warm public path: %v", err)
+	}
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if err := run(); err != nil {
+		t.Fatalf("measure public path: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+func TestUndoPayloadAllocationPublicPaths(t *testing.T) {
+	type sample struct {
+		undo         *BlockUndo
+		payload, raw []byte
+		store        *BlockStore
+		path         string
+		get, put     uint64
+	}
+	for _, version := range []uint32{undoEnvelopeVersionV1, undoEnvelopeVersion} {
+		hash := mustHeaderHash(t, testHeaderBytes(byte(version), 1))
+		var samples [2]sample
+		for i, size := range [2]int{8 << 20, 12 << 20} {
+			undo, payload, raw := undoPayloadAllocationCorpus(t, hash, version, size)
+			store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
+			path := filepath.Join(store.undoDir, hex.EncodeToString(hash[:])+".json")
+			undoPayloadWrite(t, path, raw)
+			samples[i] = sample{undo, payload, raw, store, path, 0, 0}
+		}
+		for i := range samples {
+			s := &samples[i]
+			if got, err := s.store.GetUndo(hash); err != nil || !reflect.DeepEqual(got, s.undo) {
+				t.Fatalf("v%d GetUndo: equal=%t err=%v", version, reflect.DeepEqual(got, s.undo), err)
+			}
+			s.get = undoPayloadAllocationDelta(t, func() error { _, err := s.store.GetUndo(hash); return err }, func() error { _, err := s.store.GetUndo(hash); return err })
+			s.put = undoPayloadAllocationDelta(t, func() error { return s.store.PutUndo(hash, s.undo) }, func() error { return s.store.PutUndo(hash, s.undo) })
+			if after, err := os.ReadFile(s.path); err != nil || !bytes.Equal(after, s.raw) {
+				t.Fatalf("v%d existing bytes changed: %v", version, err)
+			}
+		}
+		small, large := samples[0], samples[1]
+		deltaR, deltaP := len(large.raw)-len(small.raw), len(large.payload)-len(small.payload)
+		deltaL := 2 * (len(large.undo.Txs[0].Spent[0].Entry.CovenantData) - len(small.undo.Txs[0].Spent[0].Entry.CovenantData))
+		if large.get < small.get || large.get-small.get > uint64(deltaR+4*deltaP+deltaL+1<<20) {
+			t.Fatalf("v%d GetUndo paired allocation exceeded bound", version)
+		}
+		if large.put < small.put || large.put-small.put > uint64(4*deltaR+7*deltaP+1<<20) {
+			t.Fatalf("v%d PutUndo paired allocation exceeded bound", version)
+		}
+	}
+	rows := `{"spent":[]}` + strings.Repeat(`,{"spent":[]}`, undoPayloadAllocationRows-1)
+	for _, tc := range []struct {
+		version      uint32
+		supply, want string
+	}{
+		{undoEnvelopeVersionV1, `"0"`, "decode undo: envelope v1 previous_already_generated must be a nonnegative JSON integer through u64"},
+		{undoEnvelopeVersion, `0`, "decode undo: envelope v2 previous_already_generated must be a canonical unsigned decimal string within u128"},
+	} {
+		payload := []byte(`{"block_height":0,"previous_already_generated":` + tc.supply + `,"txs":[` + rows + `]}`)
+		hash, store := [32]byte{byte(tc.version)}, mustCreateBlockStore(t, filepath.Join(t.TempDir(), "invalid"))
+		raw := marshalUndoEnvelopePayload(t, tc.version, hash, payload)
+		undoPayloadWrite(t, filepath.Join(store.undoDir, hex.EncodeToString(hash[:])+".json"), raw)
+		if _, err := store.GetUndo(hash); err == nil || err.Error() != tc.want {
+			t.Fatalf("v%d invalid supply: %v", tc.version, err)
+		}
+	}
+}

--- a/clients/go/node/undo_payload_allocation_test.go
+++ b/clients/go/node/undo_payload_allocation_test.go
@@ -36,11 +36,7 @@ func undoPayloadAllocationCorpus(t *testing.T, hash [32]byte, version uint32, co
 	}
 	return undo, payload, raw
 }
-func undoPayloadWrite(t *testing.T, path string, raw []byte) {
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
-		t.Fatal(err)
-	}
-}
+
 func undoPayloadAllocationDelta(t *testing.T, warm, run func() error) uint64 {
 	procs, gc := runtime.GOMAXPROCS(1), debug.SetGCPercent(-1)
 	defer func() { debug.SetGCPercent(gc); runtime.GOMAXPROCS(procs) }()
@@ -71,7 +67,7 @@ func TestUndoPayloadAllocationPublicPaths(t *testing.T) {
 			undo, payload, raw := undoPayloadAllocationCorpus(t, hash, version, size)
 			store := mustCreateBlockStore(t, filepath.Join(t.TempDir(), "blockstore"))
 			path := filepath.Join(store.undoDir, hex.EncodeToString(hash[:])+".json")
-			undoPayloadWrite(t, path, raw)
+			mustWriteFile(t, path, raw)
 			samples[i] = sample{undo, payload, raw, store, path, 0, 0}
 		}
 		for i := range samples {
@@ -94,6 +90,26 @@ func TestUndoPayloadAllocationPublicPaths(t *testing.T) {
 		if large.put < small.put || large.put-small.put > uint64(4*deltaR+7*deltaP+1<<20) {
 			t.Fatalf("v%d PutUndo paired allocation exceeded bound", version)
 		}
+		for _, mutation := range []struct {
+			name  string
+			apply func(*BlockUndo)
+		}{
+			{"outer_txs_length", func(undo *BlockUndo) { undo.Txs = append(undo.Txs, TxUndo{}) }},
+			{"inner_spent_length", func(undo *BlockUndo) { undo.Txs[0].Spent = append(undo.Txs[0].Spent, SpentUndo{}) }},
+			{"nested_entry_value", func(undo *BlockUndo) { undo.Txs[0].Spent[0].Entry.Value++ }},
+		} {
+			candidate, err := small.store.GetUndo(hash)
+			if err != nil {
+				t.Fatalf("v%d %s setup: %v", version, mutation.name, err)
+			}
+			mutation.apply(candidate)
+			if err := small.store.PutUndo(hash, candidate); err == nil || !strings.Contains(err.Error(), "file already exists with different content") {
+				t.Fatalf("v%d %s PutUndo: %v", version, mutation.name, err)
+			}
+			if after, err := os.ReadFile(small.path); err != nil || !bytes.Equal(after, small.raw) {
+				t.Fatalf("v%d %s changed existing bytes: %v", version, mutation.name, err)
+			}
+		}
 	}
 	rows := `{"spent":[]}` + strings.Repeat(`,{"spent":[]}`, undoPayloadAllocationRows-1)
 	for _, tc := range []struct {
@@ -106,7 +122,7 @@ func TestUndoPayloadAllocationPublicPaths(t *testing.T) {
 		payload := []byte(`{"block_height":0,"previous_already_generated":` + tc.supply + `,"txs":[` + rows + `]}`)
 		hash, store := [32]byte{byte(tc.version)}, mustCreateBlockStore(t, filepath.Join(t.TempDir(), "invalid"))
 		raw := marshalUndoEnvelopePayload(t, tc.version, hash, payload)
-		undoPayloadWrite(t, filepath.Join(store.undoDir, hex.EncodeToString(hash[:])+".json"), raw)
+		mustWriteFile(t, filepath.Join(store.undoDir, hex.EncodeToString(hash[:])+".json"), raw)
 		if _, err := store.GetUndo(hash); err == nil || err.Error() != tc.want {
 			t.Fatalf("v%d invalid supply: %v", tc.version, err)
 		}

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -34,7 +34,7 @@ name = "runtime_baseline"
 harness = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)', 'cfg(tarpaulin_include)'] }
 
 [package.metadata.cargo-machete]
 # RUB-225 uses platform-specific signal dependencies behind cfg gates. Host-only

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -18,7 +18,10 @@ use crate::store_envelope::{
     marshal_store_envelope, open_store_envelope, STORE_ENVELOPE_BLOCK_INDEX,
     STORE_GENESIS_ANCHOR_ERR,
 };
-use crate::undo::{marshal_undo_envelope, unmarshal_undo_envelope, BlockUndo};
+use crate::undo::{
+    marshal_undo_envelope, unmarshal_undo_envelope, unmarshal_undo_envelope_disk,
+    validated_block_undo_matches, BlockUndo,
+};
 use std::ffi::OsStr;
 
 pub const BLOCK_STORE_DIR_NAME: &str = "blockstore";
@@ -825,8 +828,8 @@ impl BlockStore {
                 )
             })?;
         let validate_existing = |existing_raw: &[u8]| {
-            let existing = unmarshal_undo_envelope(block_hash_bytes, existing_raw)?;
-            if existing != *undo {
+            let existing = unmarshal_undo_envelope_disk(block_hash_bytes, existing_raw)?;
+            if !validated_block_undo_matches(&existing, undo) {
                 return Err(existing_content_differs(&path));
             }
             Ok(())

--- a/clients/rust/crates/rubin-node/src/undo.rs
+++ b/clients/rust/crates/rubin-node/src/undo.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fmt;
+use std::io::{self, Write};
 
 use rubin_consensus::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT};
 use rubin_consensus::{block_hash, parse_block_bytes, Outpoint, UtxoEntry};
@@ -263,7 +264,7 @@ pub(crate) struct BlockUndoDisk {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct BlockUndoDiskV2 {
+pub(crate) struct BlockUndoDiskV2 {
     block_height: u64,
     #[serde(serialize_with = "rubin_consensus::uint128_json::serialize")]
     previous_already_generated: u128,
@@ -277,43 +278,6 @@ struct BlockUndoDiskRaw {
     #[serde(rename = "previous_already_generated")]
     _previous_already_generated: IgnoredAny,
     txs: Vec<TxUndoDisk>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct BlockUndoPayloadShape {
-    #[serde(rename = "block_height")]
-    _block_height: IgnoredAny,
-    #[serde(rename = "previous_already_generated")]
-    _previous_already_generated: IgnoredAny,
-    #[serde(rename = "txs")]
-    _txs: Vec<TxUndoPayloadShape>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct TxUndoPayloadShape {
-    #[serde(rename = "spent")]
-    _spent: Vec<SpentUndoPayloadShape>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct SpentUndoPayloadShape {
-    #[serde(rename = "txid")]
-    _txid: IgnoredAny,
-    #[serde(rename = "vout")]
-    _vout: IgnoredAny,
-    #[serde(rename = "value")]
-    _value: IgnoredAny,
-    #[serde(rename = "covenant_type")]
-    _covenant_type: IgnoredAny,
-    #[serde(rename = "covenant_data")]
-    _covenant_data: IgnoredAny,
-    #[serde(rename = "creation_height")]
-    _creation_height: IgnoredAny,
-    #[serde(rename = "created_by_coinbase")]
-    _created_by_coinbase: IgnoredAny,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,6 +301,11 @@ enum UndoSupplyToken {
     Unsigned(u64),
     String { value: String, unescaped: bool },
     Other,
+}
+
+pub(crate) enum ValidatedBlockUndo {
+    V1(BlockUndoDisk),
+    V2(BlockUndoDiskV2),
 }
 
 struct UndoSupplyTokenVisitor;
@@ -433,46 +402,111 @@ const UNDO_INVALID_V2_SUPPLY: &str =
     "decode undo: envelope v2 previous_already_generated must be a canonical unsigned decimal string within u128";
 const UNDO_PAYLOAD_NOT_CANONICAL: &str = "decode undo: payload is not the canonical encoding";
 
-struct UndoSupplyProbe(UndoSupplyToken);
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlockUndoPayloadShape {
+    #[serde(rename = "block_height")]
+    _block_height: IgnoredAny,
+    #[serde(rename = "previous_already_generated")]
+    _previous_already_generated: IgnoredAny,
+    #[serde(rename = "txs")]
+    _txs: TxUndoPayloadSequence,
+}
 
-struct UndoSupplyProbeVisitor;
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TxUndoPayloadShape {
+    #[serde(rename = "spent")]
+    _spent: SpentUndoPayloadSequence,
+}
 
-impl<'de> Visitor<'de> for UndoSupplyProbeVisitor {
-    type Value = UndoSupplyProbe;
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SpentUndoPayloadShape {
+    #[serde(rename = "txid")]
+    _txid: IgnoredAny,
+    #[serde(rename = "vout")]
+    _vout: IgnoredAny,
+    #[serde(rename = "value")]
+    _value: IgnoredAny,
+    #[serde(rename = "covenant_type")]
+    _covenant_type: IgnoredAny,
+    #[serde(rename = "covenant_data")]
+    _covenant_data: IgnoredAny,
+    #[serde(rename = "creation_height")]
+    _creation_height: IgnoredAny,
+    #[serde(rename = "created_by_coinbase")]
+    _created_by_coinbase: IgnoredAny,
+}
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("an undo payload JSON object")
-    }
+struct TxUndoPayloadSequence;
 
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut supply = None;
-        while let Some(key) = map.next_key::<String>()? {
-            if key == "previous_already_generated" {
-                if supply.is_some() {
-                    return Err(serde::de::Error::duplicate_field(
-                        "previous_already_generated",
-                    ));
-                }
-                supply = Some(map.next_value::<UndoSupplyToken>()?);
-            } else {
-                map.next_value::<IgnoredAny>()?;
+impl<'de> Deserialize<'de> for TxUndoPayloadSequence {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SequenceVisitor;
+        impl<'de> Visitor<'de> for SequenceVisitor {
+            type Value = TxUndoPayloadSequence;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON array")
+            }
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                while seq.next_element::<TxUndoPayloadShape>()?.is_some() {}
+                Ok(TxUndoPayloadSequence)
             }
         }
-        supply
-            .map(UndoSupplyProbe)
-            .ok_or_else(|| serde::de::Error::missing_field("previous_already_generated"))
+        deserializer.deserialize_seq(SequenceVisitor)
     }
 }
 
+struct SpentUndoPayloadSequence;
+
+impl<'de> Deserialize<'de> for SpentUndoPayloadSequence {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SequenceVisitor;
+        impl<'de> Visitor<'de> for SequenceVisitor {
+            type Value = SpentUndoPayloadSequence;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON array")
+            }
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                while seq.next_element::<SpentUndoPayloadShape>()?.is_some() {}
+                Ok(SpentUndoPayloadSequence)
+            }
+        }
+        deserializer.deserialize_seq(SequenceVisitor)
+    }
+}
+
+struct UndoSupplyProbe(UndoSupplyToken);
+
 impl<'de> Deserialize<'de> for UndoSupplyProbe {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_map(UndoSupplyProbeVisitor)
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ProbeVisitor;
+        impl<'de> Visitor<'de> for ProbeVisitor {
+            type Value = UndoSupplyProbe;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an undo payload JSON object")
+            }
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut supply = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    if key == "previous_already_generated" {
+                        if supply.is_some() {
+                            return Err(serde::de::Error::duplicate_field(
+                                "previous_already_generated",
+                            ));
+                        }
+                        supply = Some(map.next_value::<UndoSupplyToken>()?);
+                    } else {
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                supply
+                    .map(UndoSupplyProbe)
+                    .ok_or_else(|| serde::de::Error::missing_field("previous_already_generated"))
+            }
+        }
+        deserializer.deserialize_map(ProbeVisitor)
     }
 }
 
@@ -482,10 +516,9 @@ fn decode_block_undo_supply(
 ) -> Result<UndoSupplyToken, String> {
     serde_json::from_slice::<BlockUndoPayloadShape>(raw)
         .map_err(|_| UNDO_PAYLOAD_NOT_CANONICAL.to_string())?;
-    let supply = serde_json::from_slice::<UndoSupplyProbe>(raw)
-        .map_err(|_| invalid_supply_error.to_string())?
-        .0;
-    Ok(supply)
+    serde_json::from_slice::<UndoSupplyProbe>(raw)
+        .map(|probe| probe.0)
+        .map_err(|_| invalid_supply_error.to_string())
 }
 
 fn decode_block_undo_typed(raw: &[u8]) -> Result<BlockUndoDiskRaw, String> {
@@ -507,18 +540,43 @@ fn marshal_block_undo_v2(undo: &BlockUndo) -> Result<Vec<u8>, String> {
     serde_json::to_vec(&disk).map_err(|e| format!("encode undo: {e}"))
 }
 
-/// Strictly decode a canonical payload. A field/container-shape pass runs before
-/// the version-specific supply token is interpreted, so an unknown, duplicate,
-/// missing or invalid container at any nesting level wins over a simultaneous
-/// supply defect and parser wording never escapes. Remaining scalar conversion
-/// follows supply classification, then the typed disk value is re-encoded to pin
-/// field order and whitespace byte-for-byte.
-///
-/// The whole decision happens BEFORE `block_undo_from_disk`, so a checksum-valid
-/// but non-canonical payload is refused without allocating the runtime spent
-/// entries. The contract orders strict rejection ahead of `BlockUndo` conversion;
-/// converting first satisfied that only by accident. Go twin: `unmarshalBlockUndo`.
-pub fn unmarshal_block_undo(raw: &[u8]) -> Result<BlockUndo, String> {
+struct CanonicalPayloadSink<'a> {
+    expected: &'a [u8],
+    offset: usize,
+    mismatch: bool,
+}
+
+impl Write for CanonicalPayloadSink<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.offset > self.expected.len() {
+            self.mismatch = true;
+        } else {
+            let expected = &self.expected[self.offset..];
+            let compared = expected.len().min(buf.len());
+            if expected[..compared] != buf[..compared] || compared != buf.len() {
+                self.mismatch = true;
+            }
+        }
+        self.offset = self.offset.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn canonical_payload_matches<T: Serialize>(value: &T, raw: &[u8]) -> Result<bool, String> {
+    let mut sink = CanonicalPayloadSink {
+        expected: raw,
+        offset: 0,
+        mismatch: false,
+    };
+    serde_json::to_writer(&mut sink, value).map_err(|e| format!("encode undo: {e}"))?;
+    Ok(!sink.mismatch && sink.offset == raw.len())
+}
+
+fn decode_validated_block_undo_v1(raw: &[u8]) -> Result<ValidatedBlockUndo, String> {
     let supply = decode_block_undo_supply(raw, UNDO_INVALID_V1_SUPPLY)?;
     let previous_already_generated = match supply {
         UndoSupplyToken::Unsigned(value) => value,
@@ -531,13 +589,13 @@ pub fn unmarshal_block_undo(raw: &[u8]) -> Result<BlockUndo, String> {
         txs: decoded.txs,
     };
     check_undo_txs_canonical_fields(&disk.txs)?;
-    if serde_json::to_vec(&disk).map_err(|e| format!("encode undo: {e}"))? != raw {
+    if !canonical_payload_matches(&disk, raw)? {
         return Err(UNDO_PAYLOAD_NOT_CANONICAL.into());
     }
-    block_undo_from_disk(disk)
+    Ok(ValidatedBlockUndo::V1(disk))
 }
 
-fn unmarshal_block_undo_v2(raw: &[u8]) -> Result<BlockUndo, String> {
+fn decode_validated_block_undo_v2(raw: &[u8]) -> Result<ValidatedBlockUndo, String> {
     let supply = decode_block_undo_supply(raw, UNDO_INVALID_V2_SUPPLY)?;
     let previous_already_generated = match supply {
         UndoSupplyToken::String {
@@ -554,10 +612,21 @@ fn unmarshal_block_undo_v2(raw: &[u8]) -> Result<BlockUndo, String> {
         txs: decoded.txs,
     };
     check_undo_txs_canonical_fields(&disk.txs)?;
-    if serde_json::to_vec(&disk).map_err(|e| format!("encode undo: {e}"))? != raw {
+    if !canonical_payload_matches(&disk, raw)? {
         return Err(UNDO_PAYLOAD_NOT_CANONICAL.into());
     }
-    block_undo_from_parts(disk.block_height, previous_already_generated, disk.txs)
+    Ok(ValidatedBlockUndo::V2(disk))
+}
+
+/// Compatibility payload entry point. Envelope paths retain only validated disk
+/// data until this conversion starts.
+pub fn unmarshal_block_undo(raw: &[u8]) -> Result<BlockUndo, String> {
+    block_undo_from_validated(decode_validated_block_undo_v1(raw)?)
+}
+
+#[cfg(test)]
+fn unmarshal_block_undo_v2(raw: &[u8]) -> Result<BlockUndo, String> {
+    block_undo_from_validated(decode_validated_block_undo_v2(raw)?)
 }
 
 /// Covers the property the disk-level byte comparison is blind to, allocating
@@ -628,6 +697,15 @@ fn block_undo_to_disk_v2(undo: &BlockUndo) -> BlockUndoDiskV2 {
     }
 }
 
+fn block_undo_from_validated(disk: ValidatedBlockUndo) -> Result<BlockUndo, String> {
+    match disk {
+        ValidatedBlockUndo::V1(disk) => block_undo_from_disk(disk),
+        ValidatedBlockUndo::V2(disk) => {
+            block_undo_from_parts(disk.block_height, disk.previous_already_generated, disk.txs)
+        }
+    }
+}
+
 fn block_undo_from_disk(disk: BlockUndoDisk) -> Result<BlockUndo, String> {
     block_undo_from_parts(
         disk.block_height,
@@ -669,6 +747,71 @@ fn block_undo_from_parts(
         previous_already_generated,
         txs,
     })
+}
+
+pub(crate) fn validated_block_undo_matches(
+    disk: &ValidatedBlockUndo,
+    candidate: &BlockUndo,
+) -> bool {
+    match disk {
+        ValidatedBlockUndo::V1(disk) => {
+            candidate.block_height == disk.block_height
+                && candidate.previous_already_generated
+                    == u128::from(disk.previous_already_generated)
+                && disk_txs_match_candidate(&disk.txs, &candidate.txs)
+        }
+        ValidatedBlockUndo::V2(disk) => {
+            candidate.block_height == disk.block_height
+                && candidate.previous_already_generated == disk.previous_already_generated
+                && disk_txs_match_candidate(&disk.txs, &candidate.txs)
+        }
+    }
+}
+
+fn disk_txs_match_candidate(disk_txs: &[TxUndoDisk], candidate_txs: &[TxUndo]) -> bool {
+    if disk_txs.len() != candidate_txs.len() {
+        return false;
+    }
+    for (disk_tx, candidate_tx) in disk_txs.iter().zip(candidate_txs) {
+        if disk_tx.spent.len() != candidate_tx.spent.len() {
+            return false;
+        }
+        for (disk_spent, candidate_spent) in disk_tx.spent.iter().zip(&candidate_tx.spent) {
+            if disk_spent.vout != candidate_spent.outpoint.vout
+                || disk_spent.value != candidate_spent.entry.value
+                || disk_spent.covenant_type != candidate_spent.entry.covenant_type
+                || disk_spent.creation_height != candidate_spent.entry.creation_height
+                || disk_spent.created_by_coinbase != candidate_spent.entry.created_by_coinbase
+                || !lowercase_hex_matches_bytes(&disk_spent.txid, &candidate_spent.outpoint.txid)
+                || !lowercase_hex_matches_bytes(
+                    &disk_spent.covenant_data,
+                    &candidate_spent.entry.covenant_data,
+                )
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn lowercase_hex_matches_bytes(value: &str, bytes: &[u8]) -> bool {
+    let Some(length) = bytes.len().checked_mul(2) else {
+        return false;
+    };
+    if value.len() != length {
+        return false;
+    }
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let encoded = value.as_bytes();
+    for (index, byte) in bytes.iter().enumerate() {
+        if encoded[index * 2] != HEX[usize::from(byte >> 4)]
+            || encoded[index * 2 + 1] != HEX[usize::from(byte & 0x0f)]
+        {
+            return false;
+        }
+    }
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -891,7 +1034,7 @@ fn marshal_undo_envelope_version(
 /// version-literal, duplicate, unknown, missing, null, ordering, whitespace and
 /// trailing-token rejection), hash equality against the hash the CALLER asked
 /// for, canonical base64, decoded payload bound, checksum — and only then the
-/// payload decode and `BlockUndo` conversion.
+/// payload decode into a validated disk tree.
 ///
 /// MEMORY: everything before the checksum decision allocates exactly ONE
 /// payload-sized buffer — the base64 output, which is unavoidable because the
@@ -902,7 +1045,10 @@ fn marshal_undo_envelope_version(
 /// in 7 allocations on an 11.9 MB envelope and this path is structurally
 /// identical. The payload decode past the checksum is far more expensive and
 /// runs only once the bytes are proven intact.
-pub fn unmarshal_undo_envelope(block_hash: [u8; 32], raw: &[u8]) -> Result<BlockUndo, String> {
+pub(crate) fn unmarshal_undo_envelope_disk(
+    block_hash: [u8; 32],
+    raw: &[u8],
+) -> Result<ValidatedBlockUndo, String> {
     if raw.len() as u64 > UNDO_FILE_MAX_BYTES {
         return Err(format!(
             "{UNDO_INTEGRITY_PREFIX}: undo record is {} bytes, class bound {UNDO_FILE_MAX_BYTES}",
@@ -933,10 +1079,14 @@ pub fn unmarshal_undo_envelope(block_hash: [u8; 32], raw: &[u8]) -> Result<Block
         return Err(UNDO_CHECKSUM_MISMATCH_ERR.to_string());
     }
     if version == UNDO_ENVELOPE_VERSION_V1 {
-        unmarshal_block_undo(&payload)
+        decode_validated_block_undo_v1(&payload)
     } else {
-        unmarshal_block_undo_v2(&payload)
+        decode_validated_block_undo_v2(&payload)
     }
+}
+
+pub fn unmarshal_undo_envelope(block_hash: [u8; 32], raw: &[u8]) -> Result<BlockUndo, String> {
+    block_undo_from_validated(unmarshal_undo_envelope_disk(block_hash, raw)?)
 }
 
 /// Validates the canonical layout and returns sub-slices of `raw`. The body

--- a/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
+++ b/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
@@ -1,0 +1,246 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+
+use rubin_consensus::{block_hash, Outpoint, UtxoEntry, BLOCK_HEADER_BYTES};
+use rubin_node::undo::{BlockUndo, SpentUndo, TxUndo};
+use rubin_node::{devnet_genesis_block_bytes, BlockStore};
+use sha3::{Digest, Sha3_256};
+
+const ROWS: usize = 1 << 17;
+const MARGIN: isize = 1 << 20;
+const TREE_BYTES: usize = std::mem::size_of::<TxUndo>() + std::mem::size_of::<SpentUndo>();
+const INVALID_SUPPLY: [&str; 2] = [
+    "decode undo: envelope v1 previous_already_generated must be a nonnegative JSON integer through u64",
+    "decode undo: envelope v2 previous_already_generated must be a canonical unsigned decimal string within u128",
+];
+struct CountingAllocator;
+static ARMED: AtomicBool = AtomicBool::new(false);
+static LIVE: AtomicIsize = AtomicIsize::new(0);
+static PEAK: AtomicIsize = AtomicIsize::new(0);
+fn signed(size: usize) -> isize {
+    isize::try_from(size).unwrap_or(isize::MAX)
+}
+
+fn adjust(delta: isize) {
+    if !ARMED.load(Ordering::Relaxed) {
+        return;
+    }
+    let old = LIVE.fetch_add(delta, Ordering::Relaxed);
+    let live = old.saturating_add(delta);
+    PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+// SAFETY: every pointer/layout is passed to System unchanged; bookkeeping is atomic only.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        adjust(signed(l.size()));
+        System.alloc(l)
+    }
+    unsafe fn alloc_zeroed(&self, l: Layout) -> *mut u8 {
+        adjust(signed(l.size()));
+        System.alloc_zeroed(l)
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        adjust(-signed(l.size()));
+        System.dealloc(p, l)
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
+        adjust(signed(n).saturating_sub(signed(l.size())));
+        System.realloc(p, l, n)
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAllocator = CountingAllocator;
+
+fn measure<T>(run: impl FnOnce() -> T) -> (T, isize) {
+    LIVE.store(0, Ordering::Relaxed);
+    PEAK.store(0, Ordering::Relaxed);
+    ARMED.store(true, Ordering::Relaxed);
+    let value = run();
+    ARMED.store(false, Ordering::Relaxed);
+    (value, PEAK.load(Ordering::Relaxed))
+}
+
+fn base64(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for c in bytes.chunks(3) {
+        let word = u32::from(c[0]) << 16
+            | u32::from(*c.get(1).unwrap_or(&0)) << 8
+            | u32::from(*c.get(2).unwrap_or(&0));
+        for (shift, needed) in [(18, 0), (12, 0), (6, 1), (0, 2)] {
+            out.push(if c.len() > needed {
+                TABLE[((word >> shift) & 63) as usize] as char
+            } else {
+                '='
+            });
+        }
+    }
+    out
+}
+
+fn envelope(version: u32, hash: [u8; 32], payload: &[u8]) -> Vec<u8> {
+    let mut digest = Sha3_256::new();
+    let domain: &[u8] = if version == 1 {
+        b"RUBIN_BLOCK_UNDO_V1"
+    } else {
+        b"RUBIN_BLOCK_UNDO_V2"
+    };
+    digest.update(domain);
+    digest.update(hash);
+    digest.update((payload.len() as u64).to_be_bytes());
+    digest.update(payload);
+    (format!(
+        r#"{{"version":{version},"block_hash":"{}","payload_b64":"{}","checksum":"{}"}}"#,
+        hex::encode(hash),
+        base64(payload),
+        hex::encode(digest.finalize())
+    ) + "\n")
+        .into_bytes()
+}
+
+fn payload(supply: &str, data: &[u8]) -> Vec<u8> {
+    let spent = format!(
+        r#"{{"txid":"{}","vout":2,"value":3,"covenant_type":4,"covenant_data":"{}","creation_height":5,"created_by_coinbase":true}}"#,
+        hex::encode([1u8; 32]),
+        hex::encode(data)
+    );
+    format!(
+        r#"{{"block_height":0,"previous_already_generated":{supply},"txs":[{{"spent":[{spent}]}}]}}"#
+    )
+    .into_bytes()
+}
+
+fn invalid_payload(supply: &str) -> Vec<u8> {
+    let rows = "{\"spent\":[]}".to_owned() + &",{\"spent\":[]}".repeat(ROWS - 1);
+    format!(r#"{{"block_height":0,"previous_already_generated":{supply},"txs":[{rows}]}}"#)
+        .into_bytes()
+}
+
+fn get_peak_limit(raw: &[u8], payload: &[u8], data: &[u8]) -> isize {
+    let disk = signed(payload.len()).saturating_add(signed(TREE_BYTES));
+    let runtime = signed(data.len()).saturating_add(signed(TREE_BYTES));
+    signed(raw.len())
+        .saturating_add(
+            signed(payload.len())
+                .saturating_add(disk)
+                .max(disk.saturating_add(runtime)),
+        )
+        .saturating_add(MARGIN)
+}
+
+fn existing_peak_limit(raw: &[u8], payload: &[u8]) -> isize {
+    // <=2P payload Vec, <=R base64 and <=2R envelope Vec fit 4R+P because R >= P.
+    let candidate_encode = signed(raw.len())
+        .saturating_mul(4)
+        .saturating_add(signed(payload.len()));
+    let existing_decode = signed(raw.len())
+        .saturating_mul(2)
+        .saturating_add(signed(payload.len()).saturating_mul(2))
+        .saturating_add(signed(TREE_BYTES));
+    candidate_encode.max(existing_decode).saturating_add(MARGIN)
+}
+
+#[test]
+fn undo_payload_public_paths_have_bounded_allocation() {
+    let genesis = devnet_genesis_block_bytes();
+    let header = &genesis[..BLOCK_HEADER_BYTES];
+    let hash = block_hash(header).expect("genesis hash");
+    let name = format!("{}.json", hex::encode(hash));
+    let pid = std::process::id();
+    let mut corpus = Vec::with_capacity(4);
+    for (version, supply) in [(1, "7"), (2, "\"7\"")] {
+        for size in [8 << 20, 12 << 20] {
+            let undo = BlockUndo {
+                block_height: 0,
+                previous_already_generated: 7,
+                txs: vec![TxUndo {
+                    spent: vec![SpentUndo {
+                        outpoint: Outpoint {
+                            txid: [1; 32],
+                            vout: 2,
+                        },
+                        entry: UtxoEntry {
+                            value: 3,
+                            covenant_type: 4,
+                            covenant_data: vec![0xab; size],
+                            creation_height: 5,
+                            created_by_coinbase: true,
+                        },
+                    }],
+                }],
+            };
+            let data = &undo.txs[0].spent[0].entry.covenant_data;
+            let payload = payload(supply, data);
+            let raw = envelope(version, hash, &payload);
+            corpus.push((version, undo, payload, raw));
+        }
+    }
+    let invalid_payloads = [invalid_payload("\"0\""), invalid_payload("0")];
+    let invalid_raws = [
+        envelope(1, hash, &invalid_payloads[0]),
+        envelope(2, hash, &invalid_payloads[1]),
+    ]; // All corpus bytes exist before arming.
+    let different = BlockUndo {
+        block_height: 0,
+        previous_already_generated: 8,
+        txs: vec![],
+    };
+    let (_held, control) = measure(|| vec![0u8; MARGIN as usize]);
+    assert!(
+        control >= MARGIN,
+        "counting allocator missed held allocation"
+    );
+    for (version, undo, payload, raw) in &corpus {
+        let size = undo.txs[0].spent[0].entry.covenant_data.len() >> 20;
+        let root = std::env::temp_dir().join(format!("rubin-undo-{version}-{size}-{pid}"));
+        let _ = std::fs::remove_dir_all(&root);
+        let mut store = BlockStore::create(&root).expect("create store");
+        let path = root.join("undo").join(&name);
+        std::fs::write(&path, raw).expect("seed undo");
+        let (got, get_peak) = measure(|| store.get_undo(hash).expect("public get"));
+        assert_eq!(&got, undo);
+        assert!(
+            get_peak <= get_peak_limit(raw, payload, &undo.txs[0].spent[0].entry.covenant_data),
+            "v{version} {size} MiB get {get_peak}"
+        );
+        drop(got);
+        let mut commit =
+            |candidate| store.commit_canonical_block(0, hash, header, &genesis, candidate);
+        let (_, commit_peak) = measure(|| commit(undo).expect("existing-file commit"));
+        assert!(
+            commit_peak <= existing_peak_limit(raw, payload),
+            "v{version} {size} MiB commit {commit_peak}"
+        );
+        // Small Q makes a restored Ue conversion add the large existing U above this decoder-only ceiling.
+        let (_, different_peak) = measure(|| commit(&different).expect_err("different existing"));
+        assert!(
+            different_peak <= get_peak_limit(raw, payload, &[]),
+            "v{version} {size} MiB different {different_peak}"
+        );
+        assert_eq!(
+            std::fs::read(&path).expect("read undo"),
+            *raw,
+            "v{version} {size} MiB rewrote undo"
+        );
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+    for (index, (payload, raw)) in invalid_payloads.iter().zip(&invalid_raws).enumerate() {
+        let version = index + 1;
+        let root = std::env::temp_dir().join(format!("rubin-undo-invalid-{version}-{pid}"));
+        let _ = std::fs::remove_dir_all(&root);
+        let store = BlockStore::create(&root).expect("create invalid store");
+        std::fs::write(root.join("undo").join(&name), raw).expect("seed invalid undo");
+        let (err, invalid_peak) = measure(|| store.get_undo(hash).expect_err("invalid supply"));
+        assert_eq!(err, INVALID_SUPPLY[index], "v{version} invalid supply");
+        assert!(
+            invalid_peak
+                <= signed(raw.len())
+                    .saturating_add(signed(payload.len()))
+                    .saturating_add(MARGIN),
+            "v{version} invalid supply {invalid_peak}"
+        );
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+}

--- a/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
+++ b/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
@@ -6,7 +6,7 @@ use rubin_node::undo::{BlockUndo, SpentUndo, TxUndo};
 use rubin_node::{devnet_genesis_block_bytes, BlockStore};
 use sha3::{Digest, Sha3_256};
 
-const ROWS: usize = 1 << 17;
+const ROWS: usize = if cfg!(tarpaulin) { 8 } else { 1 << 17 };
 const MARGIN: isize = 1 << 20;
 const TREE_BYTES: usize = std::mem::size_of::<TxUndo>() + std::mem::size_of::<SpentUndo>();
 const INVALID_SUPPLY: [&str; 2] = [
@@ -142,8 +142,6 @@ fn existing_peak_limit(raw: &[u8], payload: &[u8]) -> isize {
     candidate_encode.max(existing_decode).saturating_add(MARGIN)
 }
 
-// Normal CI owns this resource probe; LLVM coverage exceeds tarpaulin's no-output watchdog.
-#[cfg_attr(tarpaulin, ignore)]
 #[test]
 fn undo_payload_public_paths_have_bounded_allocation() {
     let genesis = devnet_genesis_block_bytes();
@@ -153,7 +151,11 @@ fn undo_payload_public_paths_have_bounded_allocation() {
     let pid = std::process::id();
     let mut corpus = Vec::with_capacity(4);
     for (version, supply) in [(1, "7"), (2, "\"7\"")] {
-        for size in [8 << 20, 12 << 20] {
+        for size in if cfg!(tarpaulin) {
+            [8 << 10, 12 << 10]
+        } else {
+            [8 << 20, 12 << 20]
+        } {
             let undo = BlockUndo {
                 block_height: 0,
                 previous_already_generated: 7,
@@ -195,7 +197,7 @@ fn undo_payload_public_paths_have_bounded_allocation() {
         "counting allocator missed held allocation"
     );
     for (version, undo, payload, raw) in &corpus {
-        let size = undo.txs[0].spent[0].entry.covenant_data.len() >> 20;
+        let size = undo.txs[0].spent[0].entry.covenant_data.len();
         let root = std::env::temp_dir().join(format!("rubin-undo-{version}-{size}-{pid}"));
         let _ = std::fs::remove_dir_all(&root);
         let mut store = BlockStore::create(&root).expect("create store");
@@ -205,7 +207,7 @@ fn undo_payload_public_paths_have_bounded_allocation() {
         assert_eq!(&got, undo);
         assert!(
             get_peak <= get_peak_limit(raw, payload, &undo.txs[0].spent[0].entry.covenant_data),
-            "v{version} {size} MiB get {get_peak}"
+            "v{version} {size} bytes get {get_peak}"
         );
         drop(got);
         let mut commit =
@@ -213,18 +215,18 @@ fn undo_payload_public_paths_have_bounded_allocation() {
         let (_, commit_peak) = measure(|| commit(undo).expect("existing-file commit"));
         assert!(
             commit_peak <= existing_peak_limit(raw, payload),
-            "v{version} {size} MiB commit {commit_peak}"
+            "v{version} {size} bytes commit {commit_peak}"
         );
         // Small Q makes a restored Ue conversion add the large existing U above this decoder-only ceiling.
         let (_, different_peak) = measure(|| commit(&different).expect_err("different existing"));
         assert!(
             different_peak <= get_peak_limit(raw, payload, &[]),
-            "v{version} {size} MiB different {different_peak}"
+            "v{version} {size} bytes different {different_peak}"
         );
         assert_eq!(
             std::fs::read(&path).expect("read undo"),
             *raw,
-            "v{version} {size} MiB rewrote undo"
+            "v{version} {size} bytes rewrote undo"
         );
         std::fs::remove_dir_all(root).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
+++ b/clients/rust/crates/rubin-node/tests/undo_payload_allocation.rs
@@ -142,6 +142,8 @@ fn existing_peak_limit(raw: &[u8], payload: &[u8]) -> isize {
     candidate_encode.max(existing_decode).saturating_add(MARGIN)
 }
 
+// Normal CI owns this resource probe; LLVM coverage exceeds tarpaulin's no-output watchdog.
+#[cfg_attr(tarpaulin, ignore)]
 #[test]
 fn undo_payload_public_paths_have_bounded_allocation() {
     let genesis = devnet_genesis_block_bytes();


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1157
- GitHub Issue mirror (non-authoritative): #2893

Refs: Q-XCLIENT-UNDO-PAYLOAD-MEMORY-01

## Summary
Bound post-checksum undo decoding memory in Go and Rust, return one validated disk tree from the shared decoder, compare existing records directly without constructing a second runtime undo or normalized payload, and keep the heavy resource proof in normal CI while using a reduced public-path corpus under tarpaulin coverage.

## Invariant
Preserve exact v1/v2 bytes, public values, errors and ordering, idempotence, and no-rewrite behavior while removing the retained Rust shape/canonical copies and existing-record runtime-copy amplification in both clients.

## Scope
- Changed files: 7
- Surfaces: clients/go, clients/rust
- Non-scope: consensus, recovery callers, envelope/checksum/base64 rules, bounds, public APIs, specification, formal, and shared conformance
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "^TestUndoPayloadAllocationPublicPaths$" -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -count=1'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node --test undo_payload_allocation -- --exact undo_payload_public_paths_have_bounded_allocation'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo tarpaulin -p rubin-node --test undo_payload_allocation --out Stdout -- --exact undo_payload_public_paths_have_bounded_allocation'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node --locked'` — PASS

## Follow-ups / Waivers
- None.
