### PR TITLE
[Q-GO-NATIVE-SUITE-RELAY-CONTEXT-TRUST-01] Gate stable native-suite rejection on frozen policy snapshot

### DIFF
--- a/clients/go/consensus/errors.go
+++ b/clients/go/consensus/errors.go
@@ -134,6 +134,10 @@ const (
 	// configuration: it is the ONE deployment outcome that is stable for these
 	// bytes under a context a consumer has already proven.
 	TxErrorCauseSimplicityDeploymentInactiveFrozen
+	// TxErrorCauseSimplicityWitnessSuiteInvalid means a CORE_SIMPLICITY witness
+	// selected a suite other than mandatory 0xF0. It is candidate-intrinsic and
+	// independent of provider or policy, so it remains stable terminal invalidity.
+	TxErrorCauseSimplicityWitnessSuiteInvalid
 )
 
 type TxError struct {

--- a/clients/go/consensus/simplicity_covenant.go
+++ b/clients/go/consensus/simplicity_covenant.go
@@ -138,7 +138,7 @@ type simplicityTxContextProvider func() (*SimplicityTxContext, error)
 
 func parseCoreSimplicityWitnessEnvelope(witness WitnessItem) (parsedSimplicityEnvelope, error) {
 	if witness.SuiteID != SUITE_ID_SIMPLICITY_ENVELOPE {
-		return parsedSimplicityEnvelope{}, txerr(TX_ERR_SIG_ALG_INVALID, "CORE_SIMPLICITY witness suite must be 0xF0")
+		return parsedSimplicityEnvelope{}, txerrWithCause(TX_ERR_SIG_ALG_INVALID, "CORE_SIMPLICITY witness suite must be 0xF0", TxErrorCauseSimplicityWitnessSuiteInvalid)
 	}
 	if len(witness.Pubkey) != 0 {
 		return parsedSimplicityEnvelope{}, txerr(TX_ERR_PARSE, "non-canonical Simplicity envelope witness item")

--- a/clients/go/consensus/simplicity_live_gate_test.go
+++ b/clients/go/consensus/simplicity_live_gate_test.go
@@ -219,7 +219,7 @@ func TestSimplicityLiveGate_OrderedErrorSet(t *testing.T) {
 			prev := hashWithPrefix(0xA0)
 			w := simplicityAcceptWitnessSig(tc.witness)
 			if tc.witness == nil {
-				w = WitnessItem{SuiteID: SUITE_ID_SENTINEL}
+				w = WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{1}}
 			}
 			tx := &Tx{
 				Version: TX_WIRE_VERSION, TxKind: 0x00, TxNonce: 1,
@@ -228,7 +228,11 @@ func TestSimplicityLiveGate_OrderedErrorSet(t *testing.T) {
 				Witness: []WitnessItem{w},
 			}
 			utxos := map[Outpoint]UtxoEntry{{Txid: prev, Vout: 0}: tc.entry()}
-			assertTxErrCode(t, runSimplicitySeq(tx, hashWithPrefix(0xA1), utxos, H, chainID, rot), tc.code)
+			err := runSimplicitySeq(tx, hashWithPrefix(0xA1), utxos, H, chainID, rot)
+			assertTxErrCode(t, err, tc.code)
+			if tc.name == "step1_suite" {
+				mustTxErrorCause(t, err, TX_ERR_SIG_ALG_INVALID, "CORE_SIMPLICITY witness suite must be 0xF0", TxErrorCauseSimplicityWitnessSuiteInvalid)
+			}
 		})
 	}
 }

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -1,8 +1,34 @@
 package node
 
 import (
+	"errors"
+
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
+
+func nativeSuiteRelayContextTrusted(policy MempoolConfig) bool {
+	switch rotation := policy.RotationProvider.(type) {
+	case nil:
+		return policy.SuiteRegistry == nil
+	case consensus.DefaultRotationProvider:
+		return policy.SuiteRegistry == nil || policy.SuiteRegistry.IsCanonicalDefaultLiveManifest()
+	case *consensus.DefaultRotationProvider:
+		return rotation != nil && (policy.SuiteRegistry == nil || policy.SuiteRegistry.IsCanonicalDefaultLiveManifest())
+	case consensus.DescriptorRotationProvider:
+		return rotation.Descriptor.Validate(policy.SuiteRegistry) == nil
+	default:
+		return false
+	}
+}
+
+func relayDispositionForConsensusError(err error, policy MempoolConfig) RelayAdmissionDisposition {
+	disposition := relayDispositionForInputError(err, RelayAdmissionStableTerminalReject)
+	var txErr *consensus.TxError
+	if disposition == RelayAdmissionStableTerminalReject && errors.As(err, &txErr) && txErr.Cause() == consensus.TxErrorCauseUnspecified && txErr.Code == consensus.TX_ERR_SIG_ALG_INVALID && !nativeSuiteRelayContextTrusted(policy) {
+		return RelayAdmissionUnavailable
+	}
+	return disposition
+}
 
 // buildPolicyInputSnapshotIfNeeded returns the immutable pre-validation
 // snapshot of only the transaction inputs that policy lanes inspect.
@@ -145,8 +171,8 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 		// An input that is absent, still immature, or not yet unlocked becomes
 		// spendable at a later height and stays retryable; every other
 		// consensus failure is stable terminal invalidity of these exact bytes
-		// against the exact stable context this call is bound to.
-		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForInputError(err, RelayAdmissionStableTerminalReject))
+		// unless its typed cause or untrusted native-suite policy selects otherwise.
+		return nil, nil, selectRelayDisposition(txAdmitRejected(err.Error()), relayDispositionForConsensusError(err, policy))
 	}
 	if err := m.applyPolicyAgainstState(checked, nextHeight, policyUtxos, policy); err != nil {
 		// Constructor-frozen, context-bound static policy: anchor outputs, the

--- a/clients/go/node/relay_admission.go
+++ b/clients/go/node/relay_admission.go
@@ -65,8 +65,8 @@ const (
 	// consensus error carrying TxErrorCauseSimplicityDeployment{Unavailable,
 	// EvidenceInvalid, InactiveProvider}, whose public code and message say only
 	// "not active" while the deployment set the answer came from is not pinned
-	// by the published context. The frozen no-provider state is NOT one of
-	// these: it reads no set and stays a stable terminal rejection.
+	// by the published context. An uncaused TX_ERR_SIG_ALG_INVALID under an untrusted native-suite policy snapshot is also unavailable.
+	// The frozen no-provider state is NOT one of these: it reads no set and stays a stable terminal rejection.
 	RelayAdmissionUnavailable
 	// RelayAdmissionInternal covers an impossible invariant, a retained
 	// identity mismatch, accounting corruption, an adapter contract violation,
@@ -548,8 +548,7 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 // selection, reading only typed values the producer set — never Error(), Msg,
 // backend text, or an OpenSSL error string.
 //
-// It reads the typed CAUSE first, because the cause outranks the code. Two
-// families need it:
+// It reads the typed CAUSE first, because the cause outranks the code. Three families need it:
 //
 //   - A process-local crypto-backend fault is published under a public code that
 //     also carries genuine candidate invalidity (TX_ERR_PARSE for a latched
@@ -559,7 +558,7 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 //     it is INTERNAL — never a stable terminal rejection, and therefore never
 //     cache-authorizing. A candidate that selected an unsupported or
 //     unauthorized suite carries no such cause and keeps its baseline
-//     classification.
+//     classification here; relayDispositionForConsensusError may downgrade an uncaused native-suite failure under an untrusted snapshot.
 //   - A CORE_SIMPLICITY deployment rejection collapses five distinct states onto
 //     TX_ERR_COVENANT_TYPE_INVALID and two fixed messages. Three of them —
 //     provider unavailability, invalid provider evidence, and inactivity
@@ -576,13 +575,14 @@ func relayDispositionForPolicyError(err error) RelayAdmissionDisposition {
 //     no-provider-configured state rests entirely on constructor-frozen
 //     configuration and stays a stable terminal rejection, with cache authority
 //     still governed by the caller's own exact-context proof.
+//   - A non-0xF0 CORE_SIMPLICITY witness is candidate-intrinsic and policy-independent, so it stays STABLE_TERMINAL_REJECT.
 //
 // ORDERING NOTE — structural, and deliberately NOT claimed by any test. Reading
 // the cause before the code switch is a PAIRWISE fact, and on today's inputs the
 // two orders are observationally identical: the closed cause set is
 // {LocalCryptoBackendFault, SimplicityDeploymentUnavailable,
 // SimplicityDeploymentEvidenceInvalid, SimplicityDeploymentInactiveProvider,
-// SimplicityDeploymentInactiveFrozen}, every producer of those causes emits
+// SimplicityDeploymentInactiveFrozen, SimplicityWitnessSuiteInvalid}, every producer of those causes emits
 // TX_ERR_PARSE, TX_ERR_SIG_INVALID, TX_ERR_SIG_ALG_INVALID or
 // TX_ERR_COVENANT_TYPE_INVALID, and none of those codes is a member of the
 // switch set below. No error can therefore carry a cause AND a switch-set code,
@@ -616,7 +616,7 @@ func relayDispositionForInputError(err error, nonDependency RelayAdmissionDispos
 			consensus.TxErrorCauseSimplicityDeploymentEvidenceInvalid,
 			consensus.TxErrorCauseSimplicityDeploymentInactiveProvider:
 			return RelayAdmissionUnavailable
-		case consensus.TxErrorCauseSimplicityDeploymentInactiveFrozen:
+		case consensus.TxErrorCauseSimplicityDeploymentInactiveFrozen, consensus.TxErrorCauseSimplicityWitnessSuiteInvalid:
 			return RelayAdmissionStableTerminalReject
 		default:
 			return RelayAdmissionInternal

--- a/clients/go/node/relay_admission_native_suite_context_test.go
+++ b/clients/go/node/relay_admission_native_suite_context_test.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+type nativeSuiteRelayContextMutableRotation struct {
+	consensus.DefaultRotationProvider
+	calls     int
+	nilResult bool
+}
+
+func (p *nativeSuiteRelayContextMutableRotation) NativeSpendSuites(uint64) *consensus.NativeSuiteSet {
+	p.calls++
+	if p.nilResult {
+		return nil
+	}
+	if p.calls%2 == 1 {
+		return consensus.NewNativeSuiteSet(consensus.SUITE_ID_ML_DSA_87)
+	}
+	return consensus.NewNativeSuiteSet(0x03)
+}
+func TestNativeSuiteRelayContextTrust(t *testing.T) {
+	registry := reorgTestSuiteRegistry(0x02)
+	descriptor := consensus.CryptoRotationDescriptor{Name: "test", OldSuiteID: consensus.SUITE_ID_ML_DSA_87, NewSuiteID: 0x02, CreateHeight: 200, SpendHeight: 300}
+	valid := consensus.DescriptorRotationProvider{Descriptor: descriptor}
+	invalid := valid
+	invalid.Descriptor.Name = ""
+	validPointer := &consensus.DescriptorRotationProvider{Descriptor: descriptor}
+	if err := validPointer.Descriptor.Validate(registry); err != nil || nativeSuiteRelayContextTrusted(MempoolConfig{RotationProvider: validPointer, SuiteRegistry: registry}) {
+		t.Fatalf("pointer descriptor trust=%v validation=%v", nativeSuiteRelayContextTrusted(MempoolConfig{RotationProvider: validPointer, SuiteRegistry: registry}), err)
+	}
+	mutatedPointer := &consensus.DescriptorRotationProvider{Descriptor: descriptor}
+	mutatedPointer.Descriptor.Name = ""
+	var nilDefault *consensus.DefaultRotationProvider
+	var nilDescriptor *consensus.DescriptorRotationProvider
+	uncausedSuiteError := &consensus.TxError{Code: consensus.TX_ERR_SIG_ALG_INVALID}
+	for _, rotation := range []consensus.RotationProvider{nilDefault, nilDescriptor} {
+		policy := MempoolConfig{RotationProvider: rotation}
+		if nativeSuiteRelayContextTrusted(policy) || relayDispositionForConsensusError(uncausedSuiteError, policy) != RelayAdmissionUnavailable {
+			t.Fatal("typed-nil provider trusted or cache-authorizing")
+		}
+	}
+	suiteMessage := "TX_ERR_SIG_ALG_INVALID: CORE_P2PK suite not in native spend set"
+	cases := []struct {
+		name    string
+		policy  MempoolConfig
+		trusted bool
+	}{
+		{"nil", MempoolConfig{}, true},
+		{"nil canonical registry", MempoolConfig{SuiteRegistry: consensus.DefaultSuiteRegistry()}, false},
+		{"default value nil registry", MempoolConfig{RotationProvider: consensus.DefaultRotationProvider{}}, true},
+		{"default value canonical registry", MempoolConfig{RotationProvider: consensus.DefaultRotationProvider{}, SuiteRegistry: consensus.DefaultSuiteRegistry()}, true},
+		{"default pointer nil registry", MempoolConfig{RotationProvider: &consensus.DefaultRotationProvider{}}, true},
+		{"default pointer canonical registry", MempoolConfig{RotationProvider: &consensus.DefaultRotationProvider{}, SuiteRegistry: consensus.DefaultSuiteRegistry()}, true},
+		{"default pointer noncanonical registry", MempoolConfig{RotationProvider: &consensus.DefaultRotationProvider{}, SuiteRegistry: unboundAlgSuiteRegistry()}, false},
+		{"default noncanonical registry", MempoolConfig{RotationProvider: consensus.DefaultRotationProvider{}, SuiteRegistry: unboundAlgSuiteRegistry()}, false},
+		{"validated descriptor", MempoolConfig{RotationProvider: valid, SuiteRegistry: registry}, true},
+		{"invalid descriptor", MempoolConfig{RotationProvider: invalid, SuiteRegistry: registry}, false},
+		{"descriptor missing registry membership", MempoolConfig{RotationProvider: valid, SuiteRegistry: consensus.DefaultSuiteRegistry()}, false},
+		{"validated descriptor pointer", MempoolConfig{RotationProvider: validPointer, SuiteRegistry: registry}, false},
+		{"mutated descriptor pointer", MempoolConfig{RotationProvider: mutatedPointer, SuiteRegistry: registry}, false},
+		{"custom default behavior", MempoolConfig{RotationProvider: &deploymentCauseRotation{}}, false},
+		{"custom nil suites", MempoolConfig{RotationProvider: &nativeSuiteRelayContextMutableRotation{nilResult: true}}, false},
+		{"custom empty suites", MempoolConfig{RotationProvider: emptySpendRotationProvider{}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nativeSuiteRelayContextTrusted(tc.policy); got != tc.trusted {
+				t.Fatalf("trusted=%v, want %v", got, tc.trusted)
+			}
+			h := newRelayHarness(t, &tc.policy, 1_000_000)
+			got := h.mp.AddRemoteTxForRelay(retargetFirstWitnessSuite(t, h.tx(0, 100_000, 100_000, 1), 0x02), h.context())
+			want := RelayAdmissionUnavailable
+			if tc.trusted {
+				want = RelayAdmissionStableTerminalReject
+			}
+			if got.Disposition != want || got.HasAdmissionContext != tc.trusted || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != suiteMessage || h.mp.Len() != 0 || (!tc.trusted && got.AdmissionContext != (PendingOutpointAdmissionContext{})) {
+				t.Fatalf("result=%+v, want disposition=%v context=%v message=%q", got, want, tc.trusted, suiteMessage)
+			}
+		})
+	}
+	h := newRelayHarness(t, nil, 1_000_000)
+	h.mp.mu.Lock()
+	h.mp.policy.RotationProvider = &deploymentCauseRotation{}
+	h.mp.mu.Unlock()
+	got := h.mp.AddRemoteTxForRelay(retargetFirstWitnessSuite(t, h.tx(0, 100_000, 100_000, 1), 0x02), h.context())
+	if got.Disposition != RelayAdmissionUnavailable || got.HasAdmissionContext || got.AdmissionContext != (PendingOutpointAdmissionContext{}) || h.mp.Len() != 0 || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != suiteMessage {
+		t.Fatalf("replacement result=%+v", got)
+	}
+	shape := &nativeSuiteRelayContextMutableRotation{}
+	first, second := shape.NativeSpendSuites(0), shape.NativeSpendSuites(0)
+	if first.Len() != 1 || !first.Contains(consensus.SUITE_ID_ML_DSA_87) || first.Contains(0x02) || first.Contains(0x03) || second.Len() != 1 || !second.Contains(0x03) || second.Contains(0x02) || second.Contains(consensus.SUITE_ID_ML_DSA_87) || first.Contains(0x03) == second.Contains(0x03) {
+		t.Fatal("mutable provider suite shapes collapsed")
+	}
+	mutable := &nativeSuiteRelayContextMutableRotation{}
+	if nativeSuiteRelayContextTrusted(MempoolConfig{RotationProvider: mutable}) || mutable.calls != 0 {
+		t.Fatal("trust predicate called custom provider")
+	}
+	h = newRelayHarness(t, &MempoolConfig{RotationProvider: mutable}, 1_000_000)
+	context, raw := h.context(), retargetFirstWitnessSuite(t, h.tx(0, 100_000, 100_000, 1), 0x02)
+	for i := range 2 {
+		got = h.mp.AddRemoteTxForRelay(raw, context)
+		if got.Disposition != RelayAdmissionUnavailable || got.HasAdmissionContext || got.AdmissionContext != (PendingOutpointAdmissionContext{}) || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != suiteMessage || h.mp.Len() != 0 || mutable.calls != 2*(i+1) {
+			t.Fatalf("mutable provider result=%+v", got)
+		}
+	}
+	if after := h.context(); *after != *context {
+		t.Fatalf("admission context moved: after=%+v before=%+v", *after, *context)
+	}
+	h = newRelayHarness(t, &MempoolConfig{SuiteRegistry: unboundAlgSuiteRegistry()}, 1_000_000)
+	got = h.mp.AddRemoteTxForRelay(h.tx(0, 100_000, 100_000, 1), h.context())
+	localMessage := fmt.Sprintf("%s: suite_id=0x%02x resolveSuiteVerifierBinding: unsupported alg=%q pubkey_len=%d sig_len=%d", consensus.TX_ERR_SIG_ALG_INVALID, consensus.SUITE_ID_ML_DSA_87, "ML-DSA-87-NOT-LIVE-BOUND", consensus.ML_DSA_87_PUBKEY_BYTES, consensus.ML_DSA_87_SIG_BYTES)
+	if got.Disposition != RelayAdmissionInternal || got.HasAdmissionContext || got.AdmissionContext != (PendingOutpointAdmissionContext{}) || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != localMessage || h.mp.Len() != 0 {
+		t.Fatalf("local backend result=%+v", got)
+	}
+	h = newRelayHarness(t, &MempoolConfig{RotationProvider: &deploymentCauseRotation{}}, 1_000_000)
+	got = h.mp.AddRemoteTxForRelay(corruptFirstWitnessSignature(t, h.tx(0, 100_000, 100_000, 1)), h.context())
+	if got.Disposition != RelayAdmissionStableTerminalReject || !got.HasAdmissionContext || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != "TX_ERR_SIG_INVALID: CORE_P2PK signature invalid" || h.mp.Len() != 0 {
+		t.Fatalf("unrelated result=%+v", got)
+	}
+}

--- a/clients/go/node/relay_admission_native_suite_context_test.go
+++ b/clients/go/node/relay_admission_native_suite_context_test.go
@@ -23,6 +23,7 @@ func (p *nativeSuiteRelayContextMutableRotation) NativeSpendSuites(uint64) *cons
 	}
 	return consensus.NewNativeSuiteSet(0x03)
 }
+
 func TestNativeSuiteRelayContextTrust(t *testing.T) {
 	registry := reorgTestSuiteRegistry(0x02)
 	descriptor := consensus.CryptoRotationDescriptor{Name: "test", OldSuiteID: consensus.SUITE_ID_ML_DSA_87, NewSuiteID: 0x02, CreateHeight: 200, SpendHeight: 300}

--- a/clients/go/node/relay_admission_native_suite_context_test.go
+++ b/clients/go/node/relay_admission_native_suite_context_test.go
@@ -45,6 +45,10 @@ func TestNativeSuiteRelayContextTrust(t *testing.T) {
 			t.Fatal("typed-nil provider trusted or cache-authorizing")
 		}
 	}
+	uncausedSimplicitySuiteError := &consensus.TxError{Code: consensus.TX_ERR_SIG_ALG_INVALID, Msg: "CORE_SIMPLICITY witness suite must be 0xF0"}
+	if relayDispositionForConsensusError(uncausedSimplicitySuiteError, MempoolConfig{RotationProvider: &deploymentCauseRotation{}}) != RelayAdmissionUnavailable {
+		t.Fatal("uncaused CORE_SIMPLICITY suite error cache-authorizing under untrusted policy")
+	}
 	suiteMessage := "TX_ERR_SIG_ALG_INVALID: CORE_P2PK suite not in native spend set"
 	cases := []struct {
 		name    string
@@ -111,6 +115,20 @@ func TestNativeSuiteRelayContextTrust(t *testing.T) {
 	}
 	if after := h.context(); *after != *context {
 		t.Fatalf("admission context moved: after=%+v before=%+v", *after, *context)
+	}
+	rotation := testSimplicityRotation{activeAt: 0, chainID: devnetGenesisChainID}
+	if nativeSuiteRelayContextTrusted(MempoolConfig{RotationProvider: rotation}) {
+		t.Fatal("custom CORE_SIMPLICITY provider trusted")
+	}
+	h = consensusSeamHarness(t, rotation)
+	entry := h.st.Utxos[h.outpoints[0]]
+	entry.CovenantType, entry.CovenantData = consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x54}, nil)
+	h.st.Utxos[h.outpoints[0]] = entry
+	expected := h.context()
+	simplicityRaw := txWithOneInputOneOutput(h.outpoints[0].Txid, h.outpoints[0].Vout, 1, consensus.COV_TYPE_P2PK, h.toAddr, []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}})
+	got = h.mp.AddRemoteTxForRelay(simplicityRaw, expected)
+	if got.Disposition != RelayAdmissionStableTerminalReject || !got.HasAdmissionContext || got.AdmissionContext != *expected || admitKind(t, got.Err) != TxAdmitRejected || got.Err.Error() != "TX_ERR_SIG_ALG_INVALID: CORE_SIMPLICITY witness suite must be 0xF0" || h.mp.Len() != 0 {
+		t.Fatalf("CORE_SIMPLICITY witness suite result=%+v", got)
 	}
 	h = newRelayHarness(t, &MempoolConfig{SuiteRegistry: unboundAlgSuiteRegistry()}, 1_000_000)
 	got = h.mp.AddRemoteTxForRelay(h.tx(0, 100_000, 100_000, 1), h.context())


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1154
- GitHub Issue mirror (non-authoritative): #2888

Refs: Q-GO-NATIVE-SUITE-RELAY-CONTEXT-TRUST-01

## Summary
Gate stable relay rejection for unspecified native-suite mismatch on the exact immutable Mempool policy snapshot. Trusted default or validated value-descriptor policies retain stable rejection; custom, mutable, pointer-descriptor, typed-nil, or otherwise untrusted policies remain unavailable and non-cache-authorizing. Source-tag the policy-independent CORE_SIMPLICITY non-0xF0 witness-suite error so it remains stable without message matching.

## Invariant
Only an unspecified TX_ERR_SIG_ALG_INVALID under a frozen validated native-suite policy may authorize STABLE_TERMINAL_REJECT; source-tagged candidate-intrinsic Simplicity suite errors remain stable, while typed process/deployment causes retain their existing mappings. Public errors, validation order, acceptance and state mutation remain unchanged.

## Scope
- Changed files: 6
- Surfaces: clients/go node relay-admission classification, private consensus TxError cause provenance, and focused tests
- Non-scope: provider and registry APIs, AdmissionContext shape, P2P cache, startup wiring, Rust, conformance, formal, specification, persistence, and public schemas
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `./scripts/dev-env.sh -- bash -lc "cd clients/go && go test -count=1 ./consensus -run 'SimplicityLiveGate_OrderedErrorSet'"` — PASS; `./scripts/dev-env.sh -- bash -lc "cd clients/go && go test -count=1 ./node -run 'NativeSuiteRelayContext'"` — PASS

## Follow-ups / Waivers
- parity-exempt is intentional: this change adds only private Go TxError provenance consumed by Go relay admission; ErrorCode, message, acceptance, serialization and state remain unchanged.

### Parity exemption justification
The changed consensus line attaches private Go error provenance to an existing rejection. It does not change consensus validity, public error code or message, validation order, bytes, or state; the only consumer is Go node relay cache-authority classification, so there is no Rust behavior to mirror.
