### PR TITLE
[Q-GO-ATOMIC-RETAINED-SNAPSHOT-01] Expose atomic mempool identity and bytes by txid

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -224,6 +224,49 @@ func (m *Mempool) TxByID(txid [32]byte) ([]byte, bool) {
 	return raw, true
 }
 
+// RetainedTxSnapshot is one indivisible read of a retained mempool row: the txid
+// it is indexed under, the wtxid stored at its admission, and a defensive copy of
+// its exact retained bytes, all read under one continuously held mempool read lock
+// so that they describe one row incarnation and never a mixed tuple.
+type RetainedTxSnapshot struct {
+	IndexedTxID    [32]byte
+	AdmissionWTxID [32]byte
+	Raw            []byte
+}
+
+// RetainedTxByID snapshots the retained row indexed under txid.
+//
+// The bool reports ONLY whether the primary txid index held that key under the
+// read lock — never validity, availability, standard-domain, or relay authority.
+// The method parses, hashes, validates and repairs nothing, and never consults
+// the separate wtxid index. Raw is a defensive exact-length copy: mutating it
+// cannot alter the retained entry or any later snapshot.
+//
+// A present nil row is CORRUPTION, not absence, and stays distinguishable from
+// it: it returns (IndexedTxID = the requested key, zero AdmissionWTxID, nil Raw,
+// true), where a nil receiver or a missing key returns (zero snapshot, false).
+// Classifying that corruption belongs to the caller.
+func (m *Mempool) RetainedTxByID(txid [32]byte) (RetainedTxSnapshot, bool) {
+	if m == nil {
+		return RetainedTxSnapshot{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, ok := m.txs[txid]
+	if !ok {
+		return RetainedTxSnapshot{}, false
+	}
+	// The indexed key, never entry.txid: a [32]byte map hit means the argument IS the key.
+	snapshot := RetainedTxSnapshot{IndexedTxID: txid}
+	if entry == nil {
+		return snapshot, true
+	}
+	snapshot.AdmissionWTxID = entry.wtxid
+	snapshot.Raw = make([]byte, len(entry.raw))
+	copy(snapshot.Raw, entry.raw)
+	return snapshot, true
+}
+
 // Contains reports whether a transaction with the given txid is currently
 // present in the mempool.
 func (m *Mempool) Contains(txid [32]byte) bool {

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5176,6 +5176,188 @@ func TestMempoolTxByIDNilReceiver(t *testing.T) {
 	}
 }
 
+// TestMempoolRetainedTxByID drives the RUB-1166 hostile matrix R0-R11 over the
+// atomic retained snapshot: nil and absent rows, every admission source, the
+// test-only corruption rows, the defensive copy, every removal and restore path,
+// and a concurrent reader racing complete remove/restore cycles.
+func TestMempoolRetainedTxByID(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	defaultCfg := MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20}
+	mustOK := func(t *testing.T, what string, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", what, err)
+		}
+	}
+	newPool := func(t *testing.T, cfg MempoolConfig, values ...uint64) (*Mempool, *ChainState, []consensus.Outpoint) {
+		t.Helper()
+		st, outpoints := testSpendableChainState(fromAddress, values)
+		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, cfg)
+		mustOK(t, "new mempool", err)
+		return mp, st, outpoints
+	}
+	buildTx := func(t *testing.T, st *ChainState, op consensus.Outpoint, fee, nonce uint64) []byte {
+		t.Helper()
+		return mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{op}, 100_000, fee, nonce, fromKey, fromAddress, toAddress)
+	}
+	// wantHit pins the complete triple against the admitted bytes themselves.
+	wantHit := func(t *testing.T, mp *Mempool, raw []byte) RetainedTxSnapshot {
+		t.Helper()
+		_, txid, wtxid, _, err := consensus.ParseTx(raw)
+		mustOK(t, "ParseTx", err)
+		got, ok := mp.RetainedTxByID(txid)
+		if !ok || got.IndexedTxID != txid || got.AdmissionWTxID != wtxid || !bytes.Equal(got.Raw, raw) {
+			t.Fatalf("snapshot=(%x,%x,%x,%v), want (%x,%x,%x,true)", got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok, txid, wtxid, raw)
+		}
+		return got
+	}
+	wantMiss := func(t *testing.T, label string, mp *Mempool, key [32]byte) {
+		t.Helper()
+		got, ok := mp.RetainedTxByID(key)
+		if ok || got.IndexedTxID != ([32]byte{}) || got.AdmissionWTxID != ([32]byte{}) || got.Raw != nil {
+			t.Fatalf("%s=(%x,%x,%x,%v), want the zero snapshot and false", label, got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok)
+		}
+	}
+
+	t.Run("R0/R1 nil receiver and absent txid", func(t *testing.T) {
+		var nilPool *Mempool
+		wantMiss(t, "nil receiver", nilPool, [32]byte{})
+		mp, _, _ := newPool(t, defaultCfg, 1_000_000)
+		wantMiss(t, "absent txid", mp, [32]byte{0xAB})
+	})
+
+	t.Run("R2/R8 every admission source yields the exact triple as a defensive copy", func(t *testing.T) {
+		mp, st, outpoints := newPool(t, defaultCfg, 1_000_000, 1_000_000, 1_000_000)
+		for i, admit := range []func([]byte) error{mp.AddTx, mp.AddRemoteTx, mp.AddReorgTx} {
+			raw := buildTx(t, st, outpoints[i], 300_000, uint64(i+1))
+			mustOK(t, "admit", admit(raw))
+			mutated := wantHit(t, mp, raw)
+			mutated.Raw[0] ^= 0xFF
+			wantHit(t, mp, raw)
+		}
+	})
+
+	t.Run("R3 present nil row is corruption, not absence", func(t *testing.T) {
+		key := [32]byte{0x5A}
+		mp := &Mempool{txs: map[[32]byte]*mempoolEntry{key: nil}}
+		got, ok := mp.RetainedTxByID(key)
+		if !ok || got.IndexedTxID != key || got.AdmissionWTxID != ([32]byte{}) || got.Raw != nil {
+			t.Fatalf("present nil row=(%x,%x,%x,%v), want (%x, zero, nil, true)", got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok, key)
+		}
+		wantMiss(t, "absent key in the same pool", mp, [32]byte{0x5B})
+	})
+
+	// One row corrupted in every dimension at once: the snapshot must report the
+	// primary row's own stored values, unclassified and unrepaired.
+	t.Run("R4-R7 corrupted row is reported from the primary index", func(t *testing.T) {
+		mp, st, outpoints := newPool(t, defaultCfg, 1_000_000)
+		raw := buildTx(t, st, outpoints[0], 100_000, 1)
+		mustOK(t, "AddTx", mp.AddTx(raw))
+		id := txID(t, raw)
+		wantWTxID := [32]byte{0xC0, 0xDE}
+		wantRaw := append(append([]byte(nil), raw...), 0xFF)
+		mp.mu.Lock()
+		entry := mp.txs[id]
+		delete(mp.wtxids, entry.wtxid) // R6: the secondary binding goes missing.
+		entry.wtxid = wantWTxID        // R4: the stored wtxid no longer matches Raw.
+		entry.txid = [32]byte{0x99}    // R5: the entry field disagrees with the index.
+		entry.raw = wantRaw            // R7: retained bytes are no longer canonical.
+		mp.mu.Unlock()
+		got, ok := mp.RetainedTxByID(id)
+		if !ok || got.IndexedTxID != id || got.AdmissionWTxID != wantWTxID || !bytes.Equal(got.Raw, wantRaw) {
+			t.Fatalf("corrupted row=(%x,%x,%x,%v), want (%x,%x,%x,true)", got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok, id, wantWTxID, wantRaw)
+		}
+		mp.mu.RLock()
+		defer mp.mu.RUnlock()
+		if len(mp.wtxids) != 0 {
+			t.Fatalf("the read repaired the secondary wtxid index: %d bindings", len(mp.wtxids))
+		}
+	})
+
+	t.Run("R9 removal makes the row absent", func(t *testing.T) {
+		removalCase := func(t *testing.T, label string, cfg MempoolConfig, remove func(*testing.T, *Mempool, *ChainState, []consensus.Outpoint, []byte, mempoolSnapshot)) {
+			t.Helper()
+			mp, st, outpoints := newPool(t, cfg, 1_000_000, 1_000_000)
+			empty, err := snapshotMempool(mp)
+			mustOK(t, "snapshotMempool", err)
+			raw := buildTx(t, st, outpoints[0], 100_000, 1)
+			mustOK(t, "AddTx", mp.AddTx(raw))
+			wantHit(t, mp, raw)
+			remove(t, mp, st, outpoints, raw, empty)
+			wantMiss(t, label, mp, txID(t, raw))
+		}
+		removalCase(t, "confirmed", defaultCfg, func(t *testing.T, mp *Mempool, _ *ChainState, _ []consensus.Outpoint, raw []byte, _ mempoolSnapshot) {
+			mustOK(t, "EvictConfirmed", mp.EvictConfirmed(buildSingleTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, raw)))
+		})
+		removalCase(t, "conflict", defaultCfg, func(t *testing.T, mp *Mempool, st *ChainState, ops []consensus.Outpoint, _ []byte, _ mempoolSnapshot) {
+			conflicting := buildTx(t, st, ops[0], 200_000, 2)
+			coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0))
+			mustOK(t, "RemoveConflicting", mp.RemoveConflicting(buildMultiTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, coinbase, conflicting)))
+		})
+		removalCase(t, "capacity", MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20}, func(t *testing.T, mp *Mempool, st *ChainState, ops []consensus.Outpoint, _ []byte, _ mempoolSnapshot) {
+			mustOK(t, "AddTx(better fee)", mp.AddTx(buildTx(t, st, ops[1], 400_000, 2)))
+		})
+		removalCase(t, "empty restore", defaultCfg, func(t *testing.T, mp *Mempool, _ *ChainState, _ []consensus.Outpoint, _ []byte, empty mempoolSnapshot) {
+			mustOK(t, "restoreMempoolSnapshot", restoreMempoolSnapshot(mp, empty))
+		})
+	})
+
+	t.Run("R10 restore observations are complete", func(t *testing.T) {
+		mp, st, outpoints := newPool(t, defaultCfg, 1_000_000, 1_000_000)
+		tx1 := buildTx(t, st, outpoints[0], 200_000, 1)
+		mustOK(t, "AddTx(tx1)", mp.AddTx(tx1))
+		withTx1, err := snapshotMempool(mp)
+		mustOK(t, "snapshotMempool", err)
+		tx2 := buildTx(t, st, outpoints[1], 200_000, 2)
+		mustOK(t, "AddTx(tx2)", mp.AddTx(tx2))
+		mustOK(t, "restoreMempoolSnapshot", restoreMempoolSnapshot(mp, withTx1))
+		wantHit(t, mp, tx1)
+		wantMiss(t, "row dropped by the restore", mp, txID(t, tx2))
+		// A rejected restore publishes nothing, so the pre-restore tuple stands.
+		broken := withTx1
+		broken.lastAdmissionSeq = 0
+		if err := restoreMempoolSnapshot(mp, broken); err == nil {
+			t.Fatal("restore accepted an admission high-water below the restored max")
+		}
+		wantHit(t, mp, tx1)
+	})
+
+	t.Run("R11 concurrent remove and restore never yields a mixed tuple", func(t *testing.T) {
+		mp, st, outpoints := newPool(t, defaultCfg, 1_000_000)
+		raw := buildTx(t, st, outpoints[0], 100_000, 1)
+		mustOK(t, "AddTx", mp.AddTx(raw))
+		_, id, wtxid, _, err := consensus.ParseTx(raw)
+		mustOK(t, "ParseTx", err)
+		withRow, err := snapshotMempool(mp)
+		mustOK(t, "snapshotMempool", err)
+		block := buildSingleTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, raw)
+		done, stopped := make(chan struct{}), make(chan struct{})
+		defer func() { close(done); <-stopped }()
+		go func() {
+			defer close(stopped)
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				// Absence is a legal observation; a hit must be one whole row.
+				if got, ok := mp.RetainedTxByID(id); ok && (got.IndexedTxID != id || got.AdmissionWTxID != wtxid || !bytes.Equal(got.Raw, raw)) {
+					t.Errorf("mixed tuple: (%x,%x,%x)", got.IndexedTxID, got.AdmissionWTxID, got.Raw)
+					return
+				}
+			}
+		}()
+		for i := 0; i < 200; i++ {
+			mustOK(t, "EvictConfirmed", mp.EvictConfirmed(block))
+			mustOK(t, "restoreMempoolSnapshot", restoreMempoolSnapshot(mp, withRow))
+		}
+	})
+}
+
 func TestMempoolContainsReflectsAdmission(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5331,6 +5331,13 @@ func TestMempoolRetainedTxByID(t *testing.T) {
 		mustOK(t, "AddTx", mp.AddTx(raw))
 		_, id, wtxid, _, err := consensus.ParseTx(raw)
 		mustOK(t, "ParseTx", err)
+		mp.mu.RLock()
+		entryA := mp.txs[id]
+		mp.mu.RUnlock()
+		wtxidB := wtxid
+		wtxidB[0] ^= 0xFF
+		rawB := append(append([]byte(nil), raw...), 0xEE)
+		entryB := &mempoolEntry{txid: id, wtxid: wtxidB, raw: rawB}
 		withRow, err := snapshotMempool(mp)
 		mustOK(t, "snapshotMempool", err)
 		block := buildSingleTxBlock(t, [32]byte{}, consensus.POW_LIMIT, 1, raw)
@@ -5345,15 +5352,23 @@ func TestMempoolRetainedTxByID(t *testing.T) {
 				default:
 				}
 				// Absence is a legal observation; a hit must be one whole row.
-				if got, ok := mp.RetainedTxByID(id); ok && (got.IndexedTxID != id || got.AdmissionWTxID != wtxid || !bytes.Equal(got.Raw, raw)) {
+				if got, ok := mp.RetainedTxByID(id); ok && (got.IndexedTxID != id || (got.AdmissionWTxID != wtxid || !bytes.Equal(got.Raw, raw)) && (got.AdmissionWTxID != wtxidB || !bytes.Equal(got.Raw, rawB))) {
 					t.Errorf("mixed tuple: (%x,%x,%x)", got.IndexedTxID, got.AdmissionWTxID, got.Raw)
 					return
 				}
 			}
 		}()
+		// Public-path cycles kill stale/fabricated hits and prove race-cleanliness.
 		for i := 0; i < 200; i++ {
 			mustOK(t, "EvictConfirmed", mp.EvictConfirmed(block))
 			mustOK(t, "restoreMempoolSnapshot", restoreMempoolSnapshot(mp, withRow))
+		}
+		// Divergent-incarnation swap kills fields assembled across two incarnations.
+		incarnations := [2]*mempoolEntry{entryA, entryB}
+		for i := 0; i < 200; i++ {
+			mp.mu.Lock()
+			mp.txs[id] = incarnations[i%2]
+			mp.mu.Unlock()
 		}
 	})
 }

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -64,6 +64,23 @@ func (p *CanonicalMempoolTxPool) Has(txid [32]byte) bool {
 	return p.mempool.Contains(txid)
 }
 
+// RetainedTxByID forwards the adapted mempool's atomic retained snapshot —
+// indexed txid, admission-time wtxid, and the owner's single defensive copy of
+// the exact retained bytes — with the owner's meaning unchanged: no identity
+// recompute, no second payload copy, no added classification, and a bool that
+// stays primary-index presence only, so a present nil row still reports found and
+// remains distinguishable from absence. A nil adapter or a nil adapted mempool
+// returns the zero snapshot and false.
+//
+// Deliberately NOT part of the generic TxPool interface: the interface stays the
+// narrow relay contract, and only this concrete adapter exposes retained metadata.
+func (p *CanonicalMempoolTxPool) RetainedTxByID(txid [32]byte) (node.RetainedTxSnapshot, bool) {
+	if p == nil || p.mempool == nil {
+		return node.RetainedTxSnapshot{}, false
+	}
+	return p.mempool.RetainedTxByID(txid)
+}
+
 // AddRemoteTxForRelay admits a peer transaction through the canonical mempool
 // and returns the producer's result UNCHANGED: the same disposition, the
 // producer's own TxID and WTxID, the same admission-context evidence, and the

--- a/clients/go/node/p2p/mempool_test.go
+++ b/clients/go/node/p2p/mempool_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"sync"
 	"testing"
@@ -41,6 +42,62 @@ func TestCanonicalMempoolTxPoolPendingOutpointOwner(t *testing.T) {
 		PendingOutpointOwner() *node.PendingOutpointOwner
 	}); widened {
 		t.Fatal("the generic TxPool surface was widened with the owner accessor")
+	}
+}
+
+// TestCanonicalMempoolTxPoolRetainedTxByID proves the adapter surface: nil
+// adapter, nil-backed adapter, and a live miss all return the zero snapshot
+// and false; a healthy canonically-admitted hit carries the producer's own
+// identities and the owner's defensive copy survives caller mutation; the
+// generic TxPool interface stays non-widened. Package p2p cannot construct a
+// corrupted owner row (node internals are unexported with no product
+// mutation hook), so owner-row corruption forwarding (R3-R7) is pinned by
+// the owner-side tests in package node, not through this adapter.
+func TestCanonicalMempoolTxPoolRetainedTxByID(t *testing.T) {
+	chainState := node.NewChainState()
+	raw, txid, utxos := signedCanonicalP2PTxWithoutSeeding(t, 1)
+	for op, entry := range utxos {
+		chainState.Utxos[op] = entry
+	}
+	mempool, err := node.NewMempool(chainState, nil, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	adapter := NewCanonicalMempoolTxPool(mempool)
+
+	var nilAdapter *CanonicalMempoolTxPool
+	for name, pool := range map[string]*CanonicalMempoolTxPool{
+		"nil adapter":               nilAdapter,
+		"nil-backed adapter":        NewCanonicalMempoolTxPool(nil),
+		"live adapter, absent txid": adapter,
+	} {
+		got, ok := pool.RetainedTxByID(txid)
+		if ok || got.IndexedTxID != ([32]byte{}) || got.AdmissionWTxID != ([32]byte{}) || got.Raw != nil {
+			t.Fatalf("%s=(%x,%x,%x,%v), want the zero snapshot and false", name, got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok)
+		}
+	}
+
+	admitted := adapter.AddRemoteTxForRelay(txid, raw, nil)
+	if admitted.Disposition != node.RelayAdmissionRetained {
+		t.Fatalf("disposition=%v, want RETAINED (err=%v)", admitted.Disposition, admitted.Err)
+	}
+	got, ok := adapter.RetainedTxByID(txid)
+	if !ok || got.IndexedTxID != admitted.TxID || got.AdmissionWTxID != admitted.WTxID || !bytes.Equal(got.Raw, raw) {
+		t.Fatalf("snapshot=(%x,%x,%x,%v), want the producer's (%x,%x) and the exact retained bytes", got.IndexedTxID, got.AdmissionWTxID, got.Raw, ok, admitted.TxID, admitted.WTxID)
+	}
+	got.Raw[0] ^= 0xFF
+	again, _ := adapter.RetainedTxByID(txid)
+	if !bytes.Equal(again.Raw, raw) {
+		t.Fatal("the adapter forwarded a mutable alias of the retained bytes")
+	}
+
+	// Widening the generic TxPool interface would force every implementation to
+	// carry the retained accessor. MemoryTxPool must not.
+	var generic TxPool = NewMemoryTxPool()
+	if _, widened := generic.(interface {
+		RetainedTxByID([32]byte) (node.RetainedTxSnapshot, bool)
+	}); widened {
+		t.Fatal("the generic TxPool surface was widened with the retained snapshot accessor")
 	}
 }
 


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1166
- GitHub Issue mirror (non-authoritative): #2905

Refs: Q-GO-ATOMIC-RETAINED-SNAPSHOT-01

## Summary
Add `node.RetainedTxSnapshot` and `(*node.Mempool).RetainedTxByID`: one indivisible read of a retained mempool row — the indexed txid, the admission-time stored wtxid, and a defensive exact-length copy of the exact retained bytes — under one continuously held `Mempool.mu.RLock`. A present nil row is reported as corruption (found, zero fields), distinguishable from absence; the method never parses, hashes, validates, repairs, or consults the secondary wtxid index. The concrete `*p2p.CanonicalMempoolTxPool` gains the same method as a pure forward of the owner snapshot; the generic `p2p.TxPool` interface is not widened. Existing `TxByID`/`Get`/`Has` and every admission path are untouched (the diff is insertion-only). Owner-side prerequisite of RUBIN_COMPACT_BLOCKS.md §17.1 retained-lookup authority; the OWNED/ABSENT/INTERNAL classification stays with RUB-1115.

## Invariant
Under one canonical Mempool read lock, a txid lookup snapshots the indexed txid, the entry's admission-time stored wtxid, and one defensive copy of the exact retained raw bytes; the concrete P2P canonical adapter exposes that same indivisible snapshot without recomputing identity, widening generic TxPool, or creating another index or byte store.

## Scope
- Changed files: 4
- Surfaces: clients/go
- Non-scope: relay Service/handlers/cache, producer classification, admission/replacement/retention policy, wire, RPC, Rust, fixtures, conformance, formal, spec; generic TxPool interface changes; by-wtxid lookup (RUB-1161).
- Consensus rules unchanged: yes
- SECTION_HASHES.json unchanged: yes
- Wire format unchanged: yes

## Validation
- `go test -count=1 ./node -run "^TestMempoolRetainedTxByID$"` — PASS
- `go test -count=1 ./node/p2p -run "^TestCanonicalMempoolTxPoolRetainedTxByID$"` — PASS
- `go test -race -count=1 ./node ./node/p2p -run "^(TestMempoolRetainedTxByID|TestCanonicalMempoolTxPoolRetainedTxByID)$"` — PASS
- `go test -count=1 -timeout 900s ./node ./node/p2p` — PASS

## Follow-ups / Waivers
- RUB-1115 (relay representation cache: consumes this owner API)
- RUB-1161 (by-wtxid retained lookup: reuses this owner metadata)
