### PR TITLE
[Q-RUST-CHAINSTATE-FLOCK-FORK-LEAK-01] Serialize the bare-filename child spawn with atomic writes

### DIFF
--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -1442,13 +1442,26 @@ mod tests {
         // this regression test as a silent no-op. Pass the full path
         // so the child actually re-enters this function through the
         // `CHILD_ENV`-set branch above.
-        let status = Command::new(std::env::current_exe().expect("current test binary"))
-            .current_dir(&dir)
-            .env(CHILD_ENV, "1")
-            .arg("--exact")
-            .arg("chainstate::tests::save_accepts_bare_filename_via_effective_parent")
-            .status()
-            .expect("spawn child test process");
+        // The child of a process spawn (fork/exec or posix_spawn's
+        // vfork-style clone) starts with a copy of the parent's fd table
+        // and co-owns any held flock open-file-description until its
+        // execve completes (O_CLOEXEC only applies at exec), so a spawn
+        // racing a held `.rubin-atomic-write.lock` would leave the child
+        // co-owning a contended lock. Keep the guarded span free of
+        // panicking code (a panic while held would poison the mutex for
+        // the whole suite); the child is a separate process with its own
+        // mutex, so holding this guard across `.status()` cannot deadlock it.
+        let child_exe = std::env::current_exe().expect("current test binary");
+        let status = {
+            let _fork_guard = crate::io_utils::atomic_write_process_lock_for_fork();
+            Command::new(&child_exe)
+                .current_dir(&dir)
+                .env(CHILD_ENV, "1")
+                .arg("--exact")
+                .arg("chainstate::tests::save_accepts_bare_filename_via_effective_parent")
+                .status()
+        };
+        let status = status.expect("spawn child test process");
 
         assert!(
             status.success(),

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -927,6 +927,22 @@ pub(crate) fn is_atomic_write_post_commit(error: &AtomicWriteError) -> bool {
     error.stage() == AtomicWriteStage::AfterNamespaceCommit
 }
 static ATOMIC_WRITE_PROCESS_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Serializes a test that spawns the test binary against in-flight atomic
+/// writes. `flock` ownership is per open-file-description, and the child of
+/// a process spawn (fork/exec or posix_spawn's vfork-style clone) starts
+/// with a copy of the parent's fd table, co-owning any held
+/// `.rubin-atomic-write.lock` open-file-description until its `execve`
+/// completes (`O_CLOEXEC` only applies at exec). Holding this guard across
+/// the spawn guarantees no atomic-write lock fd is open in the parent when
+/// the child is created.
+#[cfg(test)]
+pub(crate) fn atomic_write_process_lock_for_fork() -> std::sync::MutexGuard<'static, ()> {
+    ATOMIC_WRITE_PROCESS_MUTEX
+        .lock()
+        .expect("atomic write process mutex")
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum AtomicWriteTestOp {


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1174
- GitHub Issue mirror (non-authoritative): #2914

Refs: Q-RUST-CHAINSTATE-FLOCK-FORK-LEAK-01

## Summary
Close the CI coverage-job flake root-caused on PR #2912 (`chainstate::tests::chainstate_v1_read_and_v2_u128_round_trip` intermittently panicking with `atomic write lock failed: …: Contended`). flock ownership is per open-file-description and a process spawn (fork/exec or posix_spawn's vfork-style clone) starts the child with a copy of the parent's fd table, so the self-spawning test `save_accepts_bare_filename_via_effective_parent` could capture a sibling test's held `.rubin-atomic-write.lock` and keep it alive until the child's `execve` — visible only under tarpaulin's ptrace-stretched pre-exec window. The fix adds one `#[cfg(test)]` accessor over the existing atomic-write process mutex and holds it across the entire child spawn+wait, so no atomic-write lock fd can be open at spawn time. The guarded span is unwind-free (a panic while held would poison the mutex suite-wide); the child runs in its own process with its own mutex, so no deadlock. Non-test builds gain no symbol (nm symbol-set comparison baseline vs HEAD identical). Test-infrastructure only; no production behavior change.

## Invariant
The bare-filename child-process spawn in the rubin-node test suite executes entirely while holding the process-wide atomic-write mutex, so at the moment the test binary spawns, no atomic-write parent-directory lock fd can be open anywhere in the parent process, and no spawned child can inherit a held .rubin-atomic-write.lock open-file-description that would make a later sequential save observe a Contended lock.

## Scope
- Changed files: 2
- Surfaces: clients/rust (rubin-node test suite only)
- Non-scope: production locking/atomic-write behavior, consensus, wire, persistence format, CI workflows and coverage tooling, Go client, fixtures, conformance, formal, spec; direct `file_lock::acquire` test holders (same-class residual, recorded in Linear).
- Consensus rules unchanged: yes
- SECTION_HASHES.json unchanged: yes
- Wire format unchanged: yes

## Validation
- `cargo fmt --check -p rubin-node` — PASS
- `cargo clippy -p rubin-node --tests -- -D warnings` — PASS
- `cargo test -p rubin-node --lib -- chainstate::tests::save_accepts_bare_filename_via_effective_parent chainstate::tests::chainstate_v1_read_and_v2_u128_round_trip` — PASS
- soak: 30x and 10x fail-fast repetitions of the previous command — PASS (0 failures)
- `cargo build -p rubin-node` — PASS
- `cargo test -p rubin-node` — PASS

## Follow-ups / Waivers
- RUB-1174 Linear thread records the same-class residual: direct `file_lock::acquire` holders in file_lock.rs tests remain outside the mutex and exposed to the spawn window.
