### PR TITLE
[Q-GO-P2P-SERVICE-WORK-LIFECYCLE-01] Drain Service work before Close returns

### DIFF
--- a/clients/go/node/p2p/addr_discovery.go
+++ b/clients/go/node/p2p/addr_discovery.go
@@ -49,11 +49,19 @@ func (s *Service) connectDiscoveredAddrs(addrs []string) {
 		if s.isConnected(addr) {
 			continue
 		}
+		// Register the discovered-dial worker before the in-flight
+		// reservation and before MarkAttempted: once Close has published
+		// the non-OPEN state this handler-inherited path makes no
+		// reservation, no addr-manager mutation and no goroutine at all,
+		// and no later address in this batch can start one either.
+		if !s.acquireWork() {
+			return
+		}
 		if !s.tryTrackDiscoveredDial(addr, limit) {
+			s.releaseWork()
 			continue
 		}
 		s.addrMgr.MarkAttempted(addr)
-		s.loopWG.Add(1)
 		go s.dialPeer(addr)
 	}
 }

--- a/clients/go/node/p2p/da_relay_consume.go
+++ b/clients/go/node/p2p/da_relay_consume.go
@@ -41,10 +41,19 @@ func (s *Service) consumeCanonicalAppliedDASets(blocks []node.CanonicalAppliedBl
 // cmd/rubin-node. It parses, then delegates to the same
 // node.CompleteDASetIDsFromParsedBlock core the canonical-apply path uses, so
 // the two entry points cannot select different DA sets for the same block.
+//
+// It takes one Service call lease before parsing or DA mutation: once Close
+// has published the non-OPEN state the call returns exactly "service already
+// closed" with no parse, no DA-state mutation and no send, and a call that
+// won the lease first keeps running while Close waits for it.
 func (s *Service) ConsumeAcceptedBlockDASets(blockBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
+	if !s.acquireWork() {
+		return errServiceClosed
+	}
+	defer s.releaseWork()
 	if s.daRelay == nil {
 		return errors.New("nil DA relay")
 	}

--- a/clients/go/node/p2p/handshake.go
+++ b/clients/go/node/p2p/handshake.go
@@ -53,11 +53,24 @@ func performHandshake(
 		_ = conn.SetDeadline(time.Time{})
 	}()
 
+	// The cancellation interrupter mutates conn's deadline, so performHandshake
+	// joins it before returning on every path: after this defer no child of
+	// this handshake can touch conn, and therefore none can outlive the worker
+	// that owns the connection or the Service drain that waits for that worker.
 	done := make(chan struct{})
-	defer close(done)
+	interrupterExited := make(chan struct{})
 	if ctx != nil {
-		go interruptHandshakeOnContextCancel(ctx, conn, done)
+		go func() {
+			defer close(interrupterExited)
+			interruptHandshakeOnContextCancel(ctx, conn, done)
+		}()
+	} else {
+		close(interrupterExited)
 	}
+	defer func() {
+		close(done)
+		<-interrupterExited
+	}()
 
 	payload, err := encodeVersionPayload(local)
 	if err != nil {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -51,6 +51,14 @@ func (p *peer) run(ctx context.Context) error {
 		if err := recordExpiredFallback(); err != nil {
 			return err
 		}
+		// Read authorization: an OPEN observation here authorizes exactly
+		// one further frame attempt. It sits after the compact fallback an
+		// already-authorized message is permitted to finish and before the
+		// read deadline is armed, so once Close has published the non-OPEN
+		// state this worker sets no deadline and starts no further read.
+		if !p.service.workAuthorized() {
+			return nil
+		}
 		frameStart := time.Now()
 		_, activeCompact := p.compactOutstandingExpiry()
 		if err := p.setReadDeadlineAt(frameStart, lateBlockTxn == nil || activeCompact); err != nil {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -56,6 +56,12 @@ type Service struct {
 	// Close has returned, Start refuses to restart the same Service and the
 	// accept/reconnect loops must not be revived. Guarded by peersMu.
 	closed bool
+	// closeDone is published by the Close that owns the teardown and closed
+	// when that teardown completes; every later Close waits on it instead of
+	// tearing down again. closed==true with a nil closeDone means the flag
+	// was published without a teardown owner, so the next Close still owns
+	// the teardown. Guarded by peersMu.
+	closeDone chan struct{}
 	// boundAddr caches listener.Addr().String() captured when Start
 	// successfully publishes the listener. Addr() returns it so that
 	// wildcard/ephemeral binds (e.g. ":0") still surface the concrete
@@ -215,10 +221,60 @@ func normalizeServicePeerRuntimeConfig(cfg node.PeerRuntimeConfig, syncNetwork s
 	return cfg
 }
 
+// errServiceClosed is the exact rejection a publication-capable public entry
+// returns once Close has published the non-OPEN state.
+var errServiceClosed = errors.New("service already closed")
+
+// acquireWork registers one Service work lease and reports whether the
+// Service was still OPEN. A rejected caller must perform no parsing,
+// producer call, state mutation, queueing, or send. The loopWG increment
+// happens under the same peersMu section that reads closed, and Close
+// publishes closed under that lock before it releases it and waits, so a
+// lease can never be added after Close began waiting for it.
+func (s *Service) acquireWork() bool {
+	if s == nil {
+		return false
+	}
+	s.peersMu.Lock()
+	defer s.peersMu.Unlock()
+	if s.closed {
+		return false
+	}
+	s.loopWG.Add(1)
+	return true
+}
+
+// releaseWork releases exactly one lease taken by acquireWork.
+func (s *Service) releaseWork() {
+	s.loopWG.Done()
+}
+
+// workAuthorized reports whether the Service is still OPEN. A peer worker
+// calls it immediately before authorizing one more frame read; it takes no
+// lease and the caller keeps the worker lease it already owns. A peer with
+// no Service owns no lifecycle gate and stays authorized.
+func (s *Service) workAuthorized() bool {
+	if s == nil {
+		return true
+	}
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	return !s.closed
+}
+
+// AnnounceBlock parses a locally accepted block and announces it to the
+// current peers. It takes one Service call lease before parsing, seen-set
+// mutation, broadcast or DA TTL work: once Close has published the non-OPEN
+// state it returns exactly "service already closed" with zero effects, and a
+// call that won the lease first finishes while Close waits for it.
 func (s *Service) AnnounceBlock(blockBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
+	if !s.acquireWork() {
+		return errServiceClosed
+	}
+	defer s.releaseWork()
 	pb, err := consensus.ParseBlockBytes(blockBytes)
 	if err != nil {
 		return err
@@ -238,10 +294,19 @@ func (s *Service) AnnounceBlock(blockBytes []byte) error {
 	return ttlErr
 }
 
+// AnnounceTx admits a locally submitted transaction to the relay pool and
+// announces it. It takes one Service call lease before parsing, admission,
+// DA staging, seen-set mutation or inventory send: once Close has published
+// the non-OPEN state it returns exactly "service already closed" with zero
+// effects, and a call that won the lease first finishes while Close waits.
 func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
+	if !s.acquireWork() {
+		return errServiceClosed
+	}
+	defer s.releaseWork()
 	tx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		return err

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -173,21 +173,21 @@ func (s *Service) startOutboundPeers() {
 // startWG.Wait blocks until that cleanup is done, so the listener snapshot
 // below always reflects final state — either a published listener that
 // Close itself closes, or nil if Start aborted and cleaned up.
+//
+// Close MUST be invoked only by the external lifecycle owner, never reentrantly
+// from work whose own lease it would have to await (RUBIN_L1_P2P_AUX section 5).
 func (s *Service) Close() error {
 	if s == nil {
 		return nil
 	}
 	// Phase 1: publish the closed flag so any in-progress Start observes
 	// it on its write-lock re-check and aborts with "service already
-	// closed", closing its local listener before returning. Publishing it
-	// under peersMu is also the registration cutoff: acquireWork increments
-	// loopWG only under this same lock with closed==false, so every lease
-	// this Close will wait for was registered before this section and no
-	// lease can appear after the loopWG.Wait below has begun.
-	//
-	// The first Close to reach this section owns the single teardown and
-	// publishes closeDone; a later Close observes it and waits for that one
-	// completion instead of tearing down again.
+	// closed", closing its local listener before returning. Publishing it under peersMu is also
+	// the registration cutoff: acquireWork increments loopWG only under this same lock with
+	// closed==false, so every lease this Close will wait for was registered before this section
+	// and no lease can appear after the loopWG.Wait below has begun. The first Close to reach
+	// this section owns the single teardown and publishes closeDone; a later Close observes it
+	// and waits for that one completion instead of tearing down again.
 	s.peersMu.Lock()
 	if s.closeDone != nil {
 		joined := s.closeDone

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -153,9 +153,13 @@ func (s *Service) startOutboundPeers() {
 }
 
 // Close cancels the service context, closes the listener, tears down every
-// tracked peer connection, waits for all background goroutines to exit, and
-// marks the Service as closed. The Service is dormant after Close returns:
-// any subsequent Start call will return "service already closed". Close is
+// tracked peer connection, waits for all background goroutines and every
+// in-flight public call to release their work lease, and marks the Service as
+// closed. No Service-owned network or state effect occurs after Close
+// returns. Concurrent Close calls share one teardown: only the first runs it,
+// the others return once that single completion is published. The Service is
+// dormant after Close returns: a subsequent Start returns "service already
+// closed", and so does every publication-capable public call. Close is
 // idempotent on a nil receiver. The boundAddr cache is retained so that
 // post-close Addr() calls still surface the last resolved listener address
 // for diagnostics/metrics.
@@ -175,10 +179,27 @@ func (s *Service) Close() error {
 	}
 	// Phase 1: publish the closed flag so any in-progress Start observes
 	// it on its write-lock re-check and aborts with "service already
-	// closed", closing its local listener before returning.
+	// closed", closing its local listener before returning. Publishing it
+	// under peersMu is also the registration cutoff: acquireWork increments
+	// loopWG only under this same lock with closed==false, so every lease
+	// this Close will wait for was registered before this section and no
+	// lease can appear after the loopWG.Wait below has begun.
+	//
+	// The first Close to reach this section owns the single teardown and
+	// publishes closeDone; a later Close observes it and waits for that one
+	// completion instead of tearing down again.
 	s.peersMu.Lock()
+	if s.closeDone != nil {
+		joined := s.closeDone
+		s.peersMu.Unlock()
+		<-joined
+		return nil
+	}
 	s.closed = true
+	closeDone := make(chan struct{})
+	s.closeDone = closeDone
 	s.peersMu.Unlock()
+	defer close(closeDone)
 
 	// Phase 2: wait for every in-progress Start to return. After this
 	// wait, s.listener is in its final state — either published by a
@@ -267,11 +288,18 @@ func (s *Service) acceptLoop() {
 			continue
 		}
 		errorBackoff = acceptErrorBackoffInit
+		// Register the connection worker before any handshake-slot
+		// mutation: if Close won the race there is no slot change, no
+		// child and no lease — only the accepted socket is closed.
+		if !s.acquireWork() {
+			_ = conn.Close()
+			return
+		}
 		if !s.tryAcquireHandshakeSlot() {
 			_ = conn.Close()
+			s.releaseWork()
 			continue
 		}
-		s.loopWG.Add(1)
 		go s.runConn(conn, true)
 	}
 }
@@ -322,11 +350,18 @@ func (s *Service) dialPeer(addr string) {
 	}
 }
 
+// startDialPeer registers the dial worker before it reserves the in-flight
+// dial slot, so a dial that loses the race with Close leaves no reservation,
+// no goroutine and no lease behind. The registered lease is transferred to
+// the spawned dialPeer, which releases it exactly once.
 func (s *Service) startDialPeer(addr string) bool {
-	if !s.trackDialPeer(addr) {
+	if !s.acquireWork() {
 		return false
 	}
-	s.loopWG.Add(1)
+	if !s.trackDialPeer(addr) {
+		s.releaseWork()
+		return false
+	}
 	go s.dialPeer(addr)
 	return true
 }

--- a/clients/go/node/p2p/service_work_lifecycle_test.go
+++ b/clients/go/node/p2p/service_work_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 // Service work lifecycle evidence. Barriers are channels and sockets; time-based waits are only watchdogs and the negative window asserting Close stays blocked.
 // Dead dial targets are structurally dead: no process can ever listen on TCP port 0, so "127.0.0.%d:0" dials fail immediately with no rebind window at all.
-// normalizeNetAddr rejects port 0, so the normalize-first surfaces (connectDiscoveredAddrs, addrMgr) use loopback port 1 — root-only to bind, and only 127.0.0.1:1 is ever dialed.
+// normalizeNetAddr rejects port 0, so the never-dialed rejection rows on the normalize-first surfaces (connectDiscoveredAddrs, addrMgr) use loopback port 1 — each is rejected before any dial; the one dialed discovered endpoint is a test-owned listener.
 const (
 	lifecycleWatchdog = 5 * time.Second
 	lifecycleSettle   = 100 * time.Millisecond
@@ -107,9 +107,8 @@ func requireRejectedInbound(t *testing.T, s *Service, label string) {
 	must(t, conn.Close(), "close "+label)
 }
 
-// lifecycleGateConn optionally holds the first Write until the test releases it (entered/release non-nil), parking a call
-// inside a real socket write while Close runs; optionally counts every Write (writes non-nil) and every SetReadDeadline
-// made after postDrain is set — a drained worker must arm none.
+// lifecycleGateConn optionally holds the first Write until the test releases it (entered/release non-nil), parking a call inside a real socket write while Close runs;
+// optionally counts every Write (writes non-nil) and every SetReadDeadline made after postDrain is set — a drained worker must arm none.
 type lifecycleGateConn struct {
 	net.Conn
 	once      sync.Once
@@ -204,8 +203,7 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	for i := 0; i < cap(s.handshakeSlots); i++ {
 		<-s.handshakeSlots
 	}
-	// Registration racing the first Close: the only admissible outcomes are registered-and-waited or rejected-without-Done.
-	// A third outcome (a lease added after Close began waiting) panics the WaitGroup, strands Close, or leaks a reservation.
+	// Registration racing the first Close: the only admissible outcomes are registered-and-waited or rejected-without-Done. A third outcome (a lease added after Close began waiting) panics the WaitGroup, strands Close, or leaks a reservation.
 	var starts sync.WaitGroup
 	for i := 0; i < 16; i++ {
 		addr := fmt.Sprintf("127.0.0.%d:0", 100+i)
@@ -327,8 +325,7 @@ func lifecycleDASetPresent(s *Service, daID [32]byte) bool {
 	return ok
 }
 
-// TestServiceWorkLifecyclePeerWorkerInheritance runs a real peer loop and handler stack: one authorized message finishes its publication
-// and its owed compact fallback while Close waits, and after the drain the worker arms no read deadline and starts no further read.
+// TestServiceWorkLifecyclePeerWorkerInheritance runs a real peer loop and handler stack: one authorized message finishes its publication and its owed compact fallback while Close waits, and after the drain the worker arms no read deadline and starts no further read.
 func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 	s := lifecycleService(t)
 	s.cfg.PeerRuntimeConfig.ReadDeadline = 0
@@ -343,8 +340,7 @@ func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 	}
 	runDone := make(chan error, 1)
 	go func() { defer s.releaseWork(); runDone <- p.run(context.Background()) }()
-	// The gate parks the worker inside its reply write, past every deadline arm of this iteration. The loop
-	// context is never cancelled and the socket is never closed, so only the read-authorization gate stops it.
+	// The gate parks the worker inside its reply write, past every deadline arm of this iteration. The loop context is never cancelled and the socket is never closed, so only the read-authorization gate stops it.
 	_, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr}))
 	must(t, err, "write authorized message")
 	<-gate.entered
@@ -371,11 +367,18 @@ func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 	requireZero(t, int(gate.lateArms.Load()), "post-drain read-deadline arms on the worker conn")
 }
 
-// TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain proves the discovered-dial child is waited for while OPEN, and that
-// while Close is provably still in flight a concurrent discovered burst leaves no attempt, no reservation and no dial child.
+// TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain proves the discovered-dial child is waited for while OPEN, and that while Close is provably still in flight a concurrent discovered burst leaves no attempt, no reservation and no dial child.
 func TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain(t *testing.T) {
 	s := lifecycleService(t)
-	openAddr, drainAddr := "127.0.0.1:1", "127.0.0.2:1"
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	must(t, err, "listen for the discovered dial target")
+	defer func() { _ = lis.Close() }()
+	go func() {
+		if conn, aerr := lis.Accept(); aerr == nil {
+			_ = conn.Close()
+		}
+	}()
+	openAddr, drainAddr := lis.Addr().String(), "127.0.0.2:1"
 	s.addrMgr.AddAddrs([]string{openAddr, drainAddr})
 	s.connectDiscoveredAddrs([]string{openAddr})
 	if attempts := lifecycleAddrAttempts(s, openAddr); attempts != 1 {
@@ -406,9 +409,8 @@ func lifecycleAddrAttempts(s *Service, addr string) int {
 	return s.addrMgr.addrs[normalizeNetAddr(addr)].attempts
 }
 
-// lifecycleDeadlineConn records connection-deadline mutations that are still in flight, so the test can prove no
-// handshake child touches the connection after performHandshake returned. Only non-zero deadlines — the interrupter always
-// sets one — are delayed and counted: delaying performHandshake's own reset-to-zero defer would let the parent's own delay mask an unjoined interrupter instead of exposing it.
+// lifecycleDeadlineConn records connection-deadline mutations that are still in flight, so the test can prove no handshake child touches the connection after performHandshake returned.
+// Only non-zero deadlines — the interrupter always sets one — are delayed and counted: delaying performHandshake's own reset-to-zero defer would let the parent's own delay mask an unjoined interrupter instead of exposing it.
 type lifecycleDeadlineConn struct {
 	net.Conn
 	inFlight atomic.Int64
@@ -426,8 +428,7 @@ func (c *lifecycleDeadlineConn) SetDeadline(deadline time.Time) error {
 		c.late.Add(1)
 	}
 	err := c.Conn.SetDeadline(deadline)
-	// Widen the window in which a non-joined interrupter would still be mutating the connection: with the reset defer
-	// undelayed, an unjoined interrupter is provably still inside this sleep when performHandshake returns, so the in-flight check fails.
+	// Widen the window in which a non-joined interrupter would still be mutating the connection: with the reset defer undelayed, an unjoined interrupter is provably still inside this sleep when performHandshake returns, so the in-flight check fails.
 	time.Sleep(50 * time.Millisecond)
 	return err
 }
@@ -509,9 +510,8 @@ func TestServiceWorkLifecyclePanicRelease(t *testing.T) {
 	requireReturned(t, lifecycleClose(s), "Close after a panicking call")
 }
 
-// TestServiceWorkLifecycleConcurrentClose parks the owning Close in phase 2 and proves later Close calls join that one
-// teardown: every joiner stays parked on the shared completion while the teardown is demonstrably unfinished, and
-// exactly one teardown runs.
+// TestServiceWorkLifecycleConcurrentClose parks the owning Close in phase 2 and proves later Close calls join that one teardown:
+// every joiner stays parked on the shared completion while the teardown is demonstrably unfinished, and exactly one teardown runs.
 func TestServiceWorkLifecycleConcurrentClose(t *testing.T) {
 	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
 	must(t, s.Start(context.Background()), "Start")

--- a/clients/go/node/p2p/service_work_lifecycle_test.go
+++ b/clients/go/node/p2p/service_work_lifecycle_test.go
@@ -1,0 +1,594 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+// Service work lifecycle evidence. Barriers are channels and sockets; time-based
+// waits are only watchdogs and the negative window asserting Close stays blocked.
+const (
+	lifecycleWatchdog = 5 * time.Second
+	lifecycleSettle   = 100 * time.Millisecond
+)
+
+func lifecycleService(t *testing.T) *Service {
+	t.Helper()
+	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
+	s.ctx = context.Background()
+	return s
+}
+
+func lifecycleClose(s *Service) chan error {
+	done := make(chan error, 1)
+	go func() { done <- s.Close() }()
+	return done
+}
+
+func must(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+func requireZero(t *testing.T, got int, label string) {
+	t.Helper()
+	if got != 0 {
+		t.Fatalf("%s=%d, want 0", label, got)
+	}
+}
+
+// requireStillBlocked asserts a registered lease still pins the operation. It is
+// parked on a barrier this test owns, so a return inside the window is a lost drain.
+func requireStillBlocked(t *testing.T, done <-chan error, label string) {
+	t.Helper()
+	select {
+	case err := <-done:
+		t.Fatalf("%s returned (err=%v) while a registered lease was held", label, err)
+	case <-time.After(lifecycleSettle):
+	}
+}
+
+func requireReturned(t *testing.T, done <-chan error, label string) {
+	t.Helper()
+	select {
+	case err := <-done:
+		must(t, err, label)
+	case <-time.After(lifecycleWatchdog):
+		t.Fatalf("%s did not return within %s", label, lifecycleWatchdog)
+	}
+}
+
+// waitDraining blocks until Close published the non-OPEN state, so no later
+// assertion can pass merely because Close had not started yet.
+func waitDraining(t *testing.T, s *Service) {
+	t.Helper()
+	deadline := time.Now().Add(lifecycleWatchdog)
+	for s.workAuthorized() {
+		if time.Now().After(deadline) {
+			t.Fatal("Close did not publish the non-OPEN state")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func requireClosedRejection(t *testing.T, err error, label string) {
+	t.Helper()
+	if err == nil || err.Error() != "service already closed" {
+		t.Fatalf("%s err=%v, want %q", label, err, "service already closed")
+	}
+}
+
+// lifecycleGateConn holds the first Write until the test releases it, parking a
+// public call inside a real socket write while Close runs.
+type lifecycleGateConn struct {
+	net.Conn
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (c *lifecycleGateConn) Write(b []byte) (int, error) {
+	c.once.Do(func() {
+		close(c.entered)
+		<-c.release
+	})
+	return c.Conn.Write(b)
+}
+
+type lifecycleCountingConn struct {
+	net.Conn
+	writes *atomic.Int64
+}
+
+func (c *lifecycleCountingConn) Write(b []byte) (int, error) {
+	c.writes.Add(1)
+	return c.Conn.Write(b)
+}
+
+func lifecycleReadFrame(p *peer, r net.Conn) chan message {
+	magic := networkMagic(p.service.cfg.PeerRuntimeConfig.Network)
+	maxSize := p.service.cfg.PeerRuntimeConfig.MaxMessageSize
+	out := make(chan message, 1)
+	go func() {
+		header, err := readFrameHeader(r, magic, maxSize)
+		if err != nil {
+			out <- message{}
+			return
+		}
+		payload, err := readPayloadWithChecksum(r, header.Size, header.Checksum)
+		if err != nil {
+			out <- message{}
+			return
+		}
+		out <- message{Command: header.Command, Payload: payload}
+	}()
+	return out
+}
+
+// TestServiceWorkLifecycleEntryMatrix covers every Table A entry in OPEN and in
+// DRAINING/CLOSED, plus the registration-versus-Close race.
+func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
+	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
+	// Raised before Start so the accept-path child below stays parked in its read.
+	s.cfg.PeerRuntimeConfig.HandshakeTimeout = lifecycleWatchdog
+	must(t, s.Start(context.Background()), "Start")
+	txBytes := minimalValidTxBytes(t)
+	blockBytes := node.DevnetGenesisBlockBytes()
+	must(t, s.AnnounceTx(txBytes), "OPEN AnnounceTx")
+	must(t, s.AnnounceBlock(blockBytes), "OPEN AnnounceBlock")
+	must(t, s.ConsumeAcceptedBlockDASets(blockBytes), "OPEN ConsumeAcceptedBlockDASets")
+	must(t, s.consumeCompleteDASetIDs(nil), "OPEN synchronous internal callee")
+	if !s.startDialPeer("127.0.0.1:1") {
+		t.Fatal("OPEN outbound dial was not registered")
+	}
+
+	// Accept path in OPEN: the gate registers the accepted worker before it
+	// mutates a handshake slot or spawns the child that writes this frame.
+	open, err := net.Dial("tcp", s.Addr())
+	must(t, err, "dial the OPEN listener")
+	must(t, open.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
+	if _, err := open.Read(make([]byte, 1)); err != nil {
+		t.Fatalf("the OPEN accepted child never wrote its version frame: %v", err)
+	}
+	if got := len(s.handshakeSlots); got != 1 {
+		t.Fatalf("handshake slots while OPEN=%d, want 1", got)
+	}
+	// Closing the client fails that handshake; the child releases its one slot.
+	must(t, open.Close(), "close the OPEN client conn")
+	for deadline := time.Now().Add(lifecycleWatchdog); len(s.handshakeSlots) != 0; {
+		if time.Now().After(deadline) {
+			t.Fatal("the accepted child did not release its handshake slot")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Registration racing the first Close: the only admissible outcomes are
+	// registered-and-waited or rejected-without-Done. A third outcome (a lease added after
+	// Close began waiting) panics the WaitGroup, strands Close, or leaks a reservation.
+	var registered atomic.Int64
+	var starts sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		addr := fmt.Sprintf("127.0.0.1:%d", 19200+i)
+		starts.Add(1)
+		go func() {
+			defer starts.Done()
+			if s.startDialPeer(addr) {
+				registered.Add(1)
+			}
+		}()
+	}
+	// startWG parks Close between its registration cutoff and the listener teardown
+	// (phase 2 waits on startWG, only phase 3 closes the listener), so the accept
+	// loop is still accepting while the Service is no longer OPEN.
+	s.startWG.Add(1)
+	closeDone := lifecycleClose(s)
+	waitDraining(t, s)
+	drained, err := net.Dial("tcp", s.Addr())
+	must(t, err, "dial the draining listener")
+	must(t, drained.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
+	// The gate closed the socket with no child behind it: a spawned child would have
+	// written its version frame here first.
+	if n, err := drained.Read(make([]byte, 1)); err == nil {
+		t.Fatalf("the rejected inbound connection received %d bytes", n)
+	} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		t.Fatal("the rejected inbound connection was never accepted before the deadline")
+	}
+	requireZero(t, len(s.handshakeSlots), "handshake slots after the rejected accept")
+	requireZero(t, s.connectedPeerCount(), "peers after the rejected accept")
+	must(t, drained.Close(), "close the rejected client conn")
+	s.startWG.Done()
+	requireReturned(t, closeDone, "Close")
+	starts.Wait()
+	requireZero(t, s.inFlightDialCount(), "in-flight dial reservations after Close")
+	t.Logf("registration race: %d of 16 dial workers registered before the cutoff", registered.Load())
+
+	requireClosedRejection(t, s.AnnounceTx(minimalValidTxBytes(t)), "CLOSED AnnounceTx")
+	requireClosedRejection(t, s.AnnounceBlock(blockBytes), "CLOSED AnnounceBlock")
+	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets(blockBytes), "CLOSED ConsumeAcceptedBlockDASets")
+	requireClosedRejection(t, s.Start(context.Background()), "CLOSED Start")
+	if s.startDialPeer("127.0.0.1:2") {
+		t.Fatal("CLOSED Service registered an outbound dial worker")
+	}
+	s.connectDiscoveredAddrs([]string{"127.0.0.1:19199"})
+	requireZero(t, s.inFlightDialCount(), "CLOSED discovered dial reservations")
+	// Synchronous internal callees inherit and never register a nested lease,
+	// so they behave identically after the drain; read-only queries stay valid.
+	must(t, s.consumeCompleteDASetIDs(nil), "CLOSED synchronous internal callee")
+	if s.Addr() == "" {
+		t.Fatal("CLOSED read-only Addr() returned empty")
+	}
+}
+
+// TestServiceWorkLifecycleCloseWaitsForPublicCallbacks parks each real public entry on a
+// producer, socket-write or DA-owner-lock barrier while Close runs, then observes the owners.
+func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
+	t.Run("producer barrier in AnnounceTx", func(t *testing.T) {
+		s := lifecycleService(t)
+		entered, release := make(chan struct{}), make(chan struct{})
+		s.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+			close(entered)
+			<-release
+			return node.RelayTxMetadata{Fee: consensus.Uint128FromU64(0), Size: len(b)}, nil
+		}
+		txBytes := minimalValidTxBytes(t)
+		_, txid, err := parseCanonicalTx(txBytes)
+		must(t, err, "parseCanonicalTx")
+		announce := make(chan error, 1)
+		go func() { announce <- s.AnnounceTx(txBytes) }()
+		<-entered
+		closeDone := lifecycleClose(s)
+		waitDraining(t, s)
+		requireStillBlocked(t, closeDone, "Close")
+		close(release)
+		requireReturned(t, closeDone, "Close")
+		must(t, <-announce, "pre-authorized AnnounceTx")
+		if _, ok := s.cfg.TxPool.Get(txid); !ok {
+			t.Fatal("pre-authorized AnnounceTx did not reach the real relay pool")
+		}
+	})
+
+	t.Run("socket write barrier in AnnounceBlock", func(t *testing.T) {
+		s := lifecycleService(t)
+		s.cfg.PeerRuntimeConfig.WriteDeadline = 0
+		local, remote := net.Pipe()
+		defer func() { _ = remote.Close() }()
+		gate := &lifecycleGateConn{Conn: local, entered: make(chan struct{}), release: make(chan struct{})}
+		p := &peer{conn: gate, service: s, state: node.PeerState{Addr: "lifecycle-write-peer"}}
+		s.peers[p.addr()] = p
+		received := lifecycleReadFrame(p, remote)
+		announce := make(chan error, 1)
+		go func() { announce <- s.AnnounceBlock(node.DevnetGenesisBlockBytes()) }()
+		<-gate.entered
+		// The broadcast already snapshotted its peer list, so removing the entry here
+		// leaves the in-flight write owned solely by the call: Close cannot shortcut it.
+		s.peersMu.Lock()
+		delete(s.peers, p.addr())
+		s.peersMu.Unlock()
+		closeDone := lifecycleClose(s)
+		waitDraining(t, s)
+		requireStillBlocked(t, closeDone, "Close")
+		close(gate.release)
+		requireReturned(t, closeDone, "Close")
+		must(t, <-announce, "pre-authorized AnnounceBlock")
+		frame := <-received
+		items, err := decodeInventoryVectors(frame.Payload)
+		if frame.Command != messageInv || err != nil || len(items) != 1 || items[0].Hash != node.DevnetGenesisBlockHash() {
+			t.Fatalf("socket owner received command=%q inventory=%+v err=%v", frame.Command, items, err)
+		}
+		must(t, remote.SetReadDeadline(time.Now().Add(lifecycleSettle)), "SetReadDeadline")
+		if n, err := remote.Read(make([]byte, 1)); err == nil {
+			t.Fatalf("socket owner received %d more bytes after Close returned", n)
+		}
+	})
+
+	t.Run("DA owner lock barrier in ConsumeAcceptedBlockDASets", func(t *testing.T) {
+		s := lifecycleService(t)
+		daID := daRelayTestID(0x7d)
+		blockBytes := stageCompleteDASet(t, s.daRelay, daID, "lifecycle", []byte("lifecycle-payload"))
+		s.daRelay.mu.Lock()
+		consume := make(chan error, 1)
+		go func() { consume <- s.ConsumeAcceptedBlockDASets(blockBytes) }()
+		// The Service is still OPEN, so the call cannot have been rejected: not
+		// returning here means it holds its lease and is parked on the DA owner lock.
+		select {
+		case err := <-consume:
+			t.Fatalf("ConsumeAcceptedBlockDASets returned early: %v", err)
+		case <-time.After(lifecycleSettle):
+		}
+		closeDone := lifecycleClose(s)
+		waitDraining(t, s)
+		requireStillBlocked(t, closeDone, "Close")
+		s.daRelay.mu.Unlock()
+		requireReturned(t, closeDone, "Close")
+		must(t, <-consume, "pre-authorized ConsumeAcceptedBlockDASets")
+		if lifecycleDASetPresent(s, daID) {
+			t.Fatal("pre-authorized DA consume did not reach the real DA state owner")
+		}
+	})
+}
+
+func lifecycleDASetPresent(s *Service, daID [32]byte) bool {
+	s.daRelay.mu.Lock()
+	defer s.daRelay.mu.Unlock()
+	_, ok := s.daRelay.sets[daID]
+	return ok
+}
+
+// TestServiceWorkLifecyclePeerWorkerInheritance runs a real peer loop and handler stack: one
+// authorized message finishes its publication while Close waits, and no further read begins.
+func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
+	s := lifecycleService(t)
+	s.cfg.PeerRuntimeConfig.ReadDeadline = 0
+	s.cfg.PeerRuntimeConfig.WriteDeadline = 0
+	local, remote := net.Pipe()
+	defer func() { _ = remote.Close() }()
+	p := &peer{conn: local, service: s, state: node.PeerState{Addr: "lifecycle-loop-peer"}}
+	must(t, s.cfg.PeerManager.AddPeer(&p.state), "AddPeer")
+	if !s.acquireWork() {
+		t.Fatal("OPEN peer worker was not registered")
+	}
+	runDone := make(chan error, 1)
+	go func() {
+		defer s.releaseWork()
+		runDone <- p.run(context.Background())
+	}()
+
+	// The write returns once the worker consumed the frame and nothing reads the
+	// reply yet, so the worker is provably parked inside the handler's publication
+	// when the drain is published. The loop context is never cancelled and the socket
+	// is never closed, so only the read-authorization observation stops this worker.
+	_, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr}))
+	must(t, err, "write authorized message")
+	closeDone := lifecycleClose(s)
+	waitDraining(t, s)
+	requireStillBlocked(t, closeDone, "Close")
+	if frame := <-lifecycleReadFrame(p, remote); frame.Command != messageAddr {
+		t.Fatalf("authorized message reply command=%q, want %q", frame.Command, messageAddr)
+	}
+	requireReturned(t, runDone, "peer worker")
+	requireReturned(t, closeDone, "Close")
+
+	// No next read was authorized: a further frame is never consumed.
+	must(t, remote.SetWriteDeadline(time.Now().Add(lifecycleSettle)), "SetWriteDeadline")
+	if _, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr})); err == nil {
+		t.Fatal("peer worker consumed a second frame after the drain was published")
+	}
+}
+
+// TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain proves the discovered-dial child
+// is waited for while OPEN, and a rejected dial leaves no goroutine, reservation or attempt.
+func TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain(t *testing.T) {
+	s := lifecycleService(t)
+	openAddr, drainAddr := "127.0.0.1:19181", "127.0.0.1:19182"
+	s.addrMgr.AddAddrs([]string{openAddr, drainAddr})
+	s.connectDiscoveredAddrs([]string{openAddr})
+	if attempts := lifecycleAddrAttempts(s, openAddr); attempts != 1 {
+		t.Fatalf("OPEN discovered dial attempts=%d, want 1", attempts)
+	}
+	// Close returns only after the discovered child released its lease, so the
+	// child's own reservation cleanup has already run.
+	requireReturned(t, lifecycleClose(s), "Close")
+	requireZero(t, s.inFlightDialCount(), "in-flight dial reservations after Close")
+
+	s.connectDiscoveredAddrs([]string{drainAddr})
+	requireZero(t, s.inFlightDialCount(), "rejected discovered dial reservations")
+	requireZero(t, lifecycleAddrAttempts(s, drainAddr), "rejected discovered dial attempts")
+}
+
+func lifecycleAddrAttempts(s *Service, addr string) int {
+	s.addrMgr.mu.Lock()
+	defer s.addrMgr.mu.Unlock()
+	return s.addrMgr.addrs[normalizeNetAddr(addr)].attempts
+}
+
+// lifecycleDeadlineConn records connection-deadline mutations that are still in
+// flight, so the test can prove no handshake child touches the connection after
+// performHandshake returned. Only non-zero deadlines — the interrupter always sets one —
+// are delayed and counted: delaying performHandshake's own reset-to-zero defer would let
+// the parent's own delay mask an unjoined interrupter instead of exposing it.
+type lifecycleDeadlineConn struct {
+	net.Conn
+	inFlight atomic.Int64
+	late     atomic.Int64
+	returned atomic.Bool
+}
+
+func (c *lifecycleDeadlineConn) SetDeadline(deadline time.Time) error {
+	if deadline.IsZero() {
+		return c.Conn.SetDeadline(deadline)
+	}
+	c.inFlight.Add(1)
+	defer c.inFlight.Add(-1)
+	if c.returned.Load() {
+		c.late.Add(1)
+	}
+	err := c.Conn.SetDeadline(deadline)
+	// Widen the window in which a non-joined interrupter would still be mutating the
+	// connection: with the reset defer undelayed, an unjoined interrupter is provably still
+	// inside this sleep when performHandshake returns, so the in-flight check fails.
+	time.Sleep(50 * time.Millisecond)
+	return err
+}
+
+// TestServiceWorkLifecycleFaultMatrix covers Table C: the real cancellation child exits before
+// performHandshake returns, and error, write-failure and no-publication exits release once.
+func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
+	t.Run("handshake cancellation child exits before return", func(t *testing.T) {
+		local, remote := net.Pipe()
+		defer func() { _ = remote.Close() }()
+		conn := &lifecycleDeadlineConn{Conn: local}
+		ctx, cancel := context.WithCancel(context.Background())
+		cfg := node.DefaultPeerRuntimeConfig("devnet", 8)
+		cfg.HandshakeTimeout = lifecycleWatchdog
+		handshakeDone := make(chan struct{})
+		go func() {
+			defer close(handshakeDone)
+			// The remote never answers, so only the cancellation child can
+			// unblock the handshake read.
+			_, err := performHandshake(ctx, conn, cfg, node.VersionPayloadV1{ProtocolVersion: ProtocolVersion},
+				node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
+			conn.returned.Store(true)
+			if err == nil {
+				t.Error("performHandshake returned nil error on a cancelled handshake")
+			}
+		}()
+		_, err := readFrameHeader(remote, networkMagic(cfg.Network), cfg.MaxMessageSize)
+		must(t, err, "read handshake version header")
+		cancel()
+		select {
+		case <-handshakeDone:
+		case <-time.After(lifecycleWatchdog):
+			t.Fatal("performHandshake did not return after cancellation")
+		}
+		requireZero(t, int(conn.inFlight.Load()), "deadline mutations in flight when performHandshake returned")
+		time.Sleep(lifecycleSettle)
+		requireZero(t, int(conn.late.Load()), "SetDeadline calls after performHandshake returned")
+	})
+
+	t.Run("error and no-publication exits release once", func(t *testing.T) {
+		s := lifecycleService(t)
+		if err := s.AnnounceBlock([]byte{0x00}); err == nil {
+			t.Fatal("AnnounceBlock(malformed) must preserve the parse error")
+		}
+		s.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
+			return node.RelayTxMetadata{}, fmt.Errorf("producer failure")
+		}
+		if err := s.AnnounceTx(minimalValidTxBytes(t)); err == nil {
+			t.Fatal("AnnounceTx must preserve the producer error")
+		}
+		// Socket-owner write-failure and no-publication rows: the first announcement writes
+		// and fails against a socket nobody reads, the deduplicated second never publishes.
+		s.cfg.PeerRuntimeConfig.WriteDeadline = time.Millisecond
+		local, remote := net.Pipe()
+		defer func() { _ = remote.Close() }()
+		var writes atomic.Int64
+		p := &peer{conn: &lifecycleCountingConn{Conn: local, writes: &writes}, service: s,
+			state: node.PeerState{Addr: "lifecycle-fault-peer"}}
+		s.peers[p.addr()] = p
+		must(t, s.AnnounceBlock(node.DevnetGenesisBlockBytes()), "AnnounceBlock over a failing socket")
+		if got := writes.Load(); got != 1 {
+			t.Fatalf("write attempts on the first announcement=%d, want 1", got)
+		}
+		must(t, s.AnnounceBlock(node.DevnetGenesisBlockBytes()), "deduplicated AnnounceBlock")
+		if got := writes.Load(); got != 1 {
+			t.Fatalf("write attempts after the no-publication return=%d, want 1", got)
+		}
+		// Every one of those exits released its lease exactly once: a leak
+		// strands Close past the watchdog, an extra release panics it.
+		requireReturned(t, lifecycleClose(s), "Close")
+	})
+}
+
+// TestServiceWorkLifecyclePanicRelease proves a native panic unwind releases the call lease
+// before propagating, so Close is not stranded; the only recover is this test's own frame.
+func TestServiceWorkLifecyclePanicRelease(t *testing.T) {
+	s := lifecycleService(t)
+	s.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
+		panic("lifecycle test panic")
+	}
+	panicked := false
+	func() {
+		defer func() { panicked = recover() != nil }()
+		_ = s.AnnounceTx(minimalValidTxBytes(t))
+	}()
+	if !panicked {
+		t.Fatal("AnnounceTx did not propagate the producer panic")
+	}
+	requireReturned(t, lifecycleClose(s), "Close after a panicking call")
+}
+
+// TestServiceWorkLifecycleConcurrentClose proves concurrent and repeated Close
+// calls join one teardown and all return only after it completes.
+func TestServiceWorkLifecycleConcurrentClose(t *testing.T) {
+	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
+	must(t, s.Start(context.Background()), "Start")
+	bound := s.Addr()
+	results := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		go func() { results <- s.Close() }()
+	}
+	for i := 0; i < 8; i++ {
+		requireReturned(t, results, "concurrent Close")
+	}
+	s.peersMu.RLock()
+	shared := s.closeDone
+	s.peersMu.RUnlock()
+	if shared == nil {
+		t.Fatal("no shared close completion was published")
+	}
+	select {
+	case <-shared:
+	default:
+		t.Fatal("the shared close completion is not published as complete")
+	}
+	must(t, s.Close(), "repeated Close")
+	// One teardown actually happened: the port is immediately rebindable.
+	rebind, err := net.Listen("tcp", bound)
+	must(t, err, fmt.Sprintf("port %q still bound after the shared teardown", bound))
+	_ = rebind.Close()
+}
+
+// TestServiceWorkLifecycleReadOnlyAfterClose proves read-only queries stay callable without
+// a lease and a retained callback rejects with the exact error and zero state/queue/send delta.
+func TestServiceWorkLifecycleReadOnlyAfterClose(t *testing.T) {
+	s := lifecycleService(t)
+	daID, snapshotID := daRelayTestID(0x7e), daRelayTestID(0x7f)
+	blockBytes := stageCompleteDASet(t, s.daRelay, daID, "lifecycle-readonly", []byte("readonly-payload"))
+	payload := []byte("snapshot-payload")
+	mustAddDACommit(t, s.daRelay, "lifecycle-snapshot",
+		daRelayTestCommitWithTxBytes(snapshotID, 1, []byte("commit-tx"), payload))
+	mustAddDAChunk(t, s.daRelay, "lifecycle-snapshot",
+		daRelayTestChunkWithTxBytes(snapshotID, 0, uint64(len(payload)), []byte("chunk-tx"), payload))
+	txBytes := minimalValidTxBytes(t)
+	_, txid, err := parseCanonicalTx(txBytes)
+	must(t, err, "parseCanonicalTx")
+	exitsBefore := s.PeerLifecycleExits()
+	requireReturned(t, lifecycleClose(s), "Close")
+
+	if s.Addr() == "" {
+		t.Fatal("Addr() after Close returned empty")
+	}
+	if got := s.PeerLifecycleExits(); got != exitsBefore {
+		t.Fatalf("PeerLifecycleExits after Close=%d, want %d", got, exitsBefore)
+	}
+	if got := s.CompleteDASetCandidates(1 << 20); len(got) != 1 {
+		t.Fatalf("defensive DA snapshot after Close returned %d candidates, want 1", len(got))
+	}
+	requireZero(t, s.connectedPeerCount(), "connectedPeerCount after Close")
+
+	requireClosedRejection(t, s.AnnounceTx(txBytes), "retained AnnounceTx callback")
+	requireClosedRejection(t, s.AnnounceBlock(blockBytes), "retained AnnounceBlock callback")
+	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets(blockBytes), "retained DA consume callback")
+	if _, ok := s.cfg.TxPool.Get(txid); ok {
+		t.Fatal("rejected AnnounceTx mutated the relay pool")
+	}
+	if !lifecycleDASetPresent(s, daID) {
+		t.Fatal("rejected DA consume mutated the DA state owner")
+	}
+	if s.blockSeen.Has(node.DevnetGenesisBlockHash()) {
+		t.Fatal("rejected AnnounceBlock mutated the block seen-set")
+	}
+}
+
+// TestServiceWorkLifecycleFreshServiceIndependent proves a closed Service never
+// revives and that a fresh Service owns an independent OPEN lifecycle.
+func TestServiceWorkLifecycleFreshServiceIndependent(t *testing.T) {
+	closedService := lifecycleService(t)
+	requireReturned(t, lifecycleClose(closedService), "Close")
+	requireClosedRejection(t, closedService.AnnounceTx(minimalValidTxBytes(t)), "closed AnnounceTx")
+	fresh := lifecycleService(t)
+	must(t, fresh.AnnounceTx(minimalValidTxBytes(t)), "fresh Service AnnounceTx")
+	must(t, fresh.AnnounceBlock(node.DevnetGenesisBlockBytes()), "fresh Service AnnounceBlock")
+	requireClosedRejection(t, closedService.AnnounceBlock(node.DevnetGenesisBlockBytes()), "closed AnnounceBlock")
+	requireReturned(t, lifecycleClose(fresh), "fresh Close")
+}

--- a/clients/go/node/p2p/service_work_lifecycle_test.go
+++ b/clients/go/node/p2p/service_work_lifecycle_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -13,8 +14,9 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
-// Service work lifecycle evidence. Barriers are channels and sockets; time-based
-// waits are only watchdogs and the negative window asserting Close stays blocked.
+// Service work lifecycle evidence. Barriers are channels and sockets; time-based waits are only watchdogs and the negative window asserting Close stays blocked.
+// Dead dial targets are structurally dead: no process can ever listen on TCP port 0, so "127.0.0.%d:0" dials fail immediately with no rebind window at all.
+// normalizeNetAddr rejects port 0, so the normalize-first surfaces (connectDiscoveredAddrs, addrMgr) use loopback port 1 — root-only to bind, and only 127.0.0.1:1 is ever dialed.
 const (
 	lifecycleWatchdog = 5 * time.Second
 	lifecycleSettle   = 100 * time.Millisecond
@@ -33,17 +35,6 @@ func lifecycleClose(s *Service) chan error {
 	return done
 }
 
-// deadAddr returns a loopback address that refuses connections: the
-// listener that owned the ephemeral port is closed before returning.
-func deadAddr(t *testing.T) string {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	must(t, err, "reserve dead port")
-	addr := l.Addr().String()
-	must(t, l.Close(), "release dead port")
-	return addr
-}
-
 func must(t *testing.T, err error, label string) {
 	t.Helper()
 	if err != nil {
@@ -58,8 +49,7 @@ func requireZero(t *testing.T, got int, label string) {
 	}
 }
 
-// requireStillBlocked asserts a registered lease still pins the operation. It is
-// parked on a barrier this test owns, so a return inside the window is a lost drain.
+// requireStillBlocked asserts a registered lease still pins the operation. It is parked on a barrier this test owns, so a return inside the window is a lost drain.
 func requireStillBlocked(t *testing.T, done <-chan error, label string) {
 	t.Helper()
 	select {
@@ -82,13 +72,7 @@ func requireReturned(t *testing.T, done <-chan error, label string) {
 // waitDraining blocks until Close published the non-OPEN state, so no later assertion can pass merely because Close had not started yet.
 func waitDraining(t *testing.T, s *Service) {
 	t.Helper()
-	deadline := time.Now().Add(lifecycleWatchdog)
-	for s.workAuthorized() {
-		if time.Now().After(deadline) {
-			t.Fatal("Close did not publish the non-OPEN state")
-		}
-		time.Sleep(time.Millisecond)
-	}
+	waitUntil(t, func() bool { return !s.workAuthorized() }, "Close publishing the non-OPEN state")
 }
 
 func requireClosedRejection(t *testing.T, err error, label string) {
@@ -98,48 +82,76 @@ func requireClosedRejection(t *testing.T, err error, label string) {
 	}
 }
 
-// lifecycleGateConn holds the first Write until the test releases it, parking a public call inside a real socket write while Close runs.
+// waitUntil polls cond until it holds, failing after the watchdog.
+func waitUntil(t *testing.T, cond func() bool, label string) {
+	t.Helper()
+	for deadline := time.Now().Add(lifecycleWatchdog); !cond(); {
+		if time.Now().After(deadline) {
+			t.Fatalf("%s did not happen before the watchdog", label)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// requireRejectedInbound dials the listener and requires the accepted socket to be closed without any spawned child writing its version frame first.
+func requireRejectedInbound(t *testing.T, s *Service, label string) {
+	t.Helper()
+	conn, err := net.Dial("tcp", s.Addr())
+	must(t, err, "dial "+label)
+	must(t, conn.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
+	if n, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatalf("%s: the rejected inbound connection received %d bytes", label, n)
+	} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		t.Fatalf("%s: the inbound connection was never rejected before the deadline", label)
+	}
+	must(t, conn.Close(), "close "+label)
+}
+
+// lifecycleGateConn optionally holds the first Write until the test releases it (entered/release non-nil), parking a call
+// inside a real socket write while Close runs; optionally counts every Write (writes non-nil) and every SetReadDeadline
+// made after postDrain is set — a drained worker must arm none.
 type lifecycleGateConn struct {
 	net.Conn
-	once    sync.Once
-	entered chan struct{}
-	release chan struct{}
+	once      sync.Once
+	entered   chan struct{}
+	release   chan struct{}
+	writes    *atomic.Int64
+	postDrain atomic.Bool
+	lateArms  atomic.Int64
 }
 
 func (c *lifecycleGateConn) Write(b []byte) (int, error) {
-	c.once.Do(func() {
-		close(c.entered)
-		<-c.release
-	})
+	if c.writes != nil {
+		c.writes.Add(1)
+	}
+	if c.entered != nil {
+		c.once.Do(func() {
+			close(c.entered)
+			<-c.release
+		})
+	}
 	return c.Conn.Write(b)
 }
 
-type lifecycleCountingConn struct {
-	net.Conn
-	writes *atomic.Int64
-}
-
-func (c *lifecycleCountingConn) Write(b []byte) (int, error) {
-	c.writes.Add(1)
-	return c.Conn.Write(b)
+func (c *lifecycleGateConn) SetReadDeadline(deadline time.Time) error {
+	if c.postDrain.Load() {
+		c.lateArms.Add(1)
+	}
+	return c.Conn.SetReadDeadline(deadline)
 }
 
 func lifecycleReadFrame(p *peer, r net.Conn) chan message {
-	magic := networkMagic(p.service.cfg.PeerRuntimeConfig.Network)
-	maxSize := p.service.cfg.PeerRuntimeConfig.MaxMessageSize
+	cfg := p.service.cfg.PeerRuntimeConfig
 	out := make(chan message, 1)
 	go func() {
-		header, err := readFrameHeader(r, magic, maxSize)
-		if err != nil {
-			out <- message{}
-			return
+		var frame message
+		header, err := readFrameHeader(r, networkMagic(cfg.Network), cfg.MaxMessageSize)
+		if err == nil {
+			if payload, perr := readPayloadWithChecksum(r, header.Size, header.Checksum); perr == nil {
+				frame = message{Command: header.Command, Payload: payload}
+			}
 		}
-		payload, err := readPayloadWithChecksum(r, header.Size, header.Checksum)
-		if err != nil {
-			out <- message{}
-			return
-		}
-		out <- message{Command: header.Command, Payload: payload}
+		out <- frame
 	}()
 	return out
 }
@@ -150,16 +162,27 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	// Raised before Start so the accept-path child below stays parked in its read.
 	s.cfg.PeerRuntimeConfig.HandshakeTimeout = lifecycleWatchdog
 	must(t, s.Start(context.Background()), "Start")
-	txBytes := minimalValidTxBytes(t)
 	blockBytes := node.DevnetGenesisBlockBytes()
-	must(t, s.AnnounceTx(txBytes), "OPEN AnnounceTx")
+	must(t, s.AnnounceTx(minimalValidTxBytes(t)), "OPEN AnnounceTx")
 	must(t, s.AnnounceBlock(blockBytes), "OPEN AnnounceBlock")
 	must(t, s.ConsumeAcceptedBlockDASets(blockBytes), "OPEN ConsumeAcceptedBlockDASets")
 	must(t, s.consumeCompleteDASetIDs(nil), "OPEN synchronous internal callee")
-	if !s.startDialPeer(deadAddr(t)) {
+	// Registered-then-rejected register paths release the lease and add no reservation; a leaked lease would strand the final Close past its watchdog.
+	if !s.trackDialPeer("127.0.0.21:0") || !s.trackDialPeer("127.0.0.22:1") {
+		t.Fatal("pre-insert dial reservations")
+	}
+	if s.startDialPeer("127.0.0.21:0") {
+		t.Fatal("duplicate outbound dial was registered")
+	}
+	s.connectDiscoveredAddrs([]string{"127.0.0.22:1"})
+	if got := s.inFlightDialCount(); got != 2 {
+		t.Fatalf("rejected register paths left %d reservations, want the 2 pre-inserted", got)
+	}
+	s.finishDialPeer("127.0.0.21:0")
+	s.finishDialPeer("127.0.0.22:1")
+	if !s.startDialPeer("127.0.0.1:0") {
 		t.Fatal("OPEN outbound dial was not registered")
 	}
-
 	// Accept path in OPEN: the gate registers the accepted worker before it mutates a handshake slot or spawns the child that writes this frame.
 	open, err := net.Dial("tcp", s.Addr())
 	must(t, err, "dial the OPEN listener")
@@ -172,70 +195,49 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	}
 	// Closing the client fails that handshake; the child releases its one slot.
 	must(t, open.Close(), "close the OPEN client conn")
-	for deadline := time.Now().Add(lifecycleWatchdog); len(s.handshakeSlots) != 0; {
-		if time.Now().After(deadline) {
-			t.Fatal("the accepted child did not release its handshake slot")
-		}
-		time.Sleep(time.Millisecond)
+	waitUntil(t, func() bool { return len(s.handshakeSlots) == 0 }, "the accepted child's handshake-slot release")
+	// Slot-saturated accept: the worker lease registered before the slot check is released on rejection, or the final Close strands past its watchdog.
+	for i := 0; i < cap(s.handshakeSlots); i++ {
+		s.handshakeSlots <- struct{}{}
 	}
-
-	// Registration racing the first Close: the only admissible outcomes are
-	// registered-and-waited or rejected-without-Done. A third outcome (a lease added after
-	// Close began waiting) panics the WaitGroup, strands Close, or leaks a reservation.
-	var registered atomic.Int64
+	requireRejectedInbound(t, s, "the slot-saturated listener")
+	for i := 0; i < cap(s.handshakeSlots); i++ {
+		<-s.handshakeSlots
+	}
+	// Registration racing the first Close: the only admissible outcomes are registered-and-waited or rejected-without-Done.
+	// A third outcome (a lease added after Close began waiting) panics the WaitGroup, strands Close, or leaks a reservation.
 	var starts sync.WaitGroup
 	for i := 0; i < 16; i++ {
-		addr := deadAddr(t)
+		addr := fmt.Sprintf("127.0.0.%d:0", 100+i)
 		starts.Add(1)
-		go func() {
-			defer starts.Done()
-			if s.startDialPeer(addr) {
-				registered.Add(1)
-			}
-		}()
+		go func() { defer starts.Done(); s.startDialPeer(addr) }()
 	}
-	// startWG parks Close between its registration cutoff and the listener teardown (phase 2 waits on startWG, only
-	// phase 3 closes the listener), so the accept loop is still accepting while the Service is no longer OPEN.
+	// startWG parks Close between its registration cutoff and the listener teardown (phase 2 waits on startWG, only phase 3 closes the listener), so the accept loop is still accepting while the Service is no longer OPEN.
 	s.startWG.Add(1)
 	closeDone := lifecycleClose(s)
 	waitDraining(t, s)
-	drained, err := net.Dial("tcp", s.Addr())
-	must(t, err, "dial the draining listener")
-	must(t, drained.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
-	// The gate closed the socket with no child behind it: a spawned child would have written its version frame here first.
-	if n, err := drained.Read(make([]byte, 1)); err == nil {
-		t.Fatalf("the rejected inbound connection received %d bytes", n)
-	} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
-		t.Fatal("the rejected inbound connection was never accepted before the deadline")
-	}
+	requireRejectedInbound(t, s, "the draining listener")
 	requireZero(t, len(s.handshakeSlots), "handshake slots after the rejected accept")
 	requireZero(t, s.connectedPeerCount(), "peers after the rejected accept")
-	must(t, drained.Close(), "close the rejected client conn")
 	s.startWG.Done()
 	requireReturned(t, closeDone, "Close")
 	starts.Wait()
 	requireZero(t, s.inFlightDialCount(), "in-flight dial reservations after Close")
-	t.Logf("registration race: %d of 16 dial workers registered before the cutoff", registered.Load())
-
-	requireClosedRejection(t, s.AnnounceTx(minimalValidTxBytes(t)), "CLOSED AnnounceTx")
-	requireClosedRejection(t, s.AnnounceBlock(blockBytes), "CLOSED AnnounceBlock")
-	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets(blockBytes), "CLOSED ConsumeAcceptedBlockDASets")
+	// Malformed bytes after Close pin the priority row: the registration gate precedes parsing, so the rejection is the exact closed error, never a parse error.
+	requireClosedRejection(t, s.AnnounceTx([]byte{0x00}), "CLOSED malformed AnnounceTx")
+	requireClosedRejection(t, s.AnnounceBlock([]byte{0x00}), "CLOSED malformed AnnounceBlock")
+	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets([]byte{0x00}), "CLOSED malformed ConsumeAcceptedBlockDASets")
 	requireClosedRejection(t, s.Start(context.Background()), "CLOSED Start")
-	if s.startDialPeer(deadAddr(t)) {
+	if s.startDialPeer("127.0.0.30:0") {
 		t.Fatal("CLOSED Service registered an outbound dial worker")
 	}
-	s.connectDiscoveredAddrs([]string{deadAddr(t)})
+	s.connectDiscoveredAddrs([]string{"127.0.0.31:1"})
 	requireZero(t, s.inFlightDialCount(), "CLOSED discovered dial reservations")
-	// Synchronous internal callees inherit and never register a nested lease,
-	// so they behave identically after the drain; read-only queries stay valid.
+	// Synchronous internal callees inherit and never register a nested lease, so they behave identically after the drain.
 	must(t, s.consumeCompleteDASetIDs(nil), "CLOSED synchronous internal callee")
-	if s.Addr() == "" {
-		t.Fatal("CLOSED read-only Addr() returned empty")
-	}
 }
 
-// TestServiceWorkLifecycleCloseWaitsForPublicCallbacks parks each real public entry on a
-// producer, socket-write or DA-owner-lock barrier while Close runs, then observes the owners.
+// TestServiceWorkLifecycleCloseWaitsForPublicCallbacks parks each real public entry on a producer, socket-write or DA-owner-lock barrier while Close runs, then observes the owners.
 func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
 	t.Run("producer barrier in AnnounceTx", func(t *testing.T) {
 		s := lifecycleService(t)
@@ -261,7 +263,6 @@ func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
 			t.Fatal("pre-authorized AnnounceTx did not reach the real relay pool")
 		}
 	})
-
 	t.Run("socket write barrier in AnnounceBlock", func(t *testing.T) {
 		s := lifecycleService(t)
 		s.cfg.PeerRuntimeConfig.WriteDeadline = 0
@@ -274,8 +275,7 @@ func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
 		announce := make(chan error, 1)
 		go func() { announce <- s.AnnounceBlock(node.DevnetGenesisBlockBytes()) }()
 		<-gate.entered
-		// The broadcast already snapshotted its peer list, so removing the entry here
-		// leaves the in-flight write owned solely by the call: Close cannot shortcut it.
+		// The broadcast already snapshotted its peer list, so removing the entry here leaves the in-flight write owned solely by the call: Close cannot shortcut it.
 		s.peersMu.Lock()
 		delete(s.peers, p.addr())
 		s.peersMu.Unlock()
@@ -295,7 +295,6 @@ func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
 			t.Fatalf("socket owner received %d more bytes after Close returned", n)
 		}
 	})
-
 	t.Run("DA owner lock barrier in ConsumeAcceptedBlockDASets", func(t *testing.T) {
 		s := lifecycleService(t)
 		daID := daRelayTestID(0x7d)
@@ -303,8 +302,7 @@ func TestServiceWorkLifecycleCloseWaitsForPublicCallbacks(t *testing.T) {
 		s.daRelay.mu.Lock()
 		consume := make(chan error, 1)
 		go func() { consume <- s.ConsumeAcceptedBlockDASets(blockBytes) }()
-		// The Service is still OPEN, so the call cannot have been rejected: not
-		// returning here means it holds its lease and is parked on the DA owner lock.
+		// The Service is still OPEN, so the call cannot have been rejected: not returning here means it holds its lease and is parked on the DA owner lock.
 		select {
 		case err := <-consume:
 			t.Fatalf("ConsumeAcceptedBlockDASets returned early: %v", err)
@@ -329,63 +327,77 @@ func lifecycleDASetPresent(s *Service, daID [32]byte) bool {
 	return ok
 }
 
-// TestServiceWorkLifecyclePeerWorkerInheritance runs a real peer loop and handler stack: one
-// authorized message finishes its publication while Close waits, and no further read begins.
+// TestServiceWorkLifecyclePeerWorkerInheritance runs a real peer loop and handler stack: one authorized message finishes its publication
+// and its owed compact fallback while Close waits, and after the drain the worker arms no read deadline and starts no further read.
 func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 	s := lifecycleService(t)
 	s.cfg.PeerRuntimeConfig.ReadDeadline = 0
 	s.cfg.PeerRuntimeConfig.WriteDeadline = 0
 	local, remote := net.Pipe()
 	defer func() { _ = remote.Close() }()
-	p := &peer{conn: local, service: s, state: node.PeerState{Addr: "lifecycle-loop-peer"}}
+	gate := &lifecycleGateConn{Conn: local, entered: make(chan struct{}), release: make(chan struct{})}
+	p := &peer{conn: gate, service: s, state: node.PeerState{Addr: "lifecycle-loop-peer"}}
 	must(t, s.cfg.PeerManager.AddPeer(&p.state), "AddPeer")
 	if !s.acquireWork() {
 		t.Fatal("OPEN peer worker was not registered")
 	}
 	runDone := make(chan error, 1)
-	go func() {
-		defer s.releaseWork()
-		runDone <- p.run(context.Background())
-	}()
-
-	// The write returns once the worker consumed the frame and nothing reads the reply yet, so the worker is provably
-	// parked inside the handler's publication when the drain is published. The loop context is never cancelled and the
-	// socket is never closed, so only the read-authorization observation stops this worker.
+	go func() { defer s.releaseWork(); runDone <- p.run(context.Background()) }()
+	// The gate parks the worker inside its reply write, past every deadline arm of this iteration. The loop
+	// context is never cancelled and the socket is never closed, so only the read-authorization gate stops it.
 	_, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr}))
 	must(t, err, "write authorized message")
+	<-gate.entered
+	// An already-expired compact outstanding staged while the worker is parked is owed exactly one getdata fallback.
+	fallbackHash := node.DevnetGenesisBlockHash()
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: fallbackHash, BlockTxnPayloadCap: 1, ExpiresAt: time.Unix(1, 0)})
 	closeDone := lifecycleClose(s)
 	waitDraining(t, s)
 	requireStillBlocked(t, closeDone, "Close")
+	gate.postDrain.Store(true)
+	must(t, remote.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
+	close(gate.release)
 	if frame := <-lifecycleReadFrame(p, remote); frame.Command != messageAddr {
 		t.Fatalf("authorized message reply command=%q, want %q", frame.Command, messageAddr)
 	}
+	// The owed fallback is still delivered after the drain was published: the guard sits between the fallback flush and the next deadline arm, never above the flush.
+	fallback := <-lifecycleReadFrame(p, remote)
+	if fallback.Command != messageGetData || !bytes.Equal(fallback.Payload, append([]byte{MSG_BLOCK}, fallbackHash[:]...)) {
+		t.Fatalf("owed compact fallback command=%q payload=%x", fallback.Command, fallback.Payload)
+	}
 	requireReturned(t, runDone, "peer worker")
 	requireReturned(t, closeDone, "Close")
-
-	// No next read was authorized: a further frame is never consumed.
-	must(t, remote.SetWriteDeadline(time.Now().Add(lifecycleSettle)), "SetWriteDeadline")
-	if _, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr})); err == nil {
-		t.Fatal("peer worker consumed a second frame after the drain was published")
-	}
+	// Every read attempt in the loop arms the deadline first, so zero post-drain arms plus the worker's exit prove no further read began after the drain was published.
+	requireZero(t, int(gate.lateArms.Load()), "post-drain read-deadline arms on the worker conn")
 }
 
-// TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain proves the discovered-dial child
-// is waited for while OPEN, and a rejected dial leaves no goroutine, reservation or attempt.
+// TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain proves the discovered-dial child is waited for while OPEN, and that
+// while Close is provably still in flight a concurrent discovered burst leaves no attempt, no reservation and no dial child.
 func TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain(t *testing.T) {
 	s := lifecycleService(t)
-	openAddr, drainAddr := deadAddr(t), deadAddr(t)
+	openAddr, drainAddr := "127.0.0.1:1", "127.0.0.2:1"
 	s.addrMgr.AddAddrs([]string{openAddr, drainAddr})
 	s.connectDiscoveredAddrs([]string{openAddr})
 	if attempts := lifecycleAddrAttempts(s, openAddr); attempts != 1 {
 		t.Fatalf("OPEN discovered dial attempts=%d, want 1", attempts)
 	}
-	// Close returns only after the discovered child released its lease, so the child's own reservation cleanup has already run.
-	requireReturned(t, lifecycleClose(s), "Close")
-	requireZero(t, s.inFlightDialCount(), "in-flight dial reservations after Close")
-
-	s.connectDiscoveredAddrs([]string{drainAddr})
-	requireZero(t, s.inFlightDialCount(), "rejected discovered dial reservations")
-	requireZero(t, lifecycleAddrAttempts(s, drainAddr), "rejected discovered dial attempts")
+	// The OPEN child's own cleanup releases its reservation before any Close runs.
+	waitUntil(t, func() bool { return s.inFlightDialCount() == 0 }, "the OPEN discovered dial reservation release")
+	// Park Close in phase 2: every rejection below happens while the drain is published and the teardown is demonstrably unfinished, not merely after it.
+	s.startWG.Add(1)
+	closeDone := lifecycleClose(s)
+	waitDraining(t, s)
+	var burst sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		burst.Add(1)
+		go func() { defer burst.Done(); s.connectDiscoveredAddrs([]string{drainAddr}) }()
+	}
+	burst.Wait()
+	requireStillBlocked(t, closeDone, "Close")
+	requireZero(t, lifecycleAddrAttempts(s, drainAddr), "draining discovered dial attempts")
+	requireZero(t, s.inFlightDialCount(), "draining discovered dial reservations")
+	s.startWG.Done()
+	requireReturned(t, closeDone, "Close")
 }
 
 func lifecycleAddrAttempts(s *Service, addr string) int {
@@ -395,9 +407,8 @@ func lifecycleAddrAttempts(s *Service, addr string) int {
 }
 
 // lifecycleDeadlineConn records connection-deadline mutations that are still in flight, so the test can prove no
-// handshake child touches the connection after performHandshake returned. Only non-zero deadlines — the interrupter
-// always sets one — are delayed and counted: delaying performHandshake's own reset-to-zero defer would let the
-// parent's own delay mask an unjoined interrupter instead of exposing it.
+// handshake child touches the connection after performHandshake returned. Only non-zero deadlines — the interrupter always
+// sets one — are delayed and counted: delaying performHandshake's own reset-to-zero defer would let the parent's own delay mask an unjoined interrupter instead of exposing it.
 type lifecycleDeadlineConn struct {
 	net.Conn
 	inFlight atomic.Int64
@@ -415,15 +426,13 @@ func (c *lifecycleDeadlineConn) SetDeadline(deadline time.Time) error {
 		c.late.Add(1)
 	}
 	err := c.Conn.SetDeadline(deadline)
-	// Widen the window in which a non-joined interrupter would still be mutating the
-	// connection: with the reset defer undelayed, an unjoined interrupter is provably still
-	// inside this sleep when performHandshake returns, so the in-flight check fails.
+	// Widen the window in which a non-joined interrupter would still be mutating the connection: with the reset defer
+	// undelayed, an unjoined interrupter is provably still inside this sleep when performHandshake returns, so the in-flight check fails.
 	time.Sleep(50 * time.Millisecond)
 	return err
 }
 
-// TestServiceWorkLifecycleFaultMatrix covers Table C: the real cancellation child exits before
-// performHandshake returns, and error, write-failure and no-publication exits release once.
+// TestServiceWorkLifecycleFaultMatrix covers Table C: the real cancellation child exits before performHandshake returns, and error, write-failure and no-publication exits release once.
 func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 	t.Run("handshake cancellation child exits before return", func(t *testing.T) {
 		local, remote := net.Pipe()
@@ -436,8 +445,7 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 		go func() {
 			defer close(handshakeDone)
 			// The remote never answers, so only the cancellation child can unblock the handshake read.
-			_, err := performHandshake(ctx, conn, cfg, node.VersionPayloadV1{ProtocolVersion: ProtocolVersion},
-				node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
+			_, err := performHandshake(ctx, conn, cfg, node.VersionPayloadV1{ProtocolVersion: ProtocolVersion}, node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
 			conn.returned.Store(true)
 			if err == nil {
 				t.Error("performHandshake returned nil error on a cancelled handshake")
@@ -455,7 +463,6 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 		time.Sleep(lifecycleSettle)
 		requireZero(t, int(conn.late.Load()), "SetDeadline calls after performHandshake returned")
 	})
-
 	t.Run("error and no-publication exits release once", func(t *testing.T) {
 		s := lifecycleService(t)
 		if err := s.AnnounceBlock([]byte{0x00}); err == nil {
@@ -467,14 +474,12 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 		if err := s.AnnounceTx(minimalValidTxBytes(t)); err == nil {
 			t.Fatal("AnnounceTx must preserve the producer error")
 		}
-		// Socket-owner write-failure and no-publication rows: the first announcement writes
-		// and fails against a socket nobody reads, the deduplicated second never publishes.
+		// Socket-owner write-failure and no-publication rows: the first announcement writes and fails against a socket nobody reads, the deduplicated second never publishes.
 		s.cfg.PeerRuntimeConfig.WriteDeadline = time.Millisecond
 		local, remote := net.Pipe()
 		defer func() { _ = remote.Close() }()
 		var writes atomic.Int64
-		p := &peer{conn: &lifecycleCountingConn{Conn: local, writes: &writes}, service: s,
-			state: node.PeerState{Addr: "lifecycle-fault-peer"}}
+		p := &peer{conn: &lifecycleGateConn{Conn: local, writes: &writes}, service: s, state: node.PeerState{Addr: "lifecycle-fault-peer"}}
 		s.peers[p.addr()] = p
 		must(t, s.AnnounceBlock(node.DevnetGenesisBlockBytes()), "AnnounceBlock over a failing socket")
 		if got := writes.Load(); got != 1 {
@@ -489,13 +494,10 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 	})
 }
 
-// TestServiceWorkLifecyclePanicRelease proves a native panic unwind releases the call lease
-// before propagating, so Close is not stranded; the only recover is this test's own frame.
+// TestServiceWorkLifecyclePanicRelease proves a native panic unwind releases the call lease before propagating, so Close is not stranded; the only recover is this test's own frame.
 func TestServiceWorkLifecyclePanicRelease(t *testing.T) {
 	s := lifecycleService(t)
-	s.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
-		panic("lifecycle test panic")
-	}
+	s.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) { panic("lifecycle test panic") }
 	panicked := false
 	func() {
 		defer func() { panicked = recover() != nil }()
@@ -507,25 +509,30 @@ func TestServiceWorkLifecyclePanicRelease(t *testing.T) {
 	requireReturned(t, lifecycleClose(s), "Close after a panicking call")
 }
 
-// TestServiceWorkLifecycleConcurrentClose proves concurrent and repeated Close
-// calls join one teardown and all return only after it completes.
+// TestServiceWorkLifecycleConcurrentClose parks the owning Close in phase 2 and proves later Close calls join that one
+// teardown: every joiner stays parked on the shared completion while the teardown is demonstrably unfinished, and
+// exactly one teardown runs.
 func TestServiceWorkLifecycleConcurrentClose(t *testing.T) {
 	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
 	must(t, s.Start(context.Background()), "Start")
 	bound := s.Addr()
-	results := make(chan error, 8)
-	for i := 0; i < 8; i++ {
-		go func() { results <- s.Close() }()
+	s.startWG.Add(1)
+	closes := []chan error{lifecycleClose(s)}
+	waitDraining(t, s)
+	for i := 0; i < 4; i++ {
+		closes = append(closes, lifecycleClose(s))
 	}
-	for i := 0; i < 8; i++ {
-		requireReturned(t, results, "concurrent Close")
+	for i, done := range closes {
+		requireStillBlocked(t, done, fmt.Sprintf("Close %d", i))
+	}
+	s.startWG.Done()
+	for i, done := range closes {
+		requireReturned(t, done, fmt.Sprintf("Close %d", i))
 	}
 	s.peersMu.RLock()
 	shared := s.closeDone
 	s.peersMu.RUnlock()
-	if shared == nil {
-		t.Fatal("no shared close completion was published")
-	}
+	// A nil shared channel is never ready, so this also fails when no completion was published.
 	select {
 	case <-shared:
 	default:
@@ -538,23 +545,19 @@ func TestServiceWorkLifecycleConcurrentClose(t *testing.T) {
 	_ = rebind.Close()
 }
 
-// TestServiceWorkLifecycleReadOnlyAfterClose proves read-only queries stay callable without
-// a lease and a retained callback rejects with the exact error and zero state/queue/send delta.
+// TestServiceWorkLifecycleReadOnlyAfterClose proves read-only queries stay callable without a lease and a retained callback rejects with the exact error and zero state/queue/send delta.
 func TestServiceWorkLifecycleReadOnlyAfterClose(t *testing.T) {
 	s := lifecycleService(t)
 	daID, snapshotID := daRelayTestID(0x7e), daRelayTestID(0x7f)
 	blockBytes := stageCompleteDASet(t, s.daRelay, daID, "lifecycle-readonly", []byte("readonly-payload"))
 	payload := []byte("snapshot-payload")
-	mustAddDACommit(t, s.daRelay, "lifecycle-snapshot",
-		daRelayTestCommitWithTxBytes(snapshotID, 1, []byte("commit-tx"), payload))
-	mustAddDAChunk(t, s.daRelay, "lifecycle-snapshot",
-		daRelayTestChunkWithTxBytes(snapshotID, 0, uint64(len(payload)), []byte("chunk-tx"), payload))
+	mustAddDACommit(t, s.daRelay, "lifecycle-snapshot", daRelayTestCommitWithTxBytes(snapshotID, 1, []byte("commit-tx"), payload))
+	mustAddDAChunk(t, s.daRelay, "lifecycle-snapshot", daRelayTestChunkWithTxBytes(snapshotID, 0, uint64(len(payload)), []byte("chunk-tx"), payload))
 	txBytes := minimalValidTxBytes(t)
 	_, txid, err := parseCanonicalTx(txBytes)
 	must(t, err, "parseCanonicalTx")
 	exitsBefore := s.PeerLifecycleExits()
 	requireReturned(t, lifecycleClose(s), "Close")
-
 	if s.Addr() == "" {
 		t.Fatal("Addr() after Close returned empty")
 	}
@@ -565,7 +568,6 @@ func TestServiceWorkLifecycleReadOnlyAfterClose(t *testing.T) {
 		t.Fatalf("defensive DA snapshot after Close returned %d candidates, want 1", len(got))
 	}
 	requireZero(t, s.connectedPeerCount(), "connectedPeerCount after Close")
-
 	requireClosedRejection(t, s.AnnounceTx(txBytes), "retained AnnounceTx callback")
 	requireClosedRejection(t, s.AnnounceBlock(blockBytes), "retained AnnounceBlock callback")
 	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets(blockBytes), "retained DA consume callback")
@@ -580,15 +582,13 @@ func TestServiceWorkLifecycleReadOnlyAfterClose(t *testing.T) {
 	}
 }
 
-// TestServiceWorkLifecycleFreshServiceIndependent proves a closed Service never
-// revives and that a fresh Service owns an independent OPEN lifecycle.
+// TestServiceWorkLifecycleFreshServiceIndependent proves a closed Service never revives and that a fresh Service owns an independent OPEN lifecycle.
 func TestServiceWorkLifecycleFreshServiceIndependent(t *testing.T) {
 	closedService := lifecycleService(t)
 	requireReturned(t, lifecycleClose(closedService), "Close")
 	requireClosedRejection(t, closedService.AnnounceTx(minimalValidTxBytes(t)), "closed AnnounceTx")
 	fresh := lifecycleService(t)
 	must(t, fresh.AnnounceTx(minimalValidTxBytes(t)), "fresh Service AnnounceTx")
-	must(t, fresh.AnnounceBlock(node.DevnetGenesisBlockBytes()), "fresh Service AnnounceBlock")
 	requireClosedRejection(t, closedService.AnnounceBlock(node.DevnetGenesisBlockBytes()), "closed AnnounceBlock")
 	requireReturned(t, lifecycleClose(fresh), "fresh Close")
 }

--- a/clients/go/node/p2p/service_work_lifecycle_test.go
+++ b/clients/go/node/p2p/service_work_lifecycle_test.go
@@ -33,6 +33,17 @@ func lifecycleClose(s *Service) chan error {
 	return done
 }
 
+// deadAddr returns a loopback address that refuses connections: the
+// listener that owned the ephemeral port is closed before returning.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	must(t, err, "reserve dead port")
+	addr := l.Addr().String()
+	must(t, l.Close(), "release dead port")
+	return addr
+}
+
 func must(t *testing.T, err error, label string) {
 	t.Helper()
 	if err != nil {
@@ -68,8 +79,7 @@ func requireReturned(t *testing.T, done <-chan error, label string) {
 	}
 }
 
-// waitDraining blocks until Close published the non-OPEN state, so no later
-// assertion can pass merely because Close had not started yet.
+// waitDraining blocks until Close published the non-OPEN state, so no later assertion can pass merely because Close had not started yet.
 func waitDraining(t *testing.T, s *Service) {
 	t.Helper()
 	deadline := time.Now().Add(lifecycleWatchdog)
@@ -88,8 +98,7 @@ func requireClosedRejection(t *testing.T, err error, label string) {
 	}
 }
 
-// lifecycleGateConn holds the first Write until the test releases it, parking a
-// public call inside a real socket write while Close runs.
+// lifecycleGateConn holds the first Write until the test releases it, parking a public call inside a real socket write while Close runs.
 type lifecycleGateConn struct {
 	net.Conn
 	once    sync.Once
@@ -135,8 +144,7 @@ func lifecycleReadFrame(p *peer, r net.Conn) chan message {
 	return out
 }
 
-// TestServiceWorkLifecycleEntryMatrix covers every Table A entry in OPEN and in
-// DRAINING/CLOSED, plus the registration-versus-Close race.
+// TestServiceWorkLifecycleEntryMatrix covers every Table A entry in OPEN and in DRAINING/CLOSED, plus the registration-versus-Close race.
 func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	s := newTestHarness(t, 0, "127.0.0.1:0", nil).service
 	// Raised before Start so the accept-path child below stays parked in its read.
@@ -148,12 +156,11 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	must(t, s.AnnounceBlock(blockBytes), "OPEN AnnounceBlock")
 	must(t, s.ConsumeAcceptedBlockDASets(blockBytes), "OPEN ConsumeAcceptedBlockDASets")
 	must(t, s.consumeCompleteDASetIDs(nil), "OPEN synchronous internal callee")
-	if !s.startDialPeer("127.0.0.1:1") {
+	if !s.startDialPeer(deadAddr(t)) {
 		t.Fatal("OPEN outbound dial was not registered")
 	}
 
-	// Accept path in OPEN: the gate registers the accepted worker before it
-	// mutates a handshake slot or spawns the child that writes this frame.
+	// Accept path in OPEN: the gate registers the accepted worker before it mutates a handshake slot or spawns the child that writes this frame.
 	open, err := net.Dial("tcp", s.Addr())
 	must(t, err, "dial the OPEN listener")
 	must(t, open.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
@@ -178,7 +185,7 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	var registered atomic.Int64
 	var starts sync.WaitGroup
 	for i := 0; i < 16; i++ {
-		addr := fmt.Sprintf("127.0.0.1:%d", 19200+i)
+		addr := deadAddr(t)
 		starts.Add(1)
 		go func() {
 			defer starts.Done()
@@ -187,17 +194,15 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 			}
 		}()
 	}
-	// startWG parks Close between its registration cutoff and the listener teardown
-	// (phase 2 waits on startWG, only phase 3 closes the listener), so the accept
-	// loop is still accepting while the Service is no longer OPEN.
+	// startWG parks Close between its registration cutoff and the listener teardown (phase 2 waits on startWG, only
+	// phase 3 closes the listener), so the accept loop is still accepting while the Service is no longer OPEN.
 	s.startWG.Add(1)
 	closeDone := lifecycleClose(s)
 	waitDraining(t, s)
 	drained, err := net.Dial("tcp", s.Addr())
 	must(t, err, "dial the draining listener")
 	must(t, drained.SetReadDeadline(time.Now().Add(lifecycleWatchdog)), "SetReadDeadline")
-	// The gate closed the socket with no child behind it: a spawned child would have
-	// written its version frame here first.
+	// The gate closed the socket with no child behind it: a spawned child would have written its version frame here first.
 	if n, err := drained.Read(make([]byte, 1)); err == nil {
 		t.Fatalf("the rejected inbound connection received %d bytes", n)
 	} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
@@ -216,10 +221,10 @@ func TestServiceWorkLifecycleEntryMatrix(t *testing.T) {
 	requireClosedRejection(t, s.AnnounceBlock(blockBytes), "CLOSED AnnounceBlock")
 	requireClosedRejection(t, s.ConsumeAcceptedBlockDASets(blockBytes), "CLOSED ConsumeAcceptedBlockDASets")
 	requireClosedRejection(t, s.Start(context.Background()), "CLOSED Start")
-	if s.startDialPeer("127.0.0.1:2") {
+	if s.startDialPeer(deadAddr(t)) {
 		t.Fatal("CLOSED Service registered an outbound dial worker")
 	}
-	s.connectDiscoveredAddrs([]string{"127.0.0.1:19199"})
+	s.connectDiscoveredAddrs([]string{deadAddr(t)})
 	requireZero(t, s.inFlightDialCount(), "CLOSED discovered dial reservations")
 	// Synchronous internal callees inherit and never register a nested lease,
 	// so they behave identically after the drain; read-only queries stay valid.
@@ -343,10 +348,9 @@ func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 		runDone <- p.run(context.Background())
 	}()
 
-	// The write returns once the worker consumed the frame and nothing reads the
-	// reply yet, so the worker is provably parked inside the handler's publication
-	// when the drain is published. The loop context is never cancelled and the socket
-	// is never closed, so only the read-authorization observation stops this worker.
+	// The write returns once the worker consumed the frame and nothing reads the reply yet, so the worker is provably
+	// parked inside the handler's publication when the drain is published. The loop context is never cancelled and the
+	// socket is never closed, so only the read-authorization observation stops this worker.
 	_, err := remote.Write(mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetAddr}))
 	must(t, err, "write authorized message")
 	closeDone := lifecycleClose(s)
@@ -369,14 +373,13 @@ func TestServiceWorkLifecyclePeerWorkerInheritance(t *testing.T) {
 // is waited for while OPEN, and a rejected dial leaves no goroutine, reservation or attempt.
 func TestServiceWorkLifecycleDiscoveredDialRejectedDuringDrain(t *testing.T) {
 	s := lifecycleService(t)
-	openAddr, drainAddr := "127.0.0.1:19181", "127.0.0.1:19182"
+	openAddr, drainAddr := deadAddr(t), deadAddr(t)
 	s.addrMgr.AddAddrs([]string{openAddr, drainAddr})
 	s.connectDiscoveredAddrs([]string{openAddr})
 	if attempts := lifecycleAddrAttempts(s, openAddr); attempts != 1 {
 		t.Fatalf("OPEN discovered dial attempts=%d, want 1", attempts)
 	}
-	// Close returns only after the discovered child released its lease, so the
-	// child's own reservation cleanup has already run.
+	// Close returns only after the discovered child released its lease, so the child's own reservation cleanup has already run.
 	requireReturned(t, lifecycleClose(s), "Close")
 	requireZero(t, s.inFlightDialCount(), "in-flight dial reservations after Close")
 
@@ -391,11 +394,10 @@ func lifecycleAddrAttempts(s *Service, addr string) int {
 	return s.addrMgr.addrs[normalizeNetAddr(addr)].attempts
 }
 
-// lifecycleDeadlineConn records connection-deadline mutations that are still in
-// flight, so the test can prove no handshake child touches the connection after
-// performHandshake returned. Only non-zero deadlines — the interrupter always sets one —
-// are delayed and counted: delaying performHandshake's own reset-to-zero defer would let
-// the parent's own delay mask an unjoined interrupter instead of exposing it.
+// lifecycleDeadlineConn records connection-deadline mutations that are still in flight, so the test can prove no
+// handshake child touches the connection after performHandshake returned. Only non-zero deadlines — the interrupter
+// always sets one — are delayed and counted: delaying performHandshake's own reset-to-zero defer would let the
+// parent's own delay mask an unjoined interrupter instead of exposing it.
 type lifecycleDeadlineConn struct {
 	net.Conn
 	inFlight atomic.Int64
@@ -433,8 +435,7 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 		handshakeDone := make(chan struct{})
 		go func() {
 			defer close(handshakeDone)
-			// The remote never answers, so only the cancellation child can
-			// unblock the handshake read.
+			// The remote never answers, so only the cancellation child can unblock the handshake read.
 			_, err := performHandshake(ctx, conn, cfg, node.VersionPayloadV1{ProtocolVersion: ProtocolVersion},
 				node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
 			conn.returned.Store(true)
@@ -483,8 +484,7 @@ func TestServiceWorkLifecycleFaultMatrix(t *testing.T) {
 		if got := writes.Load(); got != 1 {
 			t.Fatalf("write attempts after the no-publication return=%d, want 1", got)
 		}
-		// Every one of those exits released its lease exactly once: a leak
-		// strands Close past the watchdog, an extra release panics it.
+		// Every one of those exits released its lease exactly once: a leak strands Close past the watchdog, an extra release panics it.
 		requireReturned(t, lifecycleClose(s), "Close")
 	})
 }


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1167
- GitHub Issue mirror (non-authoritative): #2906

Refs: Q-GO-P2P-SERVICE-WORK-LIFECYCLE-01

## Summary
Implement the RUB-1167 graceful-drain contract (normative: rubin-spec `RUBIN_L1_P2P_AUX.md` §5 at `93562d1dba569cc152d917c6c5843154966a43fc`) over the existing Service lifecycle primitives, with no new framework: registration checks OPEN and increments `loopWG` inside one `peersMu` section, the first `Close` publishes `closed` plus a mandatory `closeDone` teardown-ownership channel under that same lock (later `Close` callers join the same completion; `closed==true && closeDone==nil` means teardown-unclaimed), and `Close` returns only after every worker and public call released. `AnnounceTx`, `AnnounceBlock`, and `ConsumeAcceptedBlockDASets` take one call lease before any parsing, producer, state, queue, or send work and return exactly `service already closed` with zero effects once draining. Accepted connections, outbound, reconnect, and discovered dials register before any `inFlightDial` reservation, `MarkAttempted`, or handshake-slot mutation; a Close-losing path spawns nothing. The peer loop re-authorizes on one OPEN observation placed after the permitted compact-fallback and before arming the next read deadline; `performHandshake` joins its cancellation interrupter before returning, so no handshake child can touch the connection afterwards. `Start` stays on `startWG` only. The nine-test evidence file executes Tables A-C through real owners (producer/socket/DA-lock barriers, a real peer loop over net.Pipe, executed accept-path legs against the real listener including a deterministic DRAINING window with Close parked on `startWG`, joiner-overlap proof for concurrent Close, the owed compact-fallback flush pinned before the guard, malformed-after-Close error-priority rows, and registered-then-rejected lease-release rows). Every contract evidence row family carries an executed killer: five production mutants (join-skip, guard-below-deadline, guard-above-fallback-flush, registration-after-parsing, dropped slot-failure release) were executed with observed failures and byte-identical restores.

## Invariant
A Go P2P Service authorizes workers and publication-capable public calls only while OPEN; first Close atomically freezes registration, pre-authorized work may finish exactly once, all later calls are rejected before parsing or mutation, and Close returns only after every worker/call has released so no Service-owned effect occurs after return.

## Scope
- Changed files: 7
- Surfaces: clients/go (node/p2p only; six production files + one new test file)
- Non-scope: relay-cache, retained-owner, INV/GETDATA router, DA-owner, tx_relay mode, wire, consensus, RPC, command, storage, timeout, scoring, dependency, Rust, spec, fixture, conformance, formal, generated, workflow changes; no new executor, callback registry, goroutine-per-call, waiter table, or general lifecycle framework.
- Consensus rules unchanged: yes
- SECTION_HASHES.json unchanged: yes
- Wire format unchanged: yes

## Validation
- Dynamic checks:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "^TestServiceWorkLifecycle" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race -timeout 900s ./node/p2p -run "^TestServiceWorkLifecycle" -count=5'` — PASS (0 DATA RACE)
- Executed mutant kills M1-M4 (join-skip, guard-below-deadline, guard-above-fallback-flush, registration-after-parsing, dropped slot-failure release): each observed FAIL at its named assertion, production restored byte-identical (sha256), post-restore suite green — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -timeout 900s ./node/p2p -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -timeout 1800s ./... -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./...'` — PASS
- `gofmt -l` over the seven changed files — PASS (empty)
- `git diff --check` — PASS
- Contract exact-scope gate (seven-file allowlist vs BASE 35d3c739) — PASS (`{'extra': [], 'missing': []}`)
- Contract executable LOC gate — PASS (`{'total': 750, 'bad': []}`, hard cap 750)
- `scripts/dev-env.sh -- bash -lc 'cd conformance && go test -count=1 ./...'` — PASS
- Earlier round: accept-gate reorder and interrupter-join reverts also executed as mutants (both observed FAIL, restored byte-identical) — PASS

## Follow-ups / Waivers
- Recorded deviation (out of slice, reconnect.go is contract-forbidden): reconnectDuePeers mutates reconnectState before the dial-child registration; the mutation runs under reconnectLoop's own pre-authorized worker lease and touches only dead state before Close returns. Recorded in RUB-1167 Linear thread.
- Shutdown-window semantics note: a post-Close `ConsumeAcceptedBlockDASets` now returns `service already closed`, which the fail-closed /mine_next RPC caller surfaces as HTTP 500 for an already-accepted block if a slow handler outlives the 5s RPC drain during process shutdown; strictly better than the previous post-Close mutation. Recorded in RUB-1167 Linear thread.
